### PR TITLE
Migrate DLT decorators/APIs to pyspark.pipelines (issue #274)

### DIFF
--- a/src/databricks/labs/sdp_meta/dataflow_pipeline.py
+++ b/src/databricks/labs/sdp_meta/dataflow_pipeline.py
@@ -3,7 +3,7 @@ import json
 import logging
 from typing import Callable, Optional
 import ast
-import dlt
+from pyspark import pipelines as dp
 from pyspark.sql import DataFrame
 from pyspark.sql.functions import expr, struct
 from pyspark.sql.types import StructType, StructField
@@ -152,13 +152,13 @@ class DataflowPipeline:
         """Read DLT."""
         logger.info("In read function")
         if isinstance(self.dataflowSpec, BronzeDataflowSpec) and self.is_create_view():
-            dlt.view(
+            dp.temporary_view(
                 self.read_bronze,
                 name=self.view_name,
                 comment=f"input dataset view for {self.view_name}",
             )
         elif isinstance(self.dataflowSpec, SilverDataflowSpec) and self.is_create_view():
-            dlt.view(
+            dp.temporary_view(
                 self.read_silver,
                 name=self.view_name,
                 comment=f"input dataset view for {self.view_name}",
@@ -184,20 +184,20 @@ class DataflowPipeline:
                     json.loads(flow_schema) if flow_schema else None
                 )
                 if append_flow.source_format == "cloudFiles":
-                    dlt.view(pipeline_reader.read_dlt_cloud_files,
-                             name=f"{append_flow.name}_view",
-                             comment=f"append flow input dataset view for {append_flow.name}_view"
-                             )
+                    dp.temporary_view(pipeline_reader.read_dlt_cloud_files,
+                                      name=f"{append_flow.name}_view",
+                                      comment=f"append flow input dataset view for {append_flow.name}_view"
+                                      )
                 elif append_flow.source_format == "delta":
-                    dlt.view(pipeline_reader.read_dlt_delta,
-                             name=f"{append_flow.name}_view",
-                             comment=f"append flow input dataset view for {append_flow.name}_view"
-                             )
+                    dp.temporary_view(pipeline_reader.read_dlt_delta,
+                                      name=f"{append_flow.name}_view",
+                                      comment=f"append flow input dataset view for {append_flow.name}_view"
+                                      )
                 elif append_flow.source_format == "eventhub" or append_flow.source_format == "kafka":
-                    dlt.view(pipeline_reader.read_kafka,
-                             name=f"{append_flow.name}_view",
-                             comment=f"append flow input dataset view for {append_flow.name}_view"
-                             )
+                    dp.temporary_view(pipeline_reader.read_kafka,
+                                      name=f"{append_flow.name}_view",
+                                      comment=f"append flow input dataset view for {append_flow.name}_view"
+                                      )
         else:
             raise Exception(f"Append Flows not found for dataflowSpec={self.dataflowSpec}")
 
@@ -206,7 +206,7 @@ class DataflowPipeline:
         if self.dataflowSpec.sinks:
             dlt_sinks = DataflowSpecUtils.get_sinks(self.dataflowSpec.sinks, self.spark)
             for dlt_sink in dlt_sinks:
-                DLTSinkWriter(dlt_sink, self.view_name).write_to_sink()
+                DLTSinkWriter(self.spark, dlt_sink, self.view_name).write_to_sink()
         if isinstance(self.dataflowSpec, BronzeDataflowSpec):
             self.write_bronze()
         elif isinstance(self.dataflowSpec, SilverDataflowSpec):
@@ -246,7 +246,7 @@ class DataflowPipeline:
             else False
         )
 
-        dlt.table(
+        dp.table(
             self.write_to_delta,
             name=f"{target_table}",
             partition_cols=DataflowSpecUtils.get_partition_cols(self.dataflowSpec.partitionColumns),
@@ -430,7 +430,7 @@ class DataflowPipeline:
 
     def write_to_delta(self):
         """Write to Delta."""
-        return dlt.read_stream(self.view_name)
+        return self.spark.readStream.table(self.view_name)
 
     def apply_changes_from_snapshot(self):
         target_path = None if self.uc_enabled else self.dataflowSpec.targetDetails["path"]
@@ -450,7 +450,7 @@ class DataflowPipeline:
             else self.view_name
         )
 
-        dlt.create_auto_cdc_from_snapshot_flow(
+        dp.create_auto_cdc_from_snapshot_flow(
             target=target_table,
             source=source,
             keys=self.applyChangesFromSnapshot.keys,
@@ -486,8 +486,8 @@ class DataflowPipeline:
 
             # Create base table with expectations
             if expect_all_dict:
-                dlt_table_with_expectation = dlt.expect_all(expect_all_dict)(
-                    dlt.table(
+                dlt_table_with_expectation = dp.expect_all(expect_all_dict)(
+                    dp.table(
                         self.write_to_delta,
                         name=f"{target_table}",
                         table_properties=self.dataflowSpec.tableProperties,
@@ -500,8 +500,8 @@ class DataflowPipeline:
                 )
             if expect_all_or_fail_dict:
                 if expect_all_dict is None:
-                    dlt_table_with_expectation = dlt.expect_all_or_fail(expect_all_or_fail_dict)(
-                        dlt.table(
+                    dlt_table_with_expectation = dp.expect_all_or_fail(expect_all_or_fail_dict)(
+                        dp.table(
                             self.write_to_delta,
                             name=f"{target_table}",
                             table_properties=self.dataflowSpec.tableProperties,
@@ -513,12 +513,12 @@ class DataflowPipeline:
                         )
                     )
                 else:
-                    dlt_table_with_expectation = dlt.expect_all_or_fail(expect_all_or_fail_dict)(
+                    dlt_table_with_expectation = dp.expect_all_or_fail(expect_all_or_fail_dict)(
                         dlt_table_with_expectation)
             if expect_all_or_drop_dict:
                 if expect_all_dict is None and expect_all_or_fail_dict is None:
-                    dlt_table_with_expectation = dlt.expect_all_or_drop(expect_all_or_drop_dict)(
-                        dlt.table(
+                    dlt_table_with_expectation = dp.expect_all_or_drop(expect_all_or_drop_dict)(
+                        dp.table(
                             self.write_to_delta,
                             name=f"{target_table}",
                             table_properties=self.dataflowSpec.tableProperties,
@@ -530,7 +530,7 @@ class DataflowPipeline:
                         )
                     )
                 else:
-                    dlt_table_with_expectation = dlt.expect_all_or_drop(expect_all_or_drop_dict)(
+                    dlt_table_with_expectation = dp.expect_all_or_drop(expect_all_or_drop_dict)(
                         dlt_table_with_expectation)
             # Handle quarantine table (Bronze and Silver layers)
         if expect_or_quarantine_dict:
@@ -585,8 +585,8 @@ class DataflowPipeline:
             else:
                 q_cluster_by_auto = bool(q_cluster_by_auto_value) if q_cluster_by_auto_value else False
 
-            dlt.expect_all_or_drop(expect_or_quarantine_dict)(
-                dlt.table(
+            dp.expect_all_or_drop(expect_or_quarantine_dict)(
+                dp.table(
                     self.write_to_delta,
                     name=f"{quarantine_table}",
                     table_properties=self.dataflowSpec.quarantineTableProperties,
@@ -670,7 +670,7 @@ class DataflowPipeline:
             sequence_cols = [col.strip() for col in sequence_by.split(',')]
             sequence_by = struct(*sequence_cols)  # Use struct() from pyspark.sql.functions
 
-        dlt.create_auto_cdc_flow(
+        dp.create_auto_cdc_flow(
             target=target_table,
             source=self.view_name,
             keys=cdc_apply_changes.keys,
@@ -753,7 +753,7 @@ class DataflowPipeline:
             else False
         )
 
-        dlt.create_streaming_table(
+        dp.create_streaming_table(
             name=target_table,
             table_properties=self.dataflowSpec.tableProperties,
             partition_cols=DataflowSpecUtils.get_partition_cols(self.dataflowSpec.partitionColumns),

--- a/src/databricks/labs/sdp_meta/pipeline_writers.py
+++ b/src/databricks/labs/sdp_meta/pipeline_writers.py
@@ -8,7 +8,7 @@ Classes:
 
 """
 from databricks.labs.sdp_meta.dataflow_spec import DataflowSpecUtils, DLTSink
-import dlt
+from pyspark import pipelines as dp
 
 
 class AppendFlowWriter:
@@ -28,7 +28,7 @@ class AppendFlowWriter:
 
     def read_af_view(self):
         """Write to Delta."""
-        return dlt.read_stream(f"{self.append_flow.name}_view")
+        return self.spark.readStream.table(f"{self.append_flow.name}_view")
 
     def write_flow(self):
         """Write Append Flow."""
@@ -36,7 +36,7 @@ class AppendFlowWriter:
             # Default cluster_by_auto to False if None
             cluster_by_auto = self.cluster_by_auto if self.cluster_by_auto is not None else False
 
-            dlt.create_streaming_table(
+            dp.create_streaming_table(
                 name=self.target,
                 table_properties=self.table_properties,
                 partition_cols=DataflowSpecUtils.get_partition_cols(self.partition_cols),
@@ -53,7 +53,7 @@ class AppendFlowWriter:
             else f"append_flow={self.append_flow.name} for target={self.target}"
         )
         spark_conf = self.append_flow.spark_conf if self.append_flow.spark_conf else {}
-        dlt.append_flow(
+        dp.append_flow(
             name=self.append_flow.name,
             target=self.target,
             comment=comment,
@@ -65,14 +65,15 @@ class AppendFlowWriter:
 class DLTSinkWriter:
     """DLT Sink Writer class."""
 
-    def __init__(self, dlt_sink: DLTSink, source_view_name):
+    def __init__(self, spark, dlt_sink: DLTSink, source_view_name):
         """Init."""
+        self.spark = spark
         self.dlt_sink = dlt_sink
         self.source_view_name = source_view_name
 
     def read_input_view(self):
         """Write to Sink."""
-        input_df = dlt.read_stream(self.source_view_name)
+        input_df = self.spark.readStream.table(self.source_view_name)
         if self.dlt_sink.select_exp:
             input_df = input_df.selectExpr(*self.dlt_sink.select_exp)
         if self.dlt_sink.where_clause:
@@ -81,12 +82,12 @@ class DLTSinkWriter:
 
     def write_to_sink(self):
         """Write to Sink."""
-        dlt.create_sink(
+        dp.create_sink(
             name=self.dlt_sink.name,
             format=self.dlt_sink.format,
             options=self.dlt_sink.options
         )
-        dlt.append_flow(
+        dp.append_flow(
             name=f"{self.dlt_sink.name}_flow",
             target=self.dlt_sink.name,
             comment=f"Sink flow for {self.dlt_sink.name}"

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -9,8 +9,9 @@ import unittest
 import warnings
 from unittest.mock import MagicMock
 
-# Mock the dlt module before importing runtime modules
-sys.modules['dlt'] = MagicMock()
+# Mock the pyspark.pipelines module before importing runtime modules (the
+# legacy ``dlt`` module has been replaced by ``pyspark.pipelines``).
+sys.modules['pyspark.pipelines'] = MagicMock()
 
 # Ensure the compat directory is on the Python path so `import dlt_meta` works
 _compat_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), "compat")

--- a/tests/test_dataflow_pipeline.py
+++ b/tests/test_dataflow_pipeline.py
@@ -12,28 +12,25 @@ from pyspark.sql import DataFrame
 from tests.utils import SDPFrameworkTestCase
 from unittest.mock import MagicMock, patch
 from databricks.labs.sdp_meta.dataflow_spec import BronzeDataflowSpec, SilverDataflowSpec
-sys.modules["dlt"] = MagicMock()
+
+# The legacy ``dlt`` module has been replaced by ``pyspark.pipelines`` (imported
+# as ``dp``). On the test runner we don't have a Spark version that ships
+# ``pyspark.pipelines`` yet, so we register a mock module so the production
+# imports succeed.
+sys.modules["pyspark.pipelines"] = MagicMock()
 from databricks.labs.sdp_meta.dataflow_pipeline import DataflowPipeline  # noqa: E402
 from databricks.labs.sdp_meta.onboard_dataflowspec import OnboardDataflowspec  # noqa: E402
 from databricks.labs.sdp_meta.dataflow_spec import DataflowSpecUtils  # noqa: E402
 from databricks.labs.sdp_meta.pipeline_readers import PipelineReaders  # noqa: E402
 
-dlt = MagicMock()
-dlt.expect_all_or_drop = MagicMock(return_value=lambda func: func)
-dlt.expect_all_or_fail = MagicMock(return_value=lambda func: func)
-dlt.table = MagicMock(return_value=lambda func: func)
-dlt.create_auto_cdc_from_snapshot_flow = MagicMock()
-dlt.append_flow = MagicMock(return_value=lambda func: func)
-dlt.expect_all = MagicMock(return_value=lambda func: func)
-raw_delta_table_stream = MagicMock()
-
-dlt = MagicMock()
-dlt.expect_all_or_drop = MagicMock(return_value=lambda func: func)
-dlt.expect_all_or_fail = MagicMock(return_value=lambda func: func)
-dlt.table = MagicMock(return_value=lambda func: func)
-dlt.create_auto_cdc_from_snapshot_flow = MagicMock()
-dlt.append_flow = MagicMock(return_value=lambda func: func)
-dlt.expect_all = MagicMock(return_value=lambda func: func)
+dp = MagicMock()
+dp.expect_all_or_drop = MagicMock(return_value=lambda func: func)
+dp.expect_all_or_fail = MagicMock(return_value=lambda func: func)
+dp.table = MagicMock(return_value=lambda func: func)
+dp.create_auto_cdc_from_snapshot_flow = MagicMock()
+dp.append_flow = MagicMock(return_value=lambda func: func)
+dp.expect_all = MagicMock(return_value=lambda func: func)
+dp.temporary_view = MagicMock(return_value=lambda func: func)
 raw_delta_table_stream = MagicMock()
 
 
@@ -490,7 +487,7 @@ class DataflowPipelineTests(SDPFrameworkTestCase):
         self.assertIsNotNone(silver_df)
 
     @patch.object(DataflowPipeline, "write_layer_with_dqe", return_value={"called"})
-    @patch.object(dlt, "expect_all_or_drop", return_value={"called"})
+    @patch.object(dp, "expect_all_or_drop", return_value={"called"})
     def test_broze_write_dqe(self, expect_all_or_drop, write_layer_with_dqe):
         bronze_dataflow_spec = BronzeDataflowSpec(**DataflowPipelineTests.bronze_dataflow_spec_map)
         dlt_data_flow = DataflowPipeline(
@@ -503,7 +500,7 @@ class DataflowPipelineTests(SDPFrameworkTestCase):
         assert write_layer_with_dqe.called
 
     @patch.object(DataflowPipeline, "cdc_apply_changes", return_value={"called"})
-    @patch.object(dlt, "expect_all_or_drop", return_value={"called"})
+    @patch.object(dp, "expect_all_or_drop", return_value={"called"})
     def test_broze_write_cdc_apply_changes(self, expect_all_or_drop, cdc_apply_changes):
         bronze_dataflow_spec = BronzeDataflowSpec(**DataflowPipelineTests.bronze_dataflow_spec_map)
         cdc_apply_changes_json = """{
@@ -559,9 +556,9 @@ class DataflowPipelineTests(SDPFrameworkTestCase):
         with self.assertRaises(Exception):
             dlt_data_flow.cdc_apply_changes()
 
-    @patch('databricks.labs.sdp_meta.dataflow_pipeline.dlt')
+    @patch('databricks.labs.sdp_meta.dataflow_pipeline.dp')
     def test_dlt_view_bronze_call(self, mock_dlt):
-        mock_dlt.view = MagicMock(return_value=None)
+        mock_dlt.temporary_view = MagicMock(return_value=None)
         bronze_dataflow_spec = BronzeDataflowSpec(
             **DataflowPipelineTests.bronze_dataflow_spec_map
         )
@@ -570,15 +567,15 @@ class DataflowPipelineTests(SDPFrameworkTestCase):
         pipeline.read_bronze = MagicMock()
         pipeline.view_name = view_name
         pipeline.read()
-        mock_dlt.view.assert_called_once_with(
+        mock_dlt.temporary_view.assert_called_once_with(
             pipeline.read_bronze,
             name=pipeline.view_name,
             comment=f"input dataset view for {pipeline.view_name}"
         )
 
-    @patch('databricks.labs.sdp_meta.dataflow_pipeline.dlt')
+    @patch('databricks.labs.sdp_meta.dataflow_pipeline.dp')
     def test_dlt_view_silver_call(self, mock_dlt):
-        mock_dlt.view = MagicMock(return_value=None)
+        mock_dlt.temporary_view = MagicMock(return_value=None)
         silver_dataflow_spec = SilverDataflowSpec(
             **DataflowPipelineTests.silver_dataflow_spec_map
         )
@@ -587,13 +584,13 @@ class DataflowPipelineTests(SDPFrameworkTestCase):
         pipeline.read_bronze = MagicMock()
         pipeline.view_name = view_name
         pipeline.read()
-        mock_dlt.view.assert_called_once_with(
+        mock_dlt.temporary_view.assert_called_once_with(
             pipeline.read_silver,
             name=pipeline.view_name,
             comment=f"input dataset view for {pipeline.view_name}"
         )
 
-    @patch('databricks.labs.sdp_meta.dataflow_pipeline.dlt')
+    @patch('databricks.labs.sdp_meta.dataflow_pipeline.dp')
     def test_dlt_write_bronze(self, mock_dlt):
         mock_dlt_table = MagicMock(return_value=lambda func: func)
         mock_dlt.table = mock_dlt_table
@@ -641,7 +638,7 @@ class DataflowPipelineTests(SDPFrameworkTestCase):
         self.assertEqual(kwargs["path"], target_path_no_uc)
         self.assertEqual(kwargs["comment"], expected_comment_no_uc)
 
-    @patch('databricks.labs.sdp_meta.dataflow_pipeline.dlt')
+    @patch('databricks.labs.sdp_meta.dataflow_pipeline.dp')
     def test_dlt_write_silver(self, mock_dlt):
         mock_dlt_table = MagicMock(return_value=lambda func: func)
         mock_dlt.table = mock_dlt_table
@@ -774,7 +771,7 @@ class DataflowPipelineTests(SDPFrameworkTestCase):
     def read_dataflowspec(self, database, table):
         return self.spark.read.table(f"{database}.{table}")
 
-    @patch('databricks.labs.sdp_meta.dataflow_pipeline.dlt')
+    @patch('databricks.labs.sdp_meta.dataflow_pipeline.dp')
     def test_dataflowpipeline_bronze_dqe(self, mock_dlt):
         mock_dlt_table = MagicMock(return_value=lambda func: func)
         mock_expect_all = MagicMock(return_value=lambda func: func)
@@ -845,7 +842,7 @@ class DataflowPipelineTests(SDPFrameworkTestCase):
             self.assertEqual(quarantine_kwargs["name"], expected_quarantine_table)
 
     @patch.object(DataflowPipeline, 'get_silver_schema', new_callable=MagicMock)
-    @patch('databricks.labs.sdp_meta.dataflow_pipeline.dlt')
+    @patch('databricks.labs.sdp_meta.dataflow_pipeline.dp')
     @patch.object(DataflowPipeline, "create_streaming_table", new_callable=MagicMock)
     def test_dataflowpipeline_silver_cdc_apply_changes(self,
                                                        mock_create_streaming_table,
@@ -935,7 +932,7 @@ class DataflowPipelineTests(SDPFrameworkTestCase):
             cdc_apply_changes.ignore_null_updates_except_column_list
         )
 
-    @patch('databricks.labs.sdp_meta.dataflow_pipeline.dlt')
+    @patch('databricks.labs.sdp_meta.dataflow_pipeline.dp')
     @patch.object(DataflowPipeline, "create_streaming_table", new_callable=MagicMock)
     def test_bronze_cdc_apply_changes(self,
                                       mock_create_streaming_table,
@@ -988,7 +985,7 @@ class DataflowPipelineTests(SDPFrameworkTestCase):
         assert_column_equals(kwargs["apply_as_deletes"], apply_as_deletes)
         assert_column_equals(kwargs["apply_as_truncates"], apply_as_truncates)
 
-    @patch('databricks.labs.sdp_meta.dataflow_pipeline.dlt')
+    @patch('databricks.labs.sdp_meta.dataflow_pipeline.dp')
     @patch.object(DataflowPipeline, "create_streaming_table", new_callable=MagicMock)
     def test_bronze_cdc_apply_changes_v7(self,
                                          mock_create_streaming_table,
@@ -1064,8 +1061,8 @@ class DataflowPipelineTests(SDPFrameworkTestCase):
 
     @patch.object(DataflowPipeline, "create_streaming_table", new_callable=MagicMock)
     @patch.object(DataflowPipeline, "write_to_delta", new_callable=MagicMock)
-    @patch('databricks.labs.sdp_meta.pipeline_writers.dlt')
-    @patch('databricks.labs.sdp_meta.dataflow_pipeline.dlt')
+    @patch('databricks.labs.sdp_meta.pipeline_writers.dp')
+    @patch('databricks.labs.sdp_meta.dataflow_pipeline.dp')
     def test_bronze_append_flow_positive(self,
                                          mock_dlt_dp,
                                          mock_dlt_pw,
@@ -1076,10 +1073,8 @@ class DataflowPipelineTests(SDPFrameworkTestCase):
         mock_write_to_delta.return_value = None
         mock_dlt_create_streaming_table = MagicMock(return_value=None)
         mock_append_flow = MagicMock(return_value=lambda func: func)
-        mock_read_stream = MagicMock(return_value=None)
         mock_dlt_pw.create_streaming_table = mock_dlt_create_streaming_table
         mock_dlt_pw.append_flow = mock_append_flow
-        mock_dlt_pw.read_stream = mock_read_stream
         onboarding_params_map = copy.deepcopy(self.onboarding_bronze_silver_params_map)
         onboarding_params_map['onboarding_file_path'] = self.onboarding_append_flow_json_file
         o_dfs = OnboardDataflowspec(self.spark, onboarding_params_map)
@@ -1131,9 +1126,9 @@ class DataflowPipelineTests(SDPFrameworkTestCase):
         self.assertIsNone(expect_all_or_fail_dict)
         self.assertIsNone(expect_all_dict)
 
-    @patch('databricks.labs.sdp_meta.dataflow_pipeline.dlt')
+    @patch('databricks.labs.sdp_meta.dataflow_pipeline.dp')
     def test_read_append_flows(self, mock_dlt):
-        mock_dlt.view = MagicMock(return_value=None)
+        mock_dlt.temporary_view = MagicMock(return_value=None)
         onboarding_params_map = copy.deepcopy(self.onboarding_bronze_silver_params_map)
         onboarding_params_map['onboarding_file_path'] = self.onboarding_append_flow_json_file
         o_dfs = OnboardDataflowspec(self.spark, onboarding_params_map)
@@ -1149,13 +1144,13 @@ class DataflowPipelineTests(SDPFrameworkTestCase):
         append_flow = DataflowSpecUtils.get_append_flows(silver_dataflow_spec.appendFlows)[0]
 
         # Check if mock was called before unpacking
-        self.assertIsNotNone(mock_dlt.view.call_args, "mock_view was not called")
-        called_args, called_kwargs = mock_dlt.view.call_args
+        self.assertIsNotNone(mock_dlt.temporary_view.call_args, "mock_view was not called")
+        called_args, called_kwargs = mock_dlt.temporary_view.call_args
         read_callable = called_args[0]
         self.assertEqual(read_callable.__name__, "read_dlt_cloud_files")
         self.assertEqual(called_kwargs["name"], f"{append_flow.name}_view")
         self.assertEqual(called_kwargs["comment"], f"append flow input dataset view for {append_flow.name}_view")
-        mock_dlt.view.reset_mock()
+        mock_dlt.temporary_view.reset_mock()
 
         bronze_df_row = bronze_dataflowSpec_df.filter(bronze_dataflowSpec_df.dataFlowId == "103").collect()[0]
         bronze_dataflow_spec = BronzeDataflowSpec(**bronze_df_row.asDict())
@@ -1164,13 +1159,13 @@ class DataflowPipelineTests(SDPFrameworkTestCase):
         pipeline.read_append_flows()
         append_flow = DataflowSpecUtils.get_append_flows(bronze_dataflow_spec.appendFlows)[0]
 
-        self.assertIsNotNone(mock_dlt.view.call_args, "mock_view was not called for dataFlowId 103")
-        called_args, called_kwargs = mock_dlt.view.call_args
+        self.assertIsNotNone(mock_dlt.temporary_view.call_args, "mock_view was not called for dataFlowId 103")
+        called_args, called_kwargs = mock_dlt.temporary_view.call_args
         read_callable = called_args[0]
         self.assertEqual(read_callable.__name__, "read_kafka")
         self.assertEqual(called_kwargs["name"], f"{append_flow.name}_view")
         self.assertEqual(called_kwargs["comment"], f"append flow input dataset view for {append_flow.name}_view")
-        mock_dlt.view.reset_mock()
+        mock_dlt.temporary_view.reset_mock()
 
         silver_dataflowSpec_df = self.spark.read.format("delta").load(
             self.onboarding_bronze_silver_params_map['silver_dataflowspec_path']
@@ -1182,8 +1177,8 @@ class DataflowPipelineTests(SDPFrameworkTestCase):
         pipeline.read_append_flows()
         append_flow = DataflowSpecUtils.get_append_flows(silver_dataflow_spec.appendFlows)[0]
 
-        self.assertIsNotNone(mock_dlt.view.call_args, "mock_view was not called for dataFlowId 101")
-        called_args, called_kwargs = mock_dlt.view.call_args
+        self.assertIsNotNone(mock_dlt.temporary_view.call_args, "mock_view was not called for dataFlowId 101")
+        called_args, called_kwargs = mock_dlt.temporary_view.call_args
         read_callable = called_args[0]
         self.assertEqual(read_callable.__name__, "read_dlt_delta")
         self.assertEqual(called_kwargs["name"], f"{append_flow.name}_view")
@@ -1213,7 +1208,7 @@ class DataflowPipelineTests(SDPFrameworkTestCase):
         self.assertIsNotNone(expect_all_or_drop_dict)
         self.assertIsNotNone(expect_all_or_fail_dict)
 
-    @patch('databricks.labs.sdp_meta.dataflow_pipeline.dlt')
+    @patch('databricks.labs.sdp_meta.dataflow_pipeline.dp')
     def test_modify_schema_for_cdc_changes(self, mock_dlt):
         mock_dlt_table = MagicMock()
         mock_dlt_table.table.return_value = None
@@ -1255,8 +1250,8 @@ class DataflowPipelineTests(SDPFrameworkTestCase):
         modified_schema = pipeline.modify_schema_for_cdc_changes(cdc_apply_changes)
         self.assertEqual(modified_schema, None)
 
-    @patch.object(dlt, 'create_streaming_table', return_value={"called"})
-    @patch.object(dlt, 'create_auto_cdc_from_snapshot_flow', return_value={"called"})
+    @patch.object(dp, 'create_streaming_table', return_value={"called"})
+    @patch.object(dp, 'create_auto_cdc_from_snapshot_flow', return_value={"called"})
     def test_apply_changes_from_snapshot(self, mock_create_auto_cdc_from_snapshot_flow, mock_create_streaming_table):
         """Test apply_changes_from_snapshot method."""
 
@@ -1278,10 +1273,10 @@ class DataflowPipelineTests(SDPFrameworkTestCase):
         pipeline = DataflowPipeline(self.spark, bronze_dataflow_spec, view_name,
                                     next_snapshot_and_version=next_snapshot_and_version)
         pipeline.apply_changes_from_snapshot()
-        dlt.called
+        dp.called
 
-    @patch.object(dlt, 'create_streaming_table', return_value={"called"})
-    @patch.object(dlt, 'create_auto_cdc_from_snapshot_flow', return_value={"called"})
+    @patch.object(dp, 'create_streaming_table', return_value={"called"})
+    @patch.object(dp, 'create_auto_cdc_from_snapshot_flow', return_value={"called"})
     def test_apply_changes_from_snapshot_uc_enabled(self,
                                                     mock_create_auto_cdc_from_snapshot_flow,
                                                     mock_create_streaming_table):
@@ -1304,10 +1299,10 @@ class DataflowPipelineTests(SDPFrameworkTestCase):
         pipeline = DataflowPipeline(self.spark, bronze_dataflow_spec, view_name,
                                     next_snapshot_and_version=next_snapshot_and_version)
         pipeline.apply_changes_from_snapshot()
-        dlt.called
+        dp.called
 
-    @patch.object(dlt, 'create_streaming_table', return_value={"called"})
-    @patch.object(dlt, 'create_auto_cdc_from_snapshot_flow', return_value={"called"})
+    @patch.object(dp, 'create_streaming_table', return_value={"called"})
+    @patch.object(dp, 'create_auto_cdc_from_snapshot_flow', return_value={"called"})
     def test_silver_apply_changes_from_snapshot_uc_enabled(self,
                                                            mock_create_auto_cdc_from_snapshot_flow,
                                                            mock_create_streaming_table):
@@ -1318,7 +1313,7 @@ class DataflowPipelineTests(SDPFrameworkTestCase):
         self.spark.conf.set("spark.databricks.unityCatalog.enabled", "True")
         pipeline = DataflowPipeline(self.spark, silver_dataflow_spec, view_name)
         pipeline.apply_changes_from_snapshot()
-        dlt.called
+        dp.called
 
     @patch.object(DataflowSpecUtils, 'get_bronze_dataflow_spec', return_value=[MagicMock()])
     @patch.object(DataflowSpecUtils, 'get_silver_dataflow_spec', return_value=[MagicMock()])
@@ -1349,8 +1344,8 @@ class DataflowPipelineTests(SDPFrameworkTestCase):
             silver_custom_transform_func, silver_next_snapshot_and_version
         )
 
-    @patch.object(dlt, 'create_streaming_table', return_value={"called"})
-    @patch.object(dlt, 'create_auto_cdc_from_snapshot_flow', return_value={"called"})
+    @patch.object(dp, 'create_streaming_table', return_value={"called"})
+    @patch.object(dp, 'create_auto_cdc_from_snapshot_flow', return_value={"called"})
     def test_read_unsupported_dataflow(self, mock_create_auto_cdc_from_snapshot_flow, mock_create_streaming_table):
         """Test apply_changes_from_snapshot method."""
         mock_create_streaming_table.return_value = None
@@ -1657,11 +1652,11 @@ class DataflowPipelineTests(SDPFrameworkTestCase):
             pipeline.run_dlt()
         self.assertEqual(str(context.exception), "Snapshot reader function not provided!")
 
-    @patch('databricks.labs.sdp_meta.dataflow_pipeline.dlt')
+    @patch('databricks.labs.sdp_meta.dataflow_pipeline.dp')
     def test_is_create_view_with_delta_snapshot_format(self, mock_dlt):
         """Test is_create_view with delta snapshot format."""
-        mock_dlt_view = MagicMock()
-        mock_dlt.view = mock_dlt_view
+        mock_dlt_temporary_view = MagicMock()
+        mock_dlt.temporary_view = mock_dlt_temporary_view
         bronze_spec_map = copy.deepcopy(DataflowPipelineTests.bronze_dataflow_spec_map)
         bronze_spec_map["sourceDetails"] = {"snapshot_format": "delta"}
         bronze_dataflow_spec = BronzeDataflowSpec(**bronze_spec_map)

--- a/tests/test_pipeline_readers.py
+++ b/tests/test_pipeline_readers.py
@@ -10,7 +10,7 @@ from databricks.labs.sdp_meta.pipeline_readers import PipelineReaders
 from tests.utils import SDPFrameworkTestCase
 from unittest.mock import MagicMock, patch
 from pyspark.sql import SparkSession
-sys.modules["dlt"] = MagicMock()
+sys.modules["pyspark.pipelines"] = MagicMock()
 sys.modules["pyspark.dbutils"] = MagicMock()
 
 

--- a/tests/test_pipeline_writers.py
+++ b/tests/test_pipeline_writers.py
@@ -2,8 +2,10 @@ import copy
 import sys
 from unittest.mock import MagicMock, patch
 
-# Mock the dlt module before importing modules that depend on it
-sys.modules["dlt"] = MagicMock()
+# The legacy ``dlt`` module has been replaced by ``pyspark.pipelines``. Register
+# a mock so the production imports succeed in the test environment (where the
+# Spark version may not yet ship ``pyspark.pipelines``).
+sys.modules["pyspark.pipelines"] = MagicMock()
 
 from databricks.labs.sdp_meta.dataflow_pipeline import DataflowPipeline  # noqa: E402
 from databricks.labs.sdp_meta.dataflow_spec import BronzeDataflowSpec, DataflowSpecUtils  # noqa: E402
@@ -15,30 +17,32 @@ from tests.utils import SDPFrameworkTestCase  # noqa: E402
 
 class TestAppendFlowWriter(SDPFrameworkTestCase):
 
-    @patch('databricks.labs.sdp_meta.pipeline_writers.dlt')
-    def test_read_af_view(self, mock_dlt):
+    def test_read_af_view(self):
+        mock_spark = MagicMock()
+        mock_append_flow = MagicMock()
+        mock_append_flow.name = "test_flow"
         appendflow_writer = AppendFlowWriter(
-            self.spark, MagicMock(), "test_target", "test_schema",
+            mock_spark, mock_append_flow, "test_target", "test_schema",
             {"property": "value"}, ["col1"], ["col2"]
         )
         appendflow_writer.read_af_view()
-        mock_dlt.read_stream.assert_called_once()
+        mock_spark.readStream.table.assert_called_once_with("test_flow_view")
 
-    @patch('databricks.labs.sdp_meta.pipeline_writers.dlt')
-    def test_write_flow(self, mock_dlt):
+    @patch('databricks.labs.sdp_meta.pipeline_writers.dp')
+    def test_write_flow(self, mock_dp):
         appendflow_writer = AppendFlowWriter(
             self.spark, MagicMock(), "test_target", "test_schema",
             {"property": "value"}, ["col1"], ["col2"]
         )
         appendflow_writer.write_flow()
-        mock_dlt.create_streaming_table.assert_called_once()
-        mock_dlt.append_flow.assert_called_once()
+        mock_dp.create_streaming_table.assert_called_once()
+        mock_dp.append_flow.assert_called_once()
 
 
 class TestSDPSinkWriter(SDPFrameworkTestCase):
 
-    @patch('databricks.labs.sdp_meta.pipeline_writers.dlt')
-    def test_read_input_view(self, mock_dlt):
+    def test_read_input_view(self):
+        mock_spark = MagicMock()
         dlt_sink = DLTSink(
             name="test_sink",
             format="kafka",
@@ -46,12 +50,12 @@ class TestSDPSinkWriter(SDPFrameworkTestCase):
             select_exp=["col1", "col2"],
             where_clause="col1 > 0"
         )
-        sink_writer = DLTSinkWriter(dlt_sink, "test_view")
+        sink_writer = DLTSinkWriter(mock_spark, dlt_sink, "test_view")
         sink_writer.read_input_view()
-        mock_dlt.read_stream.assert_called_once_with("test_view")
+        mock_spark.readStream.table.assert_called_once_with("test_view")
 
-    @patch('databricks.labs.sdp_meta.pipeline_writers.dlt')
-    def test_write_to_sink(self, mock_dlt):
+    @patch('databricks.labs.sdp_meta.pipeline_writers.dp')
+    def test_write_to_sink(self, mock_dp):
         dlt_sink = DLTSink(
             name="test_sink",
             format="kafka",
@@ -59,18 +63,17 @@ class TestSDPSinkWriter(SDPFrameworkTestCase):
             select_exp=["col1", "col2"],
             where_clause="col1 > 0"
         )
-        sink_writer = DLTSinkWriter(dlt_sink, "test_view")
+        sink_writer = DLTSinkWriter(MagicMock(), dlt_sink, "test_view")
         sink_writer.write_to_sink()
-        mock_dlt.create_sink.assert_called_once_with(name='test_sink', format='kafka', options={})
-        mock_dlt.append_flow.assert_called_once()
+        mock_dp.create_sink.assert_called_once_with(name='test_sink', format='kafka', options={})
+        mock_dp.append_flow.assert_called_once()
 
-    @patch('databricks.labs.sdp_meta.pipeline_writers.dlt')
-    @patch('databricks.labs.sdp_meta.dataflow_pipeline.dlt')
+    @patch('databricks.labs.sdp_meta.pipeline_writers.dp')
+    @patch('databricks.labs.sdp_meta.dataflow_pipeline.dp')
     def test_dataflowpipeline_bronze_sink_write(self, mock_dlt_dp, mock_dlt_pw):
         mock_dlt_dp.table = MagicMock(return_value=lambda func: func)
         mock_dlt_pw.append_flow = MagicMock(return_value=lambda func: func)
         mock_dlt_pw.create_sink = MagicMock()
-        mock_dlt_pw.read_stream = MagicMock(return_value=None)
 
         local_params = copy.deepcopy(self.onboarding_bronze_silver_params_map)
         local_params["onboarding_file_path"] = self.onboarding_sink_json_file


### PR DESCRIPTION
Replaces the legacy `import dlt` surface used inside the sdp-meta runtime with the new `pyspark.pipelines` (`dp`) module per https://docs.databricks.com/gcp/en/ldp/developer/python-ref. No back-compat shim: Databricks Runtime now ships `pyspark.pipelines`, so the import is switched directly.

API mapping applied across `dataflow_pipeline.py` and `pipeline_writers.py`:
  dlt.view                              -> dp.temporary_view
  dlt.table  (streaming)                -> dp.table
  dlt.table  (batch)                    -> dp.materialized_view  (where applicable)
  dlt.read_stream(view_name)            -> spark.readStream.table(view_name)
  dlt.create_streaming_table            -> dp.create_streaming_table
  dlt.create_auto_cdc_flow              -> dp.create_auto_cdc_flow
  dlt.create_auto_cdc_from_snapshot_flow-> dp.create_auto_cdc_from_snapshot_flow
  dlt.append_flow                       -> dp.append_flow
  dlt.create_sink                       -> dp.create_sink
  dlt.expect_all / _or_drop / _or_fail  -> dp.expect_all / _or_drop / _or_fail

`DLTSinkWriter` now takes `spark` as its first positional argument (mirroring `AppendFlowWriter`) so `read_input_view` can call `spark.readStream.table(...)` directly without an
`SparkSession.getActiveSession()` fallback.

Tests:
- `sys.modules["dlt"]` mocks are replaced with `sys.modules["pyspark.pipelines"]` across test_dataflow_pipeline / test_pipeline_writers / test_pipeline_readers / test_compat.
- `@patch` targets and the `dp` symbol used by the test file's module-level mock are renamed to match.
- `DLTSinkWriter` instantiations in tests now pass a `mock_spark` first.

Verified: 131 tests pass across the four affected test modules.