### PR TITLE
perf(cdc) + fix(integration-tests): wide-table schema modification + UC volume paths

### DIFF
--- a/integration_tests/run_integration_tests.py
+++ b/integration_tests/run_integration_tests.py
@@ -399,15 +399,14 @@ class SDPMETARunner:
                         ),
                         "database": f"{runner_conf.uc_catalog_name}.{runner_conf.sdp_meta_schema}",
                         "onboarding_file_path": (
-                            f"{runner_conf.uc_volume_path}/{self.base_dir}/conf/"
-                            f"{os.path.basename(runner_conf.onboarding_file_path)}"
+                            f"{runner_conf.uc_volume_path}{runner_conf.onboarding_file_path}"
                         ),
                         "silver_dataflowspec_table": "silver_dataflowspec_cdc",
-                        "silver_dataflowspec_path": f"{runner_conf.uc_volume_path}/data/dlt_spec/silver",
+                        "silver_dataflowspec_path": f"{runner_conf.uc_volume_path}data/dlt_spec/silver",
                         "bronze_dataflowspec_table": "bronze_dataflowspec_cdc",
                         "import_author": "Ravi",
                         "version": "v1",
-                        "bronze_dataflowspec_path": f"{runner_conf.uc_volume_path}/data/dlt_spec/bronze",
+                        "bronze_dataflowspec_path": f"{runner_conf.uc_volume_path}data/dlt_spec/bronze",
                         "overwrite": "True",
                         "env": runner_conf.env,
                         "uc_enabled": "True",
@@ -475,8 +474,7 @@ class SDPMETARunner:
                                 "onboard_layer": "bronze",
                                 "database": f"{runner_conf.uc_catalog_name}.{runner_conf.sdp_meta_schema}",
                                 "onboarding_file_path": (  # noqa : E501
-                                    f"{runner_conf.uc_volume_path}/{self.base_dir}/conf/"
-                                    f"{os.path.basename(runner_conf.onboarding_A2_file_path)}"
+                                    f"{runner_conf.uc_volume_path}{runner_conf.onboarding_A2_file_path}"
                                 ),
                                 "bronze_dataflowspec_table": "bronze_dataflowspec_cdc",
                                 "import_author": "Ravi",
@@ -618,15 +616,15 @@ class SDPMETARunner:
                     "eventhub_namespace": runner_conf.eventhub_namespace,
                     "eventhub_secrets_scope_name": runner_conf.eventhub_secrets_scope_name,
                     "eventhub_accesskey_name": runner_conf.eventhub_producer_accesskey_name,
-                    "eventhub_input_data": f"/{runner_conf.uc_volume_path}/{self.base_dir}/resources/data/iot/iot.json",  # noqa : E501
-                    "eventhub_append_flow_input_data": f"/{runner_conf.uc_volume_path}/{self.base_dir}/resources/data/iot_eventhub_af/iot.json",  # noqa : E501
+                    "eventhub_input_data": f"{runner_conf.uc_volume_path}{self.base_dir}/resources/data/iot/iot.json",  # noqa : E501
+                    "eventhub_append_flow_input_data": f"{runner_conf.uc_volume_path}{self.base_dir}/resources/data/iot_eventhub_af/iot.json",  # noqa : E501
                 }
             elif runner_conf.source == "kafka":
                 base_parameters = {
                     "kafka_source_topic": runner_conf.kafka_source_topic,
                     "kafka_source_servers_secrets_scope_name": runner_conf.kafka_source_servers_secrets_scope_name,
                     "kafka_source_servers_secrets_scope_key": runner_conf.kafka_source_servers_secrets_scope_key,
-                    "kafka_input_data": f"/{runner_conf.uc_volume_path}/{self.base_dir}/resources/data/iot/iot.json",  # noqa : E501
+                    "kafka_input_data": f"{runner_conf.uc_volume_path}{self.base_dir}/resources/data/iot/iot.json",  # noqa : E501
                 }
 
             tasks.append(

--- a/src/databricks/labs/sdp_meta/dataflow_pipeline.py
+++ b/src/databricks/labs/sdp_meta/dataflow_pipeline.py
@@ -708,23 +708,21 @@ class DataflowPipeline:
         sequenced_by_data_type = None
 
         if cdc_apply_changes.except_column_list:
-            modified_schema = StructType([])
             if struct_schema:
-                for field in struct_schema.fields:
-                    if field.name not in cdc_apply_changes.except_column_list:
-                        modified_schema.add(field)
-                    # For SCD Type 2, get data type of first sequence column
-                    sequence_by = cdc_apply_changes.sequence_by.strip()
-                    if ',' not in sequence_by:
-                        # Single column sequence
-                        if field.name == sequence_by:
-                            sequenced_by_data_type = field.dataType
-                    else:
-                        # Multiple column sequence - use first column's type
-                        first_sequence_col = sequence_by.split(',')[0].strip()
-                        if field.name == first_sequence_col:
-                            sequenced_by_data_type = field.dataType
-                struct_schema = modified_schema
+                # Hoist all per-field-invariant work out of the loop. On wide schemas
+                # (hundreds of columns) the previous O(N*M) membership check plus
+                # repeated string parsing dominated graph build time.
+                except_set = set(cdc_apply_changes.except_column_list)
+                sequence_by = cdc_apply_changes.sequence_by.strip()
+                sequence_lookup_col = (
+                    sequence_by if ',' not in sequence_by
+                    else sequence_by.split(',', 1)[0].strip()
+                )
+                name_to_dtype = {f.name: f.dataType for f in struct_schema.fields}
+                sequenced_by_data_type = name_to_dtype.get(sequence_lookup_col)
+                struct_schema = StructType(
+                    [f for f in struct_schema.fields if f.name not in except_set]
+                )
             else:
                 raise Exception(f"Schema is None for {self.dataflowSpec} for cdc_apply_changes! ")
 

--- a/tests/test_dataflow_pipeline.py
+++ b/tests/test_dataflow_pipeline.py
@@ -1250,6 +1250,124 @@ class DataflowPipelineTests(SDPFrameworkTestCase):
         modified_schema = pipeline.modify_schema_for_cdc_changes(cdc_apply_changes)
         self.assertEqual(modified_schema, None)
 
+    @patch('databricks.labs.sdp_meta.dataflow_pipeline.dp')
+    def test_modify_schema_for_cdc_changes_composite_sequence_by(self, mock_dlt):
+        """Composite sequence_by like ' ts , id ' must use the FIRST trimmed token
+        for the SCD2 timestamp dtype lookup."""
+        cdc_apply_changes = DataflowSpecUtils.get_cdc_apply_changes(json.dumps({
+            "keys": ["id"],
+            "sequence_by": " ts , id ",
+            "scd_type": "2",
+            "except_column_list": ["op"],
+        }))
+        schema = T.StructType([
+            T.StructField("id", T.StringType()),
+            T.StructField("ts", T.TimestampType()),
+            T.StructField("op", T.StringType()),
+        ])
+        spec = BronzeDataflowSpec(**copy.deepcopy(self.bronze_dataflow_spec_map))
+        spec.schema = json.dumps(schema.jsonValue())
+        spec.dataQualityExpectations = None
+        pipeline = DataflowPipeline(
+            self.spark, spec,
+            f"{spec.targetDetails['table']}_inputview", None,
+        )
+        out = pipeline.modify_schema_for_cdc_changes(cdc_apply_changes)
+        self.assertNotIn("op", out.fieldNames())
+        self.assertIn("__START_AT", out.fieldNames())
+        self.assertIn("__END_AT", out.fieldNames())
+        self.assertEqual(out["__START_AT"].dataType, T.TimestampType())
+        self.assertEqual(out["__END_AT"].dataType, T.TimestampType())
+
+    @patch('databricks.labs.sdp_meta.dataflow_pipeline.dp')
+    def test_modify_schema_for_cdc_changes_unknown_sequence_column(self, mock_dlt):
+        """If sequence_by names a column not present in the schema, SCD2
+        START/END columns must NOT be appended (sequenced_by_data_type is None)."""
+        cdc_apply_changes = DataflowSpecUtils.get_cdc_apply_changes(json.dumps({
+            "keys": ["id"],
+            "sequence_by": "missing_col",
+            "scd_type": "2",
+            "except_column_list": ["op"],
+        }))
+        schema = T.StructType([
+            T.StructField("id", T.StringType()),
+            T.StructField("op", T.StringType()),
+        ])
+        spec = BronzeDataflowSpec(**copy.deepcopy(self.bronze_dataflow_spec_map))
+        spec.schema = json.dumps(schema.jsonValue())
+        spec.dataQualityExpectations = None
+        pipeline = DataflowPipeline(
+            self.spark, spec,
+            f"{spec.targetDetails['table']}_inputview", None,
+        )
+        out = pipeline.modify_schema_for_cdc_changes(cdc_apply_changes)
+        self.assertNotIn("__START_AT", out.fieldNames())
+        self.assertNotIn("__END_AT", out.fieldNames())
+        self.assertNotIn("op", out.fieldNames())
+        self.assertIn("id", out.fieldNames())
+
+    @patch('databricks.labs.sdp_meta.dataflow_pipeline.dp')
+    def test_modify_schema_for_cdc_changes_many_columns_correctness(self, mock_dlt):
+        """Correctness on a wide schema (the shape the optimization targets):
+        a 701-col schema with 100 excluded columns must produce the right
+        field set and SCD2 dtype regardless of width."""
+        cols = [T.StructField(f"c{i}", T.StringType()) for i in range(700)]
+        cols.append(T.StructField("ts", T.TimestampType()))
+        schema = T.StructType(cols)
+        excluded = [f"c{i}" for i in range(100)]
+        cdc_apply_changes = DataflowSpecUtils.get_cdc_apply_changes(json.dumps({
+            "keys": ["c100"],
+            "sequence_by": "ts",
+            "scd_type": "2",
+            "except_column_list": excluded,
+        }))
+        spec = BronzeDataflowSpec(**copy.deepcopy(self.bronze_dataflow_spec_map))
+        spec.schema = json.dumps(schema.jsonValue())
+        spec.dataQualityExpectations = None
+        pipeline = DataflowPipeline(
+            self.spark, spec,
+            f"{spec.targetDetails['table']}_inputview", None,
+        )
+        out = pipeline.modify_schema_for_cdc_changes(cdc_apply_changes)
+        # 700 c* cols - 100 excluded + 1 ts kept + 2 SCD2 columns = 603
+        self.assertEqual(len(out.fieldNames()), 603)
+        for c in excluded:
+            self.assertNotIn(c, out.fieldNames())
+        self.assertIn("ts", out.fieldNames())
+        self.assertEqual(out["__START_AT"].dataType, T.TimestampType())
+        self.assertEqual(out["__END_AT"].dataType, T.TimestampType())
+
+    @patch('databricks.labs.sdp_meta.dataflow_pipeline.dp')
+    def test_modify_schema_for_cdc_changes_sequence_column_in_except_list(self, mock_dlt):
+        """If the sequence_by column itself is in except_column_list, its dtype
+        must still be captured for SCD2 START/END columns (dtype lookup happens
+        before the schema is filtered) and the column itself must be dropped
+        from the data schema."""
+        cdc_apply_changes = DataflowSpecUtils.get_cdc_apply_changes(json.dumps({
+            "keys": ["id"],
+            "sequence_by": "ts",
+            "scd_type": "2",
+            "except_column_list": ["ts", "op"],
+        }))
+        schema = T.StructType([
+            T.StructField("id", T.StringType()),
+            T.StructField("ts", T.TimestampType()),
+            T.StructField("op", T.StringType()),
+        ])
+        spec = BronzeDataflowSpec(**copy.deepcopy(self.bronze_dataflow_spec_map))
+        spec.schema = json.dumps(schema.jsonValue())
+        spec.dataQualityExpectations = None
+        pipeline = DataflowPipeline(
+            self.spark, spec,
+            f"{spec.targetDetails['table']}_inputview", None,
+        )
+        out = pipeline.modify_schema_for_cdc_changes(cdc_apply_changes)
+        self.assertNotIn("ts", out.fieldNames())
+        self.assertNotIn("op", out.fieldNames())
+        self.assertIn("id", out.fieldNames())
+        self.assertEqual(out["__START_AT"].dataType, T.TimestampType())
+        self.assertEqual(out["__END_AT"].dataType, T.TimestampType())
+
     @patch.object(dp, 'create_streaming_table', return_value={"called"})
     @patch.object(dp, 'create_auto_cdc_from_snapshot_flow', return_value={"called"})
     def test_apply_changes_from_snapshot(self, mock_create_auto_cdc_from_snapshot_flow, mock_create_streaming_table):


### PR DESCRIPTION
## Summary

Two independent fixes bundled into one PR (separable on request):

1. **Performance fix** — `modify_schema_for_cdc_changes` was O(N×M) on schema width × `except_column_list` size, with `sequence_by` re-parsed on every iteration. On wide tables (~700 columns / ~100 excluded) this dominated graph-build time and made dlt-meta-driven pipelines noticeably slower than equivalent hand-written DLT notebooks. Rewritten to O(N+M) using a single set membership filter and one dict lookup. Behavior preserved.
2. **Integration test path fix** — `setup_sdp_meta_pipeline_spec` was failing on Databricks with `[PATH_NOT_FOUND]` because:
   - `runner_conf.uc_volume_path` already ends with `/`, so `f"{path}/{dir}"` was producing double slashes (`dlt_meta_files//integration_tests/...`).
   - `onboarding_file_path` was being passed through `os.path.basename`, which stripped the actual `conf/json/` subdir on the volume.

Closes #284

## Changes

| File | Change |
|---|---|
| `src/databricks/labs/sdp_meta/dataflow_pipeline.py` | Rewrite `modify_schema_for_cdc_changes` from O(N×M) to O(N+M); hoist invariant work out of per-field loop |
| `tests/test_dataflow_pipeline.py` | +4 unit tests covering the rewritten paths |
| `integration_tests/run_integration_tests.py` | Remove 7 spurious `/` in path construction; stop applying `os.path.basename` to `onboarding_file_path` |

## Performance impact

| Schema | Before (rough) | After |
|---|---|---|
| ~700 cols, ~100 excluded | ~70k membership checks + 100 string parses inside the loop, dominated wall clock | Single set build (O(M)), single dict build (O(N)), one comprehension |

The operation itself is sub-second on either side at this size — the win is in graph-build time on hundreds of CDC tables and elimination of the structural inefficiency before it scales further.

## Tests

`tests/test_dataflow_pipeline.py` — 4 new unit tests on top of the existing `test_modify_schema_for_cdc_changes`:

- `test_modify_schema_for_cdc_changes_composite_sequence_by` — composite `sequence_by` like `" ts , id "` correctly uses first trimmed token
- `test_modify_schema_for_cdc_changes_unknown_sequence_column` — when `sequence_by` names a missing column, `__START_AT`/`__END_AT` are NOT appended
- `test_modify_schema_for_cdc_changes_sequence_column_in_except_list` — when `sequence_by` column is itself excluded, its dtype is still captured for SCD2 START/END
- `test_modify_schema_for_cdc_changes_many_columns_correctness` — 701-col schema with 100 excluded → correct field set (603 fields)
