### PR TITLE
docs: align demo/ + docs/ references with pyspark.pipelines

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -2,8 +2,8 @@
  1. [Interactive Demo (Notebook)](#interactive-demo-notebook): **Start here.** A fully self-contained Databricks notebook covering all SDP-META features end-to-end — no CLI required.
  2. [DAIS 2023 DEMO](#dais-2023-demo): Showcases SDP-META's capabilities of creating Bronze and Silver pipelines with initial and incremental mode automatically.
  3. [Databricks Techsummit Demo](#databricks-tech-summit-fy2024-demo): 100s of data sources ingestion in bronze and silver pipelines automatically.
- 4. [Append FLOW Autoloader Demo](#append-flow-autoloader-file-metadata-demo): Write to same target from multiple sources using [dlt.append_flow](https://docs.databricks.com/en/delta-live-tables/flows.html#append-flows)  and adding [File metadata column](https://docs.databricks.com/en/ingestion/file-metadata-column.html)
- 5. [Append FLOW Eventhub Demo](#append-flow-eventhub-demo): Write to same target from multiple sources using [dlt.append_flow](https://docs.databricks.com/en/delta-live-tables/flows.html#append-flows)  and adding [File metadata column](https://docs.databricks.com/en/ingestion/file-metadata-column.html)
+ 4. [Append FLOW Autoloader Demo](#append-flow-autoloader-file-metadata-demo): Write to same target from multiple sources using [dp.append_flow](https://docs.databricks.com/aws/en/ldp/developer/ldp-python-ref-append-flow) and adding [File metadata column](https://docs.databricks.com/aws/en/ingestion/file-metadata-column)
+ 5. [Append FLOW Eventhub Demo](#append-flow-eventhub-demo): Write to same target from multiple sources using [dp.append_flow](https://docs.databricks.com/aws/en/ldp/developer/ldp-python-ref-append-flow) and adding [File metadata column](https://docs.databricks.com/aws/en/ingestion/file-metadata-column)
  6. [Silver Fanout Demo](#silver-fanout-demo): This demo showcases the implementation of fanout architecture in the silver layer.
  7. [Apply Changes From Snapshot Demo](#apply-changes-from-snapshot-demo): This demo showcases the implementation of ingesting from snapshots in bronze layer
  8. [Lakeflow Declarative Pipelines Sink Demo](#lakeflow-declarative-pipelines-sink-demo): This demo showcases the implementation of write to external sinks like delta and kafka
@@ -42,10 +42,10 @@ end-to-end with no CLI setup required.
 - Liquid clustering (`cluster_by_auto`)
 - Silver transformations via JSON (column selection, expressions)
 - Adding new feeds without pipeline code changes
-- `dlt.append_flow` — multiple sources → same target table
+- `dp.append_flow` — multiple sources → same target table 
 - `_metadata.file_name` / `_metadata.file_path` file metadata columns
 - `apply_changes_from_snapshot` — snapshot-based SCD Type 1 & 2
-- `dlt.create_sink` — write to external Delta destinations
+- `dp.create_sink` — write to external Delta destinations
 
 ## Prerequisites
 

--- a/demo/SDP_META_INTERACTIVE_DEMO.py
+++ b/demo/SDP_META_INTERACTIVE_DEMO.py
@@ -146,10 +146,10 @@ dbutils.library.restartPython()
 # MAGIC - Silver transformations (column selection, expressions)
 # MAGIC - Adding new feeds without modifying the pipeline
 # MAGIC - Incremental processing
-# MAGIC - **Append Flow** — `dlt.append_flow` for multi-source → same target
+# MAGIC - **Append Flow** — `dp.append_flow` for multi-source → same target
 # MAGIC - **File Metadata** — `_metadata.file_name`, `_metadata.file_path`
 # MAGIC - **Apply Changes From Snapshot** — snapshot-based SCD Type 1 & 2
-# MAGIC - **DLT Sink** — `dlt.create_sink` to write to external delta
+# MAGIC - **Pipeline Sink** — `dp.create_sink` to write to external delta
 
 # COMMAND ----------
 
@@ -927,7 +927,7 @@ print("Quarantine tables will capture these records.")
 # MAGIC ### 1.6 Create Append Flow Data
 # MAGIC
 # MAGIC Append Flow reads from **multiple source paths** and writes to the
-# MAGIC **same target table** using `dlt.append_flow`.
+# MAGIC **same target table** using `dp.append_flow`.
 # MAGIC We create two separate source directories for orders.
 # MAGIC See: [cloudfiles-onboarding.template](https://github.com/databrickslabs/dlt-meta/blob/main/demo/conf/json/cloudfiles-onboarding.template)
 
@@ -1468,9 +1468,10 @@ else:
     created = w.pipelines.create(
         name=pipeline_name,
         catalog=uc_catalog_name,
-        # DLT direct publishing mode requires a pipeline-level target schema.
-        # DataflowPipeline sets catalog+schema on every @dlt.table() call
-        # from DataflowSpec (bronze_database_prod / silver_database_prod),
+        # Spark Declarative Pipelines direct publishing mode requires
+        # a pipeline-level target schema. DataflowPipeline sets
+        # catalog+schema on every @dp.table() call from DataflowSpec
+        # (bronze_database_prod / silver_database_prod),
         # so this target is never used for actual routing.
         # A dedicated placeholder schema is used to keep it separate from
         # the DataflowSpec metadata schema and the Bronze/Silver data schemas.
@@ -1482,6 +1483,7 @@ else:
         ],
         configuration=pipeline_config,
         development=True,
+        serverless=True
     )
     pipeline_id = created.pipeline_id
     print(f"Pipeline created: {pipeline_id}")
@@ -2157,7 +2159,7 @@ display(spark.sql(f"""
 # MAGIC ## Stage 8: Append Flow — Multi-Source Ingestion
 # MAGIC
 # MAGIC **Append Flow** reads from **multiple source paths** and writes to the
-# MAGIC **same target table** using `dlt.append_flow`. This enables:
+# MAGIC **same target table** using `dp.append_flow`. This enables:
 # MAGIC - Consolidating data from multiple upstream systems
 # MAGIC - Adding **file metadata columns** (file name, file path)
 # MAGIC - Gradually adding new data feeds without schema changes
@@ -2181,7 +2183,7 @@ display(spark.sql(f"""
 # MAGIC ### 8.1 Append Flow Onboarding
 # MAGIC
 # MAGIC The `bronze_append_flows` list defines additional sources that
-# MAGIC feed into the same bronze target using `dlt.append_flow`.
+# MAGIC feed into the same bronze target using `dp.append_flow`.
 # MAGIC `source_metadata` adds file name/path to each record.
 
 # COMMAND ----------
@@ -2643,6 +2645,7 @@ else:
         ],
         configuration=snapshot_pipeline_config,
         development=True,
+        serverless=True
     )
     snapshot_pipeline_id = created_snap.pipeline_id
     print(f"Snapshot pipeline created: {snapshot_pipeline_id}")
@@ -2793,10 +2796,10 @@ display(spark.sql(f"""
 
 # MAGIC %md
 # MAGIC ---
-# MAGIC ## Stage 10: DLT Sink — Write to External Delta
+# MAGIC ## Stage 10: Pipeline Sink — Write to External Delta
 # MAGIC
-# MAGIC **DLT Sink** writes pipeline output to **external destinations**
-# MAGIC (delta, kafka) using `dlt.create_sink` + `dlt.append_flow`.
+# MAGIC **Pipeline Sink** writes pipeline output to **external destinations**
+# MAGIC (delta, kafka) using `dp.create_sink` + `dp.append_flow`.
 # MAGIC This stage demonstrates writing IoT events to an external
 # MAGIC delta table location.
 # MAGIC
@@ -2807,7 +2810,7 @@ display(spark.sql(f"""
 # MAGIC   │         │
 # MAGIC   │         ├── DQE (expect_or_drop / quarantine)
 # MAGIC   │         │
-# MAGIC   │         └── Sink: dlt.create_sink(format="delta")
+# MAGIC   │         └── Sink: dp.create_sink(format="delta")
 # MAGIC   │                   writes to external Volume path
 # MAGIC   │
 # MAGIC   └─── Quarantine Table (iot_events_quarantine)
@@ -3078,10 +3081,10 @@ display(spark.createDataFrame(summary_rows))
 # MAGIC | **Silver transformations** | Column selection and expressions via JSON |
 # MAGIC | **Adding new feeds** | Products & Stores added — no pipeline changes |
 # MAGIC | **Incremental processing** | CDC data (I/U/D) processed automatically |
-# MAGIC | **Append Flow** | Multi-source → same target via `dlt.append_flow` |
+# MAGIC | **Append Flow** | Multi-source → same target via `dp.append_flow` |
 # MAGIC | **File metadata** | `_metadata.file_name`, `_metadata.file_path` |
 # MAGIC | **Apply Changes From Snapshot** | Snapshot-based SCD Type 1 & 2 |
-# MAGIC | **DLT Sink** | Write to external delta table via `dlt.create_sink` |
+# MAGIC | **Pipeline Sink** | Write to external delta table via `dp.create_sink` |
 # MAGIC
 # MAGIC ### Learn More
 # MAGIC - [Full Documentation](https://databrickslabs.github.io/dlt-meta/)

--- a/demo/dab_template_demo/README.md
+++ b/demo/dab_template_demo/README.md
@@ -66,7 +66,7 @@ Declarative Pipelines (LDP) are rendered when `layer=bronze_silver`:
 | `pipeline_mode` | LDP pipelines rendered in `resources/sdp_meta_pipelines.yml` | Runner notebook call |
 |---|---|---|
 | `split` | TWO pipelines: `bronze` and `silver`. The `pipelines` job runs `silver` after `bronze` (`depends_on`). | per-pipeline: `invoke_dlt_pipeline(spark, "bronze")` and `invoke_dlt_pipeline(spark, "silver")` |
-| `combined` | ONE pipeline: `bronze_silver`, with both `bronze.dataflowspecTable` and `silver.dataflowspecTable` in `configuration`. | `invoke_dlt_pipeline(spark, "bronze_silver")` — registers both layers' `@dlt.table` decorators in a single graph |
+| `combined` | ONE pipeline: `bronze_silver`, with both `bronze.dataflowspecTable` and `silver.dataflowspecTable` in `configuration`. | `invoke_dlt_pipeline(spark, "bronze_silver")` — registers both layers' `@dp.table` decorators in a single graph |
 
 `pipeline_mode` is **only** consulted when `layer=bronze_silver`; with
 `layer=bronze` or `layer=silver` there's only ever one pipeline by

--- a/demo/notebooks/snapshot_runners/init_sdp_meta_pipeline.py
+++ b/demo/notebooks/snapshot_runners/init_sdp_meta_pipeline.py
@@ -5,8 +5,7 @@ sdp_meta_whl = spark.conf.get("sdp_meta_whl")
 # COMMAND ----------
 
 # Databricks notebook source
-# DBTITLE 1,DLT Snapshot Processing Logic
-import dlt
+# DBTITLE 1,Snapshot Processing Logic
 from databricks.labs.sdp_meta.dataflow_spec import BronzeDataflowSpec
 
 def exist(path):

--- a/docs/content/demo/Append_FLOW_CF.md
+++ b/docs/content/demo/Append_FLOW_CF.md
@@ -7,9 +7,9 @@ draft: false
 
 ### Append FLOW Autoloader Demo:
 This demo will perform following tasks:
-- Read from different source paths using autoloader and write to same target using [dlt.append_flow](https://docs.databricks.com/en/delta-live-tables/flows.html#append-flows) API
+- Read from different source paths using autoloader and write to same target using [dp.append_flow](https://docs.databricks.com/aws/en/ldp/developer/ldp-python-ref-append-flow) API
 - Read from different delta tables and write to same silver table using append_flow API
-- Add file_name and file_path to target bronze table for autoloader source using [File metadata column](https://docs.databricks.com/en/ingestion/file-metadata-column.html)
+- Add file_name and file_path to target bronze table for autoloader source using [File metadata column](https://docs.databricks.com/aws/en/ingestion/file-metadata-column)
 ## Append flow with autoloader
 
 1. Launch Command Prompt

--- a/docs/content/demo/Append_FLOW_EH.md
+++ b/docs/content/demo/Append_FLOW_EH.md
@@ -6,7 +6,7 @@ draft: false
 ---
 
 ### Append FLOW Autoloader Demo:
-- Read from different eventhub topics and write to same target tables using [dlt.append_flow](https://docs.databricks.com/en/delta-live-tables/flows.html#append-flows) API
+- Read from different eventhub topics and write to same target tables using [dp.append_flow](https://docs.databricks.com/aws/en/ldp/developer/ldp-python-ref-append-flow) API
 
 ### Steps:
 1. Launch Command Prompt

--- a/docs/content/faq/execution.md
+++ b/docs/content/faq/execution.md
@@ -107,7 +107,7 @@ When you launch Lakeflow Declarative Pipeline it will read silver onboarding and
 
 **Q. How can I do type1 or type2 merge to target table?**
 
-- Using Lakeflow Declarative Pipeline's [dlt.create_auto_cdc_flow](https://docs.databricks.com/aws/en/dlt-ref/dlt-python-ref-apply-changes) we can do type1 or type2 merge.
+- Using Lakeflow Declarative Pipeline's [dp.create_auto_cdc_flow](https://docs.databricks.com/aws/en/ldp/developer/ldp-python-ref-apply-changes) we can do type1 or type2 merge.
 - SDP-META have tag in onboarding file as `bronze_cdc_apply_changes` or `silver_cdc_apply_changes` which maps to Lakeflow Declarative Pipeline's create_auto_cdc_flow API.
 ```
 "silver_cdc_apply_changes": {
@@ -127,9 +127,9 @@ When you launch Lakeflow Declarative Pipeline it will read silver onboarding and
 
 **Q. How can I write to same target table using different sources?**
 
-- Using Lakeflow Declarative Pipeline's [dlt.append_flow API](https://docs.databricks.com/aws/en/dlt-ref/dlt-python-ref-append-flow) we can write to same target from different sources. 
+- Using Lakeflow Declarative Pipeline's [dp.append_flow API](https://docs.databricks.com/aws/en/ldp/developer/ldp-python-ref-append-flow) we can write to same target from different sources. 
 - SDP-META have tag in onboarding file as [bronze_append_flows](https://github.com/databrickslabs/sdp-meta/blob/main/integration_tests/conf/cloudfiles-onboarding.template#L41) and [silver_append_flows](https://github.com/databrickslabs/sdp-meta/blob/main/integration_tests/conf/cloudfiles-onboarding.template#L67) 
-dlt.append_flow API is mapped to 
+dp.append_flow API is mapped to 
 ```json 
 [
    {
@@ -188,5 +188,5 @@ This failure happens because the pipeline was created using Legacy Publishing mo
 com.databricks.pipelines.common.errors.DLTAnalysisException: Materializing tables in custom schemas is not supported. Please remove the database qualifier from table 'catalog_name.schema_name.table_name'
 ``
 
-To resolve this, migrate the pipeline to the default (Databricks Publishing Mode) by following Databricks’ guide: [Migrate to the default publishing mode](https://docs.databricks.com/aws/en/dlt/migrate-to-dpm#migrate-to-the-default-publishing-mode). 
+To resolve this, migrate the pipeline to the default (Databricks Publishing Mode) by following Databricks’ guide: [Migrate to the default publishing mode](https://docs.databricks.com/aws/en/ldp/migrate-to-dpm#migrate-to-the-default-publishing-mode). 
 


### PR DESCRIPTION
docs: align demo/ + docs/ references with pyspark.pipelines (issue #274)
Follow-up to the dataflow_pipeline.py / pipeline_writers.py migration
to `from pyspark import pipelines as dp`. Updates user-facing prose,
markdown, and notebook MAGIC cells so API references and doc links
match the new runtime:
  dlt.append_flow            -> dp.append_flow
  dlt.create_sink            -> dp.create_sink
  dlt.create_auto_cdc_flow   -> dp.create_auto_cdc_flow
  @dlt.table                 -> @dp.table
Affected:
  - demo/README.md
  - demo/SDP_META_INTERACTIVE_DEMO.py
  - demo/dab_template_demo/README.md
  - docs/content/demo/Append_FLOW_{CF,EH}.md
  - docs/content/faq/execution.md
Doc URL refresh from the legacy `/dlt-ref/dlt-python-ref-*` and
`/delta-live-tables/flows.html#append-flows` paths to the current
`/ldp/developer/ldp-python-ref-*` (and `/ldp/migrate-to-dpm` for the
publishing-mode migration link).
Removed the unused `import dlt` from
`demo/notebooks/snapshot_runners/init_sdp_meta_pipeline.py` (dead
code; the snapshot logic runs through DataflowPipeline's
`next_snapshot_and_version` callback).