### PR TITLE
Allow to specify source database instead of defaulting to bronze database in __get_silver_dataflow_spec_dataframe

### DIFF
--- a/src/onboard_dataflowspec.py
+++ b/src/onboard_dataflowspec.py
@@ -652,17 +652,25 @@ class OnboardDataflowspec:
 
             silver_target_format = "delta"
 
-            bronze_target_details = {
-                "database": onboarding_row["bronze_database_{}".format(env)],
-                "table": onboarding_row["bronze_table"]
-            }
+            if f"bronze_database_{env}" in onboarding_row:
+                source_details = {
+                    "database": onboarding_row["bronze_database_{}".format(env)],
+                    "table": onboarding_row["bronze_table"]
+                }
+            else:
+                source_details = {
+                    "database" : onboarding_row["source_details"]["source_database"],
+                    "table": onboarding_row["source_details"]["source_table"],
+                }
+
             silver_target_details = {
                 "database": onboarding_row["silver_database_{}".format(env)],
                 "table": onboarding_row["silver_table"]
             }
 
             if not self.uc_enabled:
-                bronze_target_details["path"] = onboarding_row[f"bronze_table_path_{env}"]
+                if f"bronze_table_path_{env}" in onboarding_row:
+                    source_details["path"] = onboarding_row[f"bronze_table_path_{env}"]
                 silver_target_details["path"] = onboarding_row[f"silver_table_path_{env}"]
 
             silver_table_properties = {}
@@ -684,7 +692,7 @@ class OnboardDataflowspec:
                 silver_data_flow_spec_id,
                 silver_data_flow_spec_group,
                 "delta",
-                bronze_target_details,
+                source_details,
                 silver_reader_config_options,
                 silver_target_format,
                 silver_target_details,

--- a/src/onboard_dataflowspec.py
+++ b/src/onboard_dataflowspec.py
@@ -659,7 +659,7 @@ class OnboardDataflowspec:
                 }
             else:
                 source_details = {
-                    "database" : onboarding_row["source_details"]["source_database"],
+                    "database": onboarding_row["source_details"]["source_database"],
                     "table": onboarding_row["source_details"]["source_table"],
                 }
 


### PR DESCRIPTION
## Issue
The FAQs describes that any data source can be used for silver tables. However, the code always tries to find the bronze database from the onboarding rows, and there's no explicit mention of a source database other than a bronze database.

## Fix
Change the code to accomplish the following:
- Use `bronze_database_{env}` if the field is found in onboarding rows.
- If not, find and use `source_details`.