### PR TITLE
Mismatched Keys: Update read_dlt_delta() with key "source_database" instead of "database"

### DIFF
--- a/src/pipeline_readers.py
+++ b/src/pipeline_readers.py
@@ -62,14 +62,14 @@ class PipelineReaders:
         if reader_config_options and len(reader_config_options) > 0:
             return (
                 spark.readStream.options(**reader_config_options).table(
-                    f"""{bronze_dataflow_spec.sourceDetails["database"]}
+                    f"""{bronze_dataflow_spec.sourceDetails["source_database"]}
                         .{bronze_dataflow_spec.sourceDetails["table"]}"""
                 )
             )
         else:
             return (
                 spark.readStream.table(
-                    f"""{bronze_dataflow_spec.sourceDetails["database"]}
+                    f"""{bronze_dataflow_spec.sourceDetails["source_database"]}
                         .{bronze_dataflow_spec.sourceDetails["table"]}"""
                 )
             )

--- a/tests/test_pipeline_readers.py
+++ b/tests/test_pipeline_readers.py
@@ -212,7 +212,7 @@ class PipelineReadersTests(DLTFrameworkTestCase):
         full_path = os.path.abspath("tests/resources/delta/customers")
         self.spark.sql(f"CREATE TABLE if not exists source_bronze.customer USING DELTA LOCATION '{full_path}' ")
 
-        source_details_map = {"sourceDetails": {"database": "source_bronze", "table": "customer"}}
+        source_details_map = {"sourceDetails": {"source_database": "source_bronze", "table": "customer"}}
 
         bronze_map.update(source_details_map)
         bronze_dataflow_spec = BronzeDataflowSpec(**bronze_map)
@@ -227,7 +227,7 @@ class PipelineReadersTests(DLTFrameworkTestCase):
         self.spark.sql("CREATE DATABASE IF NOT EXISTS source_bronze")
         full_path = os.path.abspath("tests/resources/delta/customers")
         self.spark.sql(f"CREATE TABLE if not exists source_bronze.customer USING DELTA LOCATION '{full_path}' ")
-        source_details_map = {"sourceDetails": {"database": "source_bronze", "table": "customer"}}
+        source_details_map = {"sourceDetails": {"source_database": "source_bronze", "table": "customer"}}
         bronze_map.update(source_details_map)
         reader_config = {"readerConfigOptions": {"maxFilesPerTrigger": "1"}}
         bronze_map.update(reader_config)


### PR DESCRIPTION
## Issue:
When the bronze_dataflow_spec dataframe is created in `onboard_dataflowspec.py`, the database is included with key `source_database` in the `sourceDetails` field. However, in `pipeline_readers.py` > `read_dlt_delta()`,  it is accessed with key `database` instead.

## Fix:
Change the key to `source_database` in `pipeline_readers.py` > `read_dlt_delta()`.