### PR TITLE
Added column comments example to custom transform notebook and docs

### DIFF
--- a/docs/content/getting_started/metadatapreperation.md
+++ b/docs/content/getting_started/metadatapreperation.md
@@ -84,3 +84,27 @@ The `onboarding.json` file contains links to [silver_transformations.json](https
 | target_partition_cols  | Specify partition columns : Type Array |
 | select_exp | Specify SQL expressions : Type Array | 
 | where_clause  | Specify filter conditions if you want to prevent certain records from main input : Type Array |
+
+### Column Comments
+
+Column-level comments enhance data discoverability in Unity Catalog.
+Use `custom_transform_func` to set column comments programmatically.
+See the [custom transform example notebook](https://github.com/databrickslabs/dlt-meta/blob/main/examples/dlt_meta_pipeline_custom_transform.ipynb) for a complete example.
+
+```python
+from pyspark.sql import DataFrame, functions as F
+
+def bronze_custom_transform_func(input_df: DataFrame, dataflow_spec) -> DataFrame:
+    column_comments = {
+        "customer_id": "Unique customer identifier",
+        "email": "Customer email address",
+    }
+    cols = []
+    for field in input_df.schema:
+        if field.name in column_comments:
+            cols.append(F.col(field.name).alias(
+                field.name, metadata={"comment": column_comments[field.name]}))
+        else:
+            cols.append(F.col(field.name))
+    return input_df.select(*cols)
+```

--- a/examples/dlt_meta_pipeline_custom_transform.ipynb
+++ b/examples/dlt_meta_pipeline_custom_transform.ipynb
@@ -22,16 +22,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "from pyspark.sql import DataFrame\n",
-    "from pyspark.sql.functions import lit\n",
-    "\n",
-    "def bronze_custom_transform_func_test(input_df, dataflow_spec) -> DataFrame:\n",
-    "  return input_df.withColumn('custom_col', lit('test'))\n",
-    "\n",
-    "def silver_custom_transform_func_test(input_df, dataflow_spec) -> DataFrame:\n",
-    "  return input_df.withColumn('custom_col', lit('test'))"
-   ]
+   "source": "from pyspark.sql import DataFrame\nfrom pyspark.sql import functions as F\n\n\ndef bronze_custom_transform_func(input_df: DataFrame, dataflow_spec) -> DataFrame:\n    \"\"\"Custom transform that adds column-level comments and a load timestamp.\n\n    Column comments appear in Unity Catalog and enhance data discoverability\n    in the Data Intelligence Platform.\n    \"\"\"\n    column_comments = {\n        \"customer_id\": \"Unique customer identifier\",\n        \"first_name\": \"Customer first name\",\n        \"last_name\": \"Customer last name\",\n        \"email\": \"Customer email address\",\n        \"address\": \"Customer mailing address\",\n        \"dob\": \"Customer date of birth\",\n        \"Op\": \"CDC operation type (I=Insert, U=Update, D=Delete)\",\n        \"dmsTimestamp\": \"DMS replication timestamp\",\n    }\n\n    cols = []\n    for field in input_df.schema:\n        if field.name in column_comments:\n            cols.append(\n                F.col(field.name).alias(\n                    field.name, metadata={\"comment\": column_comments[field.name]}\n                )\n            )\n        else:\n            cols.append(F.col(field.name))\n\n    return input_df.select(*cols).withColumn(\"load_modified_dt\", F.current_timestamp())\n\n\ndef silver_custom_transform_func(input_df: DataFrame, dataflow_spec) -> DataFrame:\n    \"\"\"Custom transform that adds column-level comments to silver table columns.\"\"\"\n    column_comments = {\n        \"customer_id\": \"Unique customer identifier\",\n        \"full_name\": \"Customer full name (first + last)\",\n        \"email\": \"Customer email address\",\n    }\n\n    cols = []\n    for field in input_df.schema:\n        if field.name in column_comments:\n            cols.append(\n                F.col(field.name).alias(\n                    field.name, metadata={\"comment\": column_comments[field.name]}\n                )\n            )\n        else:\n            cols.append(F.col(field.name))\n\n    return input_df.select(*cols)"
   },
   {
    "cell_type": "code",
@@ -46,11 +37,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "layer = spark.conf.get(\"layer\", None)\n",
-    "from src.dataflow_pipeline import DataflowPipeline\n",
-    "DataflowPipeline.invoke_dlt_pipeline(spark, layer, bronze_custom_transform_func=bronze_custom_transform_func_test, silver_custom_transform_func=silver_custom_transform_func_test)"
-   ]
+   "source": "layer = spark.conf.get(\"layer\", None)\nfrom src.dataflow_pipeline import DataflowPipeline\nDataflowPipeline.invoke_dlt_pipeline(\n    spark,\n    layer,\n    bronze_custom_transform_func=bronze_custom_transform_func,\n    silver_custom_transform_func=silver_custom_transform_func,\n)"
   }
  ],
  "metadata": {


### PR DESCRIPTION
Updated the custom transform example notebook to show how to use column-level comments via alias metadata, and also included a load_modified_dt timestamp column. Added a Column Comments section to the metadata preparation docs.

Fixes #237