### PR TITLE
docs: Rename Lakeflow Declarative Pipelines → Lakeflow Spark Declarative Pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@
 
 
 # Project Overview
-`DLT-META` is a metadata-driven framework designed to work with [Lakeflow Declarative Pipelines](https://www.databricks.com/product/data-engineering/lakeflow-declarative-pipelines). This framework enables the automation of bronze and silver data pipelines by leveraging metadata recorded in an onboarding JSON file. This file, known as the Dataflowspec, serves as the data flow specification, detailing the source and target metadata required for the pipelines.
+`DLT-META` is a metadata-driven framework designed to work with [Lakeflow Spark Declarative Pipelines](https://www.databricks.com/product/data-engineering/lakeflow-declarative-pipelines). This framework enables the automation of bronze and silver data pipelines by leveraging metadata recorded in an onboarding JSON file. This file, known as the Dataflowspec, serves as the data flow specification, detailing the source and target metadata required for the pipelines.
 
 In practice, a single generic pipeline reads the Dataflowspec and uses it to orchestrate and run the necessary data processing workloads. This approach streamlines the development and management of data pipelines, allowing for a more efficient and scalable data processing workflow
 
-[Lakeflow Declarative Pipelines](https://www.databricks.com/product/data-engineering/lakeflow-declarative-pipelines) and `DLT-META`  are designed to complement each other.  [Lakeflow Declarative Pipelines](https://www.databricks.com/product/data-engineering/lakeflow-declarative-pipelines) provide a declarative, intent-driven foundation for building and managing data workflows, while DLT-META adds a powerful configuration-driven layer that automates and scales pipeline creation. By combining these approaches, teams can move beyond manual coding to achieve true enterprise-level agility, governance, and efficiency, templatizing and automating pipelines for any scale of modern data-driven business
+[Lakeflow Spark Declarative Pipelines](https://www.databricks.com/product/data-engineering/lakeflow-declarative-pipelines) and `DLT-META`  are designed to complement each other.  [Lakeflow Spark Declarative Pipelines](https://www.databricks.com/product/data-engineering/lakeflow-declarative-pipelines) provide a declarative, intent-driven foundation for building and managing data workflows, while DLT-META adds a powerful configuration-driven layer that automates and scales pipeline creation. By combining these approaches, teams can move beyond manual coding to achieve true enterprise-level agility, governance, and efficiency, templatizing and automating pipelines for any scale of modern data-driven business
 
 ### Components:
 
@@ -47,7 +47,7 @@ In practice, a single generic pipeline reads the Dataflowspec and uses it to orc
 
 ![DLT-META Stages](./docs/static/images/dlt-meta_stages.png)
 
-## DLT-META `Lakeflow Declarative Pipelines` Features support
+## DLT-META `Lakeflow Spark Declarative Pipelines` Features support
 | Features  | DLT-META Support |
 | ------------- | ------------- |
 | Input data sources  | Autoloader, Delta, Eventhub, Kafka, snapshot  |

--- a/demo/README.md
+++ b/demo/README.md
@@ -5,7 +5,7 @@
  4. [Append FLOW Eventhub Demo](#append-flow-eventhub-demo): Write to same target from multiple sources using [dlt.append_flow](https://docs.databricks.com/en/delta-live-tables/flows.html#append-flows)  and adding [File metadata column](https://docs.databricks.com/en/ingestion/file-metadata-column.html)
  5. [Silver Fanout Demo](#silver-fanout-demo): This demo showcases the implementation of fanout architecture in the silver layer.
  6. [Apply Changes From Snapshot Demo](#apply-changes-from-snapshot-demo): This demo showcases the implementation of ingesting from snapshots in bronze layer
- 7. [Lakeflow Declarative Pipelines Sink Demo](#lakeflow-declarative-pipelines-sink-demo): This demo showcases the implementation of write to external sinks like delta and kafka
+ 7. [Lakeflow Spark Declarative Pipelines Sink Demo](#lakeflow-spark-declarative-pipelines-sink-demo): This demo showcases the implementation of write to external sinks like delta and kafka
  8. [DAB Demo](#dab-demo): This demo showcases how to use Databricks Assets Bundles with dlt-meta
 
 
@@ -298,12 +298,12 @@ This demo will perform following tasks:
     ```
     ![acfs.png](../docs/static/images/acfs.png)
 
-# Lakeflow Declarative Pipelines Sink Demo
+# Lakeflow Spark Declarative Pipelines Sink Demo
   - This demo will perform following steps
     - Showcase onboarding process for dlt writing to external sink pattern
     - Run onboarding for the bronze iot events.
     - Publish test events to kafka topic
-    - Run Bronze Lakeflow Declarative Pipelines which will read from kafka source topic and write to
+    - Run Bronze Lakeflow Spark Declarative Pipelines which will read from kafka source topic and write to
         - events delta table into uc
         - create quarantine table as per data quality expectations
         - writes to external kafka topics

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -7,11 +7,11 @@ draft: false
 
 
 ## Project Overview
-`DLT-META` is a metadata-driven framework designed to work with [Lakeflow Declarative Pipelines](https://www.databricks.com/product/data-engineering/lakeflow-declarative-pipelines). This framework enables the automation of bronze and silver data pipelines by leveraging metadata recorded in an onboarding JSON file. This file, known as the Dataflowspec, serves as the data flow specification, detailing the source and target metadata required for the pipelines.
+`DLT-META` is a metadata-driven framework designed to work with [Lakeflow Spark Declarative Pipelines](https://www.databricks.com/product/data-engineering/lakeflow-declarative-pipelines). This framework enables the automation of bronze and silver data pipelines by leveraging metadata recorded in an onboarding JSON file. This file, known as the Dataflowspec, serves as the data flow specification, detailing the source and target metadata required for the pipelines.
 
 In practice, a single generic pipeline reads the Dataflowspec and uses it to orchestrate and run the necessary data processing workloads. This approach streamlines the development and management of data pipelines, allowing for a more efficient and scalable data processing workflow
 
-[Lakeflow Declarative Pipelines](https://www.databricks.com/product/data-engineering/lakeflow-declarative-pipelines) and `DLT-META`  are designed to complement each other.  [Lakeflow Declarative Pipelines](https://www.databricks.com/product/data-engineering/lakeflow-declarative-pipelines) provide a declarative, intent-driven foundation for building and managing data workflows, while DLT-META adds a powerful configuration-driven layer that automates and scales pipeline creation. By combining these approaches, teams can move beyond manual coding to achieve true enterprise-level agility, governance, and efficiency, templatizing and automating pipelines for any scale of modern data-driven business
+[Lakeflow Spark Declarative Pipelines](https://www.databricks.com/product/data-engineering/lakeflow-declarative-pipelines) and `DLT-META`  are designed to complement each other.  [Lakeflow Spark Declarative Pipelines](https://www.databricks.com/product/data-engineering/lakeflow-declarative-pipelines) provide a declarative, intent-driven foundation for building and managing data workflows, while DLT-META adds a powerful configuration-driven layer that automates and scales pipeline creation. By combining these approaches, teams can move beyond manual coding to achieve true enterprise-level agility, governance, and efficiency, templatizing and automating pipelines for any scale of modern data-driven business
 
 
 
@@ -24,10 +24,10 @@ In practice, a single generic pipeline reads the Dataflowspec and uses it to orc
 
 #### Generic Lakeflow Declarative pipeline
 - Apply appropriate readers based on input metadata
-- Apply data quality rules with Lakeflow Declarative Pipelines expectations 
+- Apply data quality rules with Lakeflow Spark Declarative Pipelines expectations 
 - Apply CDC apply changes if specified in metadata
-- Builds Lakeflow Declarative Pipelines graph based on input/output metadata
-- Launch Lakeflow Declarative Pipelines pipeline
+- Builds Lakeflow Spark Declarative Pipelines graph based on input/output metadata
+- Launch Lakeflow Spark Declarative Pipelines pipeline
 
 ## High-Level Solution overview:
 ![High-Level Process Flow](/images/solutions_overview.png)
@@ -44,7 +44,7 @@ In practice, a single generic pipeline reads the Dataflowspec and uses it to orc
     - Option#1: [DLT-META CLI](https://databrickslabs.github.io/dlt-meta/getting_started/dltmeta_cli/#dataflow-dlt-pipeline)
     - Option#2: [DLT-META MANUAL](https://databrickslabs.github.io/dlt-meta/getting_started/dltmeta_manual/#dataflow-dlt-pipeline)
 
-## DLT-META `Lakeflow Declarative Pipelines` Features support
+## DLT-META `Lakeflow Spark Declarative Pipelines` Features support
 | Features  | DLT-META Support |
 | ------------- | ------------- |
 | Input data sources  | Autoloader, Delta, Eventhub, Kafka, snapshot  |
@@ -63,8 +63,8 @@ In practice, a single generic pipeline reads the Dataflowspec and uses it to orc
 | [DLT-META UI](https://github.com/databrickslabs/dlt-meta/tree/main/lakehouse_app#dlt-meta-lakehouse-app-setup) | Uses Databricks Lakehouse DLT-META App
 
 ## How much does it cost ?
-DLT-META does not have any **direct cost** associated with it other than the cost to run the Databricks Lakeflow Declarative Pipelines 
-on your environment.The overall cost will be determined primarily by the [Databricks Lakeflow Declarative Pipelines Pricing] (https://www.databricks.com/product/pricing/lakeflow-declarative-pipelines)
+DLT-META does not have any **direct cost** associated with it other than the cost to run the Databricks Lakeflow Spark Declarative Pipelines 
+on your environment.The overall cost will be determined primarily by the [Databricks Lakeflow Spark Declarative Pipelines Pricing] (https://www.databricks.com/product/pricing/lakeflow-declarative-pipelines)
 
 
 ## More questions

--- a/docs/content/demo/DLT_Sink.md
+++ b/docs/content/demo/DLT_Sink.md
@@ -1,16 +1,16 @@
 ---
-title: "Lakeflow Declarative Pipelines Sink Demo"
+title: "Lakeflow Spark Declarative Pipelines Sink Demo"
 date: 2024-02-26T14:25:26-04:00
 weight: 27
 draft: false
 ---
 
-### Lakeflow Declarative Pipelines Sink Demo
+### Lakeflow Spark Declarative Pipelines Sink Demo
 This demo will perform following steps:
 - Showcase onboarding process for dlt writing to external sink pattern
 - Run onboarding for the bronze iot events
 - Publish test events to kafka topic
-- Run Bronze Lakeflow Declarative Pipelines which will read from kafka source topic and write to:
+- Run Bronze Lakeflow Spark Declarative Pipelines which will read from kafka source topic and write to:
   - Events delta table into UC
   - Create quarantine table as per data quality expectations
   - Writes to external kafka topics

--- a/docs/content/demo/_index.md
+++ b/docs/content/demo/_index.md
@@ -5,11 +5,11 @@ weight: 20
 draft: false
 ---
 
- 1. **DAIS 2023 DEMO**: Showcases DLT-META's capabilities of creating Bronze and Silver Lakeflow Declarative Pipelines with initial and incremental mode automatically.
- 2. **Databricks Techsummit Demo**: 100s of data sources ingestion in bronze and silver Lakeflow Declarative Pipelines automatically.
+ 1. **DAIS 2023 DEMO**: Showcases DLT-META's capabilities of creating Bronze and Silver Lakeflow Spark Declarative Pipelines with initial and incremental mode automatically.
+ 2. **Databricks Techsummit Demo**: 100s of data sources ingestion in bronze and silver Lakeflow Spark Declarative Pipelines automatically.
  3. **Append FLOW Autoloader Demo**: Write to same target from multiple sources using append_flow and adding file metadata using [File metadata column](https://docs.databricks.com/en/ingestion/file-metadata-column.html)
  4. **Append FLOW Eventhub Demo**: Write to same target from multiple sources using append_flow and adding using [File metadata column](https://docs.databricks.com/en/ingestion/file-metadata-column.html)
  5. **Silver Fanout Demo**:  This demo will showcase fanout architecture can be implemented in silver layer
  6. **Apply Changes From Snapshot Demo**:  This demo will showcase [create_auto_cdc_from_snapshot_flow](https://docs.databricks.com/aws/en/dlt-ref/dlt-python-ref-apply-changes-from-snapshot) can be implemented inside bronze and silver layer
- 7. **Lakeflow Declarative Pipelines Sink Demo**: This demo showcases the implementation of write to external sinks like delta and kafka
+ 7. **Lakeflow Spark Declarative Pipelines Sink Demo**: This demo showcases the implementation of write to external sinks like delta and kafka
  8. **DAB Demo**: This demo showcases how to use Databricks Assets Bundles with dlt-meta

--- a/docs/content/faq/app_faq.md
+++ b/docs/content/faq/app_faq.md
@@ -9,7 +9,7 @@ draft: false
 
 **Q1. Do I need to run an initial setup before using the DLT-META App?**
 
-Yes. Before using the DLT-META App, you must click the Setup button to create the required dlt-meta environment. This initializes the app and enables you to onboard or manage Lakeflow Declarative Pipelines.
+Yes. Before using the DLT-META App, you must click the Setup button to create the required dlt-meta environment. This initializes the app and enables you to onboard or manage Lakeflow Spark Declarative Pipelines.
 
 ### Features and Capabilities
 

--- a/docs/content/faq/execution.md
+++ b/docs/content/faq/execution.md
@@ -21,9 +21,9 @@ DLT-META needs following metadata files:
 DLT-META translates input metadata into Delta table as DataflowSpecs
 
 
-**Q. How many Lakeflow Declarative Pipelines will be launched using DLT-META?**
+**Q. How many Lakeflow Spark Declarative Pipelines will be launched using DLT-META?**
 
-DLT-META uses data_flow_group to launch Lakeflow Declarative Pipelines, so all the tables belongs to same group will be executed under single Lakeflow Declarative pipeline. 
+DLT-META uses data_flow_group to launch Lakeflow Spark Declarative Pipelines, so all the tables belongs to same group will be executed under single Lakeflow Declarative pipeline. 
 
 **Q. Can we run onboarding for bronze layer only?**
 

--- a/docs/content/faq/general.md
+++ b/docs/content/faq/general.md
@@ -7,7 +7,7 @@ draft: false
 
 **Q. What is DLT-META ?**
 
-DLT-META is a solution/framework using Databricks Lakeflow Declarative Pipelines which helps you automate bronze and silver layer pipelines using CI/CD.
+DLT-META is a solution/framework using Databricks Lakeflow Spark Declarative Pipelines which helps you automate bronze and silver layer pipelines using CI/CD.
 
 **Q. What are the benefits of using DLT-META ?**
 

--- a/docs/content/getting_started/dltmeta_manual.md
+++ b/docs/content/getting_started/dltmeta_manual.md
@@ -114,11 +114,11 @@ OnboardDataflowspec(spark, onboarding_params_map, uc_enabled=True).onboard_dataf
 
 ## Lakeflow Declarative Pipeline: 
 
-### Lakeflow Declarative Pipelines launch notebook
+### Lakeflow Spark Declarative Pipelines launch notebook
 
 1. Go to your Databricks landing page and select Create a notebook, or click New Icon New in the sidebar and select Notebook. The Create Notebook dialog appears.
 
-2. In the Create Notebook dialogue, give your notebook a name e.g ```dlt_meta_pipeline``` and select Python from the Default Language dropdown menu. You can leave Cluster set to the default value. The Lakeflow Declarative Pipelines runtime creates a cluster before it runs your pipeline.
+2. In the Create Notebook dialogue, give your notebook a name e.g ```dlt_meta_pipeline``` and select Python from the Default Language dropdown menu. You can leave Cluster set to the default value. The Lakeflow Spark Declarative Pipelines runtime creates a cluster before it runs your pipeline.
 
 3. Click Create.
 
@@ -133,7 +133,7 @@ OnboardDataflowspec(spark, onboarding_params_map, uc_enabled=True).onboard_dataf
     ```
 ### Create Bronze Lakeflow Declarative Pipeline
 
-1. Click Jobs Icon Workflows in the sidebar, click the Lakeflow Declarative Pipelines tab, and click Create Pipeline.
+1. Click Jobs Icon Workflows in the sidebar, click the Lakeflow Spark Declarative Pipelines tab, and click Create Pipeline.
 
 2. Give the pipeline a name e.g. DLT_META_BRONZE and click File Picker Icon to select a notebook ```dlt_meta_pipeline``` created in step: ```Create a dlt launch notebook```.
 
@@ -154,9 +154,9 @@ OnboardDataflowspec(spark, onboarding_params_map, uc_enabled=True).onboard_dataf
 
 8. Start pipeline: click the Start button on in top panel. The system returns a message confirming that your pipeline is starting 
 
-### Create Silver Lakeflow Declarative Pipelines
+### Create Silver Lakeflow Spark Declarative Pipelines
 
-1. Click Jobs Icon Workflows in the sidebar, click the Lakeflow Declarative Pipelines tab, and click Create Pipeline.
+1. Click Jobs Icon Workflows in the sidebar, click the Lakeflow Spark Declarative Pipelines tab, and click Create Pipeline.
 
 2. Give the pipeline a name e.g. DLT_META_SILVER and click File Picker Icon to select a notebook ```dlt_meta_pipeline``` created in step: ```Create a dlt launch notebook```.
 

--- a/labs.yml
+++ b/labs.yml
@@ -1,6 +1,6 @@
 ---
 name: dlt-meta
-description: Metadata-driven framework based on Databricks Lakeflow Declarative Pipelines 
+description: Metadata-driven framework based on Databricks Lakeflow Spark Declarative Pipelines 
 install:
   script: src/install.py
 entrypoint: src/cli.py

--- a/src/cli.py
+++ b/src/cli.py
@@ -420,7 +420,7 @@ class DLTMeta:
         msg = (
             f"dlt-meta pipeline={pipeline_id} created and launched with "
             f"update_id={update_response.update_id}, Please check the pipeline status in "
-            "databricks workspace under workflows -> Lakeflow Declarative Pipelines tab"
+            "databricks workspace under workflows -> Lakeflow Spark Declarative Pipelines tab"
         )
         logger.info(msg)
         print(

--- a/src/dataflow_pipeline.py
+++ b/src/dataflow_pipeline.py
@@ -17,7 +17,7 @@ logger.setLevel(logging.INFO)
 
 
 class DataflowPipeline:
-    """This class uses dataflowSpec to launch Lakeflow Declarative Pipelines.
+    """This class uses dataflowSpec to launch Lakeflow Spark Declarative Pipelines.
 
     Raises:
         Exception: "Dataflow not supported!"

--- a/src/pipeline_writers.py
+++ b/src/pipeline_writers.py
@@ -1,10 +1,10 @@
 
 """
-This module contains classes for writing data to Lakeflow Declarative Pipelines  and other sinks.
+This module contains classes for writing data to Lakeflow Spark Declarative Pipelines  and other sinks.
 
 Classes:
-    AppendFlowWriter: A class for writing append flows to Lakeflow Declarative Pipelines.
-    DLTSinkWriter: A class for writing data to various sinks using Lakeflow Declarative Pipelines.
+    AppendFlowWriter: A class for writing append flows to Lakeflow Spark Declarative Pipelines.
+    DLTSinkWriter: A class for writing data to various sinks using Lakeflow Spark Declarative Pipelines.
 
 """
 from src.dataflow_spec import DataflowSpecUtils, DLTSink


### PR DESCRIPTION
Per [docs.databricks.com/aws/en/ldp](https://docs.databricks.com/aws/en/ldp), the official product name is now **Lakeflow Spark Declarative Pipelines (SDP)**. This PR updates all user-facing strings across docs and source code.

Changes:
- Replaced `Lakeflow Declarative Pipelines` with `Lakeflow Spark Declarative Pipelines` in README, demo README, docs, labs.yml, and Python source files
- Updated anchor link in `demo/README.md` to match new naming

Fixes #285

_Disclosure: This fix was generated with AI assistance._