### PR TITLE
issue #261 fix + demo improvements

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -15,7 +15,8 @@
 **Recommended starting point** — a single Databricks notebook that walks through all SDP-META features
 end-to-end with no CLI setup required.
 
-**Notebook:** [`demo/SDP_META_INTERACTIVE_DEMO.py`](SDP_META_INTERACTIVE_DEMO.py)
+- **Notebook:** [`demo/SDP_META_INTERACTIVE_DEMO.py`](SDP_META_INTERACTIVE_DEMO.py) — run interactively in the Databricks workspace.
+- **Headless launcher:** [`demo/launch_interactive_demo.py`](launch_interactive_demo.py) — submit the same notebook as a one-time serverless job from your laptop / CI.
 
 ## What It Covers
 
@@ -34,7 +35,7 @@ end-to-end with no CLI setup required.
 
 ## Features Demonstrated
 
-- Metadata-driven onboarding (JSON → DataflowSpec → generic pipeline)
+- Metadata-driven onboarding (JSON or YAML → DataflowSpec → generic pipeline)
 - CloudFiles (Autoloader) ingestion with schema enforcement
 - Data quality rules: `expect_or_drop` and `expect_or_quarantine`
 - Quarantine tables for bad records
@@ -42,50 +43,101 @@ end-to-end with no CLI setup required.
 - Liquid clustering (`cluster_by_auto`)
 - Silver transformations via JSON (column selection, expressions)
 - Adding new feeds without pipeline code changes
-- `dp.append_flow` — multiple sources → same target table 
+- `dp.append_flow` — multiple sources → same target table
 - `_metadata.file_name` / `_metadata.file_path` file metadata columns
 - `apply_changes_from_snapshot` — snapshot-based SCD Type 1 & 2
 - `dp.create_sink` — write to external Delta destinations
+- All Lakeflow Spark Declarative Pipelines created with `serverless=True`
 
 ## Prerequisites
 
 - Databricks workspace with Unity Catalog enabled
-- A UC catalog you have `CREATE` privileges on
+- A UC catalog you have `CREATE SCHEMA` + `CREATE VOLUME` privileges on
 
-## Steps
+## Widgets
+
+The notebook is fully driven by widgets at the top — same ones the headless launcher pre-populates via `base_parameters`.
+
+| Widget | Choices / default | Purpose |
+|---|---|---|
+| `git_branch` | text, default `main` | Branch to install SDP-META from when `install_source=git_branch`. Also used as the GitHub branch for the conf-file fallback if the notebook is imported standalone. |
+| `uc_catalog_name` | text, default `sdp_meta_demo` | UC catalog the demo writes into. Must be a Databricks SQL **regular identifier** (`[A-Za-z_][A-Za-z0-9_]*`, max 255 chars). Hyphens / dots are rejected up-front (issue #261). |
+| `uc_schema_name` | text, default `retail_data` | Schema within the catalog. Same identifier rules as above. The demo creates `<schema>_bronze`, `<schema>_silver`, `<schema>_pipeline_default` underneath. |
+| `data_source` | dropdown `dbdatagen` (default) / `github` | `dbdatagen` generates synthetic retail data with `dbldatagen` (no internet needed); `github` downloads fixed CSVs from the dlt-meta repo (requires outbound internet from the workspace). |
+| `onboarding_format` | dropdown `json` (default) / `yml` | Whether the rendered onboarding spec + silver-transformations files are written as JSON or YAML. The demo reads back the matching `demo/conf/<format>/sample_onboarding.<ext>` template. |
+| `install_source` | dropdown `git_branch` (default) / `whl_file` | Where to install SDP-META from. `git_branch` runs `pip install git+https://github.com/databrickslabs/dlt-meta.git@<git_branch>`; `whl_file` runs `pip install <whl_file_path>` against a Volume / Workspace path. Use `whl_file` when validating local changes that aren't pushed yet. |
+| `whl_file_path` | text, default empty | Path to the wheel when `install_source=whl_file`, e.g. `/Volumes/<catalog>/<schema>/<volume>/databricks_labs_sdp_meta-<version>-py3-none-any.whl`. Required when `install_source=whl_file`; ignored otherwise. |
+| `validate_counts` | dropdown `false` (default) / `true` | When `true`, the final cell turns the demo into a smoke test: it asserts deterministic row counts (`bronze.orders == 7`, `bronze.iot_events == 5`, snapshot tables `>= LOAD_2 size`) and non-empty for every demo-produced bronze / silver / quarantine table, raising a single `AssertionError` listing every failure. Use in CI / pre-release smoke runs. |
+| `cleanup` | dropdown `false` (default) / `true` | When `true`, the cleanup cell at the bottom drops every per-run resource the demo created: pipelines (main / snapshot / sink), runner notebooks (`runner_notebook_path`, `snapshot_runner_path`), and per-run schemas (`<schema>_bronze`, `<schema>_silver`, `<schema>_pipeline_default`, `<schema>` itself — including its config volume). The user-supplied UC catalog is **intentionally preserved** because it's shared across runs. |
+
+## Option A — Run interactively in the workspace
 
 1. Import the notebook into your Databricks workspace:
    - In the sidebar click **Workspace** → **Import**
-   - Upload `demo/SDP_META_INTERACTIVE_DEMO.py` or paste the GitHub raw URL
+   - Upload `demo/SDP_META_INTERACTIVE_DEMO.py`, or paste the GitHub raw URL.
+   - To use the workspace-co-located conf path (offline-friendly, no GitHub roundtrip), import the notebook into a folder that contains a `demo/` segment so its workspace path looks like `.../demo/SDP_META_INTERACTIVE_DEMO`. Otherwise the demo falls back to fetching `demo/conf/<fmt>/sample_onboarding.<ext>` from `raw.githubusercontent.com/databrickslabs/dlt-meta/<git_branch>/...` — make sure that branch is published.
 
-2. Open the notebook and fill in the widgets at the top:
+2. Open the notebook, fill in the widgets above, and click **Run All**. The notebook:
+   - Installs SDP-META + optional `dbldatagen` via `%pip install` and restarts Python.
+   - Creates all UC resources (catalog membership, per-run schemas, config volume), config files, and demo data automatically.
+   - Creates and starts every Lakeflow Spark Declarative Pipeline via the Databricks SDK with `serverless=True`.
+   - Blocks and polls until each pipeline run completes before moving to the next stage.
+   - Prints live pipeline state updates and the pipeline URL for each run.
 
-   | Widget | Default | Description |
-   |--------|---------|-------------|
-   | `git_branch` | `main` | Branch to install SDP-META from |
-   | `uc_catalog_name` | `sdp_meta_demo` | UC catalog for the demo |
-   | `uc_schema_name` | `retail_data` | Schema within the catalog |
-   | `data_source` | `dbdatagen` | `dbdatagen` (synthetic) or `github` (download from repo) |
+> No manual pipeline UI interactions are required — the notebook is fully automated end-to-end.
 
-3. Click **Run All**. The notebook:
-   - Installs SDP-META and (if selected) `dbldatagen` via `%pip install`
-   - Creates all UC resources, config files, and demo data automatically
-   - Creates and starts the Lakeflow Spark Declarative Pipeline via the Databricks SDK
-   - Blocks and polls until each pipeline run completes before moving to the next stage
-   - Prints live pipeline state updates and the pipeline URL for each run
+## Option B — Run headless via the launcher (CI-friendly)
 
-> No manual pipeline UI interactions required — the notebook is fully automated end-to-end.
+`demo/launch_interactive_demo.py` uploads the demo notebook (and the sibling `demo/conf/<fmt>/sample_onboarding.<ext>` files, so the workspace-co-located lookup always works), submits a one-time serverless job that runs it, prints + opens the run-page URL in your browser immediately so you can watch it live, and waits for completion. On failure it still surfaces the run URL in the summary — no traceback hunting required.
 
-## Data Source Options
+```commandline
+# CI smoke run — assert row counts and tear down every per-run resource
+python demo/launch_interactive_demo.py \
+    --profile <your_profile> \
+    --uc-catalog-name <your_catalog> \
+    --install-source whl_file \
+    --whl-file-path /Volumes/<catalog>/<schema>/<volume>/databricks_labs_sdp_meta-<version>-py3-none-any.whl \
+    --data-source dbdatagen \
+    --validate-counts true \
+    --cleanup true \
+    --timeout-minutes 25
+```
 
-| Option | Description |
-|--------|-------------|
-| `dbdatagen` | Generates synthetic retail data using [dbldatagen](https://github.com/databrickslabs/dbldatagen). No internet access required after install. |
-| `github` | Downloads sample CSV data directly from the [dlt-meta repo](https://github.com/databrickslabs/dlt-meta/tree/main/demo/resources). Requires outbound internet access from the cluster. |
+Local-dev shortcut: build the wheel from the working tree and push it to a UC volume in one shot, instead of having to `pip wheel` and `databricks fs cp` manually:
+
+```commandline
+python demo/launch_interactive_demo.py \
+    --profile <your_profile> \
+    --uc-catalog-name <your_catalog> \
+    --build-and-upload-whl \
+    --uc-schema-name <wheel_volume_schema> \
+    --uc-volume-name sdp_meta_wheels \
+    --data-source dbdatagen
+```
+
+Run `python demo/launch_interactive_demo.py --help` for the full flag surface. Selected flags map 1:1 onto the widgets:
+
+| CLI flag | Widget it sets | Notes |
+|---|---|---|
+| `--uc-catalog-name` (required) | `uc_catalog_name` | Validated locally against the SQL identifier rules before any workspace call. |
+| `--profile` | n/a (auth) | Databricks CLI profile to authenticate the SDK with. Omit to use ambient creds. |
+| `--git-branch` | `git_branch` | Defaults to `main`. |
+| `--install-source` | `install_source` | `git_branch` (default) or `whl_file`. |
+| `--whl-file-path` | `whl_file_path` | Required when `--install-source whl_file` and `--build-and-upload-whl` is not set. |
+| `--build-and-upload-whl` | sets `install_source=whl_file` + `whl_file_path=<uploaded path>` | Builds the local sdp-meta wheel via `bundle_prepare_wheel` and uploads it to `/Volumes/<catalog>/<uc-schema-name>/<uc-volume-name>/`. Requires `--uc-schema-name` and `--uc-volume-name`. |
+| `--data-source` | `data_source` | `dbdatagen` (default) or `github`. |
+| `--onboarding-format` | `onboarding_format` | `json` (default) or `yml`. |
+| `--validate-counts` | `validate_counts` | `true` (default for the launcher) or `false`. When `true`, the job FAILS on row-count regression. |
+| `--cleanup` | `cleanup` | `false` (default) or `true`. Set `true` for CI runs that need to leave the workspace clean. |
+| `--timeout-minutes` | n/a (driver) | Max wall-clock for the launcher to wait on the job. Default 90; for cold workspaces with all 4 pipelines, 20-25 is comfortable. |
+
+Each launch gets a unique, scannable name in the workspace **Job Runs** UI of the form `sdp-meta-demo-<UTC-timestamp>-<catalog>-<run-id>`, e.g. `sdp-meta-demo-20260427T201235Z-ravi_dlt_meta_uc-57f84fe925a1`. The same `<run-id>` flows through the per-run workspace path (`/Users/<me>/sdp_meta_demo_runs/<run-id>/demo/...`) and the per-run schema (`sdp_meta_demo_<run-id>`) so concurrent runs never collide on bronze / silver tables.
 
 ## Cleanup
 
-Uncomment and run the cleanup cell at the bottom of the notebook to drop all schemas and the catalog created during the demo.
+- **Notebook (interactive):** flip the `cleanup` widget to `true` and re-run the last cell, or call `_cleanup_demo_resources()` from a fresh cell. Both drop only per-run resources; the UC catalog is preserved.
+- **Launcher (headless):** pass `--cleanup true`. The cleanup runs as the very last cell of the demo, so it only fires on a successful end-to-end run; failed runs deliberately leave artifacts in place for debugging.
+- **Manual:** `DROP CATALOG <name> CASCADE` if you want to nuke the catalog itself (intentionally not done by the demo).
 
 ---
 

--- a/demo/SDP_META_INTERACTIVE_DEMO.py
+++ b/demo/SDP_META_INTERACTIVE_DEMO.py
@@ -48,10 +48,12 @@
 # MAGIC
 # MAGIC | Parameter | Description |
 # MAGIC |-----------|-------------|
-# MAGIC | **Git Branch** | Branch to install SDP-META from |
+# MAGIC | **Git Branch** | Branch on `databrickslabs/dlt-meta` used to (a) install SDP-META when `Install Source = git_branch` and (b) fetch demo datasets / onboarding templates from `raw.githubusercontent.com` |
 # MAGIC | **UC Catalog Name** | Unity Catalog catalog for the demo |
 # MAGIC | **UC Schema Name** | Schema within the catalog |
 # MAGIC | **Data Source** | `dbdatagen` (generate synthetic data) or `github` (download from repo) |
+# MAGIC | **Install Source** | `git_branch` (default — installs SDP-META from the GitHub branch above) or `whl_file` (installs from a pre-built wheel — preferred when validating a local build) |
+# MAGIC | **Wheel File Path** | Required only when `Install Source = whl_file`. Path to the SDP-META wheel on a Volume / Workspace, e.g. `/Volumes/<catalog>/<schema>/<volume>/sdp_meta-<version>-py3-none-any.whl` |
 
 # COMMAND ----------
 
@@ -82,6 +84,50 @@ dbutils.widgets.dropdown(
     choices=["json", "yml"],
     label="Onboarding File Format"
 )
+# Lets the demo install SDP-META either from the GitHub branch
+# (default — anyone can run the demo without building) or from a
+# pre-built wheel on a Volume / Workspace path (preferred when
+# validating a local build before merging). Note: ``git_branch`` is
+# still used regardless of this choice — it controls where demo
+# datasets and onboarding templates are fetched from on raw.github.
+dbutils.widgets.dropdown(
+    name="install_source",
+    defaultValue="git_branch",
+    choices=["git_branch", "whl_file"],
+    label="Install Source"
+)
+dbutils.widgets.text(
+    name="whl_file_path",
+    defaultValue="",
+    label="Wheel File Path (when install_source=whl_file)"
+)
+# Final-validation toggle. Off by default so SAs walking through the
+# demo interactively don't get an unexpected hard fail at the end.
+# When ``true``, the cell at the bottom of the notebook turns the demo
+# into a smoke test: it asserts the deterministic tables hit their
+# expected row counts and that every demo-produced table is non-empty.
+# Use this in CI / pre-release smoke runs.
+dbutils.widgets.dropdown(
+    name="validate_counts",
+    defaultValue="false",
+    choices=["false", "true"],
+    label="Validate Counts (smoke test mode)"
+)
+# Cleanup toggle. Off by default so SAs walking through the demo
+# interactively can keep poking at bronze/silver tables after the
+# notebook finishes. When ``true``, the cleanup cell at the bottom of
+# the notebook drops every per-run resource the demo created
+# (pipelines, runner notebooks, per-run schemas + the per-run
+# config volume). The user-supplied UC catalog is intentionally
+# preserved -- it's shared across runs and would clobber other
+# work if dropped here. Use this in CI runs that need to leave the
+# workspace clean.
+dbutils.widgets.dropdown(
+    name="cleanup",
+    defaultValue="false",
+    choices=["false", "true"],
+    label="Cleanup (drop per-run resources at end)"
+)
 
 # COMMAND ----------
 
@@ -90,27 +136,96 @@ uc_catalog_name = dbutils.widgets.get("uc_catalog_name")
 uc_schema_name = dbutils.widgets.get("uc_schema_name")
 data_source = dbutils.widgets.get("data_source")
 onboarding_format = dbutils.widgets.get("onboarding_format")
+install_source = dbutils.widgets.get("install_source")
+whl_file_path = dbutils.widgets.get("whl_file_path").strip()
+validate_counts = dbutils.widgets.get("validate_counts").lower() == "true"
+cleanup = dbutils.widgets.get("cleanup").lower() == "true"
+
+# Reject illegal UC identifiers up-front. The demo notebook splices these
+# names directly into SQL throughout the rest of the cells, so any value
+# that isn't a regular SQL identifier would only blow up much later with
+# a confusing Spark error (issue #261).
+#
+# IMPORTANT: this cell runs *before* the %pip install of sdp-meta below,
+# so we cannot import ``databricks.labs.sdp_meta.identifiers`` here -- it
+# isn't on PYTHONPATH yet. We inline the same regular-SQL-identifier rule
+# that ``validate_uc_identifier`` enforces (``[A-Za-z_][A-Za-z0-9_]*``,
+# max 255 chars). The canonical, import-based check still happens after
+# the Python restart in cell 1.1.
+#
+# KEEP IN SYNC WITH src/databricks/labs/sdp_meta/identifiers.py
+# (``_REGULAR_IDENT_RE`` and ``_MAX_IDENT_LEN``). If the canonical regex
+# or max-length tightens/loosens there, mirror the change here -- otherwise
+# this pre-install gate will silently drift from the post-install one and
+# the demo will reject names the rest of the codebase accepts (or vice
+# versa).
+import re as _re_preinstall
+_REGULAR_IDENT_RE_PREINSTALL = _re_preinstall.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+def _validate_uc_identifier_preinstall(name, *, kind):
+    if not isinstance(name, str) or not name:
+        raise ValueError(
+            f"{kind} must be a non-empty string, got {type(name).__name__}: {name!r}"
+        )
+    if len(name) > 255:
+        raise ValueError(
+            f"{kind} {name!r} is {len(name)} characters; maximum allowed is 255"
+        )
+    if not _REGULAR_IDENT_RE_PREINSTALL.match(name):
+        raise ValueError(
+            f"{kind} {name!r} is not a valid Databricks SQL regular identifier. "
+            f"Names must match {_REGULAR_IDENT_RE_PREINSTALL.pattern} (letters, "
+            f"digits and underscores only; must start with a letter or "
+            f"underscore). Hyphens, periods, spaces and leading digits are not "
+            f"supported."
+        )
+
+_validate_uc_identifier_preinstall(uc_catalog_name, kind="uc_catalog_name widget")
+_validate_uc_identifier_preinstall(uc_schema_name, kind="uc_schema_name widget")
+
+# Resolve the install target up-front so every downstream consumer
+# (this notebook's %pip install, the runner-notebook %pip install, and
+# the ``sdp_meta_whl`` pipeline config key passed into all 3 pipelines)
+# uses the exact same value. Fail fast on a missing wheel path here —
+# otherwise the error surfaces later inside the embedded runner
+# notebook where it's much harder to diagnose.
+if install_source == "whl_file":
+    if not whl_file_path:
+        raise ValueError(
+            "install_source=whl_file requires the 'whl_file_path' widget "
+            "to be set (e.g. /Volumes/<catalog>/<schema>/<volume>/"
+            "sdp_meta-<version>-py3-none-any.whl). Either set the path "
+            "or switch install_source back to 'git_branch'."
+        )
+    sdp_meta_install_target = whl_file_path
+else:
+    sdp_meta_install_target = (
+        f"git+https://github.com/databrickslabs/"
+        f"dlt-meta.git@{git_branch}"
+    )
 
 print(f"Git Branch         : {git_branch}")
 print(f"UC Catalog         : {uc_catalog_name}")
 print(f"UC Schema          : {uc_schema_name}")
 print(f"Data Source        : {data_source}")
 print(f"Onboarding Format  : {onboarding_format}")
+print(f"Install Source     : {install_source}")
+print(f"Install Target     : {sdp_meta_install_target}")
 
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ### Install SDP-META from Git
+# MAGIC ### Install SDP-META
+# MAGIC
+# MAGIC Installs from the chosen `Install Source`:
+# MAGIC - `git_branch` — `pip install git+https://github.com/databrickslabs/dlt-meta.git@<branch>`
+# MAGIC - `whl_file` — `pip install <whl_file_path>` (wheel on a Volume / Workspace path)
 
 # COMMAND ----------
 
-git_url = (
-    f"git+https://github.com/databrickslabs/"
-    f"dlt-meta.git@{dbutils.widgets.get('git_branch')}"
-)
 # dbldatagen is only needed for the "dbdatagen" data source option
 extra_packages = " dbldatagen" if data_source == "dbdatagen" else ""
-packages = git_url + extra_packages
+packages = sdp_meta_install_target + extra_packages
 %pip install $packages  # noqa: E999
 dbutils.library.restartPython()
 
@@ -186,6 +301,34 @@ uc_catalog_name = dbutils.widgets.get("uc_catalog_name")
 uc_schema_name = dbutils.widgets.get("uc_schema_name")
 data_source = dbutils.widgets.get("data_source")
 onboarding_format = dbutils.widgets.get("onboarding_format")
+install_source = dbutils.widgets.get("install_source")
+whl_file_path = dbutils.widgets.get("whl_file_path").strip()
+validate_counts = dbutils.widgets.get("validate_counts").lower() == "true"
+cleanup = dbutils.widgets.get("cleanup").lower() == "true"
+
+# Re-resolve the install target after the Python restart so the
+# pipeline runner notebooks (created later in this same cell-group) get
+# the right value pumped into ``sdp_meta_whl``. Mirrors the resolution
+# in the prerequisites cell — keep both copies in sync.
+if install_source == "whl_file":
+    if not whl_file_path:
+        raise ValueError(
+            "install_source=whl_file requires the 'whl_file_path' widget "
+            "to be set."
+        )
+    sdp_meta_install_target = whl_file_path
+else:
+    sdp_meta_install_target = (
+        f"git+https://github.com/databrickslabs/"
+        f"dlt-meta.git@{git_branch}"
+    )
+
+# Re-validate after re-reading widgets in this cell to match the strict
+# regular SQL identifier rule used everywhere else (issue #261). Cheap
+# and keeps every entry point honest.
+from databricks.labs.sdp_meta.identifiers import validate_uc_identifier  # noqa: E402
+validate_uc_identifier(uc_catalog_name, kind="uc_catalog_name widget")
+validate_uc_identifier(uc_schema_name, kind="uc_schema_name widget")
 
 w = WorkspaceClient()
 
@@ -1438,10 +1581,12 @@ print(f"Runner notebook created: {runner_notebook_path}")
 
 # COMMAND ----------
 
-git_url_for_pip = (
-    f"git+https://github.com/databrickslabs/"
-    f"dlt-meta.git@{git_branch}"
-)
+# All 3 pipelines (main, snapshot, sink) reuse the same install target
+# resolved from the ``install_source`` / ``whl_file_path`` widgets. The
+# runner notebooks read this value via ``spark.conf.get("sdp_meta_whl")``
+# and feed it straight to ``%pip install`` — works for both
+# ``git+https://...@branch`` and ``/Volumes/.../foo.whl`` shapes.
+git_url_for_pip = sdp_meta_install_target
 
 pipeline_config = {
     "layer": "bronze_silver",
@@ -1483,7 +1628,7 @@ else:
         ],
         configuration=pipeline_config,
         development=True,
-        serverless=True
+        serverless=True,
     )
     pipeline_id = created.pipeline_id
     print(f"Pipeline created: {pipeline_id}")
@@ -2645,7 +2790,7 @@ else:
         ],
         configuration=snapshot_pipeline_config,
         development=True,
-        serverless=True
+        serverless=True,
     )
     snapshot_pipeline_id = created_snap.pipeline_id
     print(f"Snapshot pipeline created: {snapshot_pipeline_id}")
@@ -2954,6 +3099,7 @@ else:
         ],
         configuration=sink_pipeline_config,
         development=True,
+        serverless=True,
     )
     sink_pipeline_id = created_sink.pipeline_id
     print(f"Sink pipeline created: {sink_pipeline_id}")
@@ -3100,38 +3246,263 @@ display(spark.createDataFrame(summary_rows))
 
 # MAGIC %md
 # MAGIC ---
-# MAGIC ## Cleanup (Optional)
+# MAGIC ## Final Validation (Smoke Test Mode)
 # MAGIC
-# MAGIC Uncomment and run the cells below to clean up all demo resources.
+# MAGIC When the **`Validate Counts`** widget is set to `true`, this cell
+# MAGIC turns the demo into a smoke test: it asserts that every table
+# MAGIC the demo is supposed to produce exists, is non-empty, and (for
+# MAGIC tables fed by hardcoded data) hits an exact expected row count.
+# MAGIC
+# MAGIC The numeric expectations come from data that is hardcoded in
+# MAGIC this notebook (`orders_main_data` + `orders_af_data`,
+# MAGIC `iot_events`, the snapshot CSV literals, and the bad-records
+# MAGIC strings) and so are deterministic regardless of the
+# MAGIC `data_source` widget. The customers / transactions / products /
+# MAGIC stores tables only get an existence + non-empty check because
+# MAGIC their counts depend on whether `data_source = github` (CSVs from
+# MAGIC the repo) or `dbdatagen` (random synthetic data).
+# MAGIC
+# MAGIC All failures are collected and reported in a single
+# MAGIC `AssertionError` — easier to fix the demo / pipelines once than
+# MAGIC to chase one failure at a time.
 
 # COMMAND ----------
 
-# -- Delete pipelines --
-# for pid_file in [
-#     pipeline_id_file,
-#     snapshot_pipeline_id_file,
-#     sink_pipeline_id_file,
-# ]:
-#     try:
-#         with open(pid_file, "r") as fh:
-#             pid = fh.read().strip()
-#         w.pipelines.delete(pipeline_id=pid)
-#         print(f"Deleted pipeline: {pid}")
-#     except Exception as e:
-#         print(f"Skipping {pid_file}: {e}")
-#
-# -- Delete runner notebooks --
-# for nb_path in [runner_notebook_path, snapshot_runner_path]:
-#     try:
-#         w.workspace.delete(nb_path)
-#         print(f"Deleted notebook: {nb_path}")
-#     except Exception as e:
-#         print(f"Skipping {nb_path}: {e}")
-#
-# -- Drop schemas and catalog --
-# spark.sql(f"DROP SCHEMA IF EXISTS {uc_catalog_name}.{bronze_schema} CASCADE")
-# spark.sql(f"DROP SCHEMA IF EXISTS {uc_catalog_name}.{silver_schema} CASCADE")
-# spark.sql(f"DROP SCHEMA IF EXISTS {uc_catalog_name}.{pipeline_target_schema} CASCADE")
-# spark.sql(f"DROP SCHEMA IF EXISTS {uc_catalog_name}.{uc_schema_name} CASCADE")
-# spark.sql(f"DROP CATALOG IF EXISTS {uc_catalog_name} CASCADE")
-# print(f"Cleaned up all demo resources for: {uc_catalog_name}")
+if not validate_counts:
+    print(
+        "Skipping final validation: 'validate_counts' widget is "
+        "'false'. Set it to 'true' to enable the smoke-test mode."
+    )
+else:
+    # ``failures`` is a list of human-readable strings; we collect
+    # every failed expectation and raise once at the end so a CI
+    # operator sees the full picture from one run instead of fixing
+    # one regression, re-running, and finding the next.
+    failures = []
+
+    def _table_count(fqn):
+        """Return row count for ``fqn``, or ``None`` if missing/unreadable.
+
+        Returning ``None`` (rather than raising) lets the caller
+        distinguish "table doesn't exist" from "table exists but is
+        empty" — both are failures, but they're reported with
+        different messages so the operator knows whether the bug is
+        in pipeline wiring or in data routing.
+        """
+        try:
+            return spark.sql(
+                f"SELECT count(*) AS c FROM {fqn}"
+            ).first().c
+        except Exception:
+            return None
+
+    def _expect_exact(fqn, want):
+        got = _table_count(fqn)
+        if got is None:
+            failures.append(f"{fqn}: missing (table not found)")
+        elif got != want:
+            failures.append(
+                f"{fqn}: expected exactly {want} rows, got {got}"
+            )
+
+    def _expect_at_least(fqn, want):
+        got = _table_count(fqn)
+        if got is None:
+            failures.append(f"{fqn}: missing (table not found)")
+        elif got < want:
+            failures.append(
+                f"{fqn}: expected >= {want} rows, got {got}"
+            )
+
+    def _expect_nonempty(fqn):
+        _expect_at_least(fqn, 1)
+
+    # 1. Append flow — bronze ``orders`` is fed by two hardcoded JSON
+    # literals (``orders_main_data`` = 4 rows, ``orders_af_data`` = 3
+    # rows). Append flow is non-merging, so the count is exactly 7
+    # regardless of widget choices. Drift here means
+    # ``dp.append_flow`` wiring broke.
+    _expect_exact(
+        f"{uc_catalog_name}.{bronze_schema}.orders", 7
+    )
+
+    # 2. Sink — bronze ``iot_events`` is fed by a hardcoded 5-row CSV
+    # literal. Drift here means the bronze table that backs the sink
+    # is broken; the external sink target is validated separately by
+    # the ``DLT Sink`` cells above.
+    _expect_exact(
+        f"{uc_catalog_name}.{bronze_schema}.iot_events", 5
+    )
+
+    # 3. Snapshot tables — fed by hardcoded CSV literals. The demo
+    # runs the snapshot pipeline TWICE: once with LOAD_1, once after
+    # LOAD_2 is copied over LOAD_1 (see "Snapshot V2" cells above).
+    # Bounds below track the *final* state after the V2 run, not the
+    # initial load:
+    #   - ``snap_products`` is SCD Type 2 → history retained, so the
+    #     final row count is ``>= LOAD_1 count`` (5). LOAD_2 keeps
+    #     the same 5 keys but renames them; SCD2 inserts new rows
+    #     for the changed values, so the actual count is closer to
+    #     ~7-9 — we assert the lower bound (5).
+    #   - ``snap_stores`` is SCD Type 1 → the demo deliberately drops
+    #     stores 3 & 4 in LOAD_2 to show SCD1's delete-on-missing
+    #     semantics, leaving exactly 2 rows. We assert ``>= 2`` (the
+    #     LOAD_2 count) rather than exact 2 so future tweaks to the
+    #     LOAD_2 fixture don't have to thread through here.
+    _expect_at_least(
+        f"{uc_catalog_name}.{bronze_schema}.snap_products", 5
+    )
+    _expect_at_least(
+        f"{uc_catalog_name}.{bronze_schema}.snap_stores", 2
+    )
+    _expect_at_least(
+        f"{uc_catalog_name}.{silver_schema}.snap_products", 5
+    )
+    _expect_at_least(
+        f"{uc_catalog_name}.{silver_schema}.snap_stores", 2
+    )
+
+    # 4. Quarantine — for each domain we wrote 2 hardcoded bad rows
+    # (lines ~963-983). Some may be DQE-dropped vs quarantined
+    # depending on the DQE rules in ``demo/conf/json/dqe/``, so we
+    # only assert ``>= 1``. An empty quarantine table after we
+    # explicitly seeded bad data means quarantine routing is broken.
+    for domain in ("customers", "transactions", "products", "stores"):
+        _expect_nonempty(
+            f"{uc_catalog_name}.{bronze_schema}"
+            f".{domain}_quarantine"
+        )
+
+    # 5. Customers / transactions / products / stores — count varies
+    # with ``data_source``: ``github`` uses fixed CSVs from the
+    # repo, ``dbdatagen`` uses random synthetic data with no fixed
+    # seed. Existence + non-empty is the strongest universal check;
+    # tightening to exact counts would require either pinning the
+    # dbdatagen seed across the codebase or splitting this branch by
+    # ``data_source``, neither of which is worth the complexity.
+    for domain in ("customers", "transactions", "products", "stores"):
+        _expect_nonempty(
+            f"{uc_catalog_name}.{bronze_schema}.{domain}"
+        )
+        _expect_nonempty(
+            f"{uc_catalog_name}.{silver_schema}.{domain}"
+        )
+
+    if failures:
+        raise AssertionError(
+            "Demo final validation failed "
+            f"({len(failures)} issue(s)):\n  - "
+            + "\n  - ".join(failures)
+        )
+    print("Demo final validation passed: all expected tables present.")
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ---
+# MAGIC ## Cleanup (Optional)
+# MAGIC
+# MAGIC Drops every per-run resource the demo created -- pipelines,
+# MAGIC runner notebooks, and per-run schemas (bronze, silver, pipeline
+# MAGIC target, config). Controlled by the `cleanup` widget; safe to
+# MAGIC re-run interactively (each step is wrapped in try/except).
+# MAGIC
+# MAGIC Intentionally **does NOT drop the UC catalog** -- the catalog
+# MAGIC is user-supplied (via the `uc_catalog_name` widget), is shared
+# MAGIC across runs, and dropping it would clobber other concurrent
+# MAGIC demos. If you want to drop the catalog too, do it manually:
+# MAGIC `DROP CATALOG <name> CASCADE`.
+
+# COMMAND ----------
+
+def _cleanup_demo_resources():
+    """Drop every per-run resource the demo created.
+
+    Resolution order matches the demo's creation order, reversed:
+
+    1. Pipelines -- read pipeline IDs from the per-run pid files we
+       wrote into ``uc_volume_path`` during pipeline creation. Falls
+       back to a name-based lookup (``sdp_meta_demo_*_<schema>``) when
+       the pid file is missing (e.g. cleanup re-run after the volume
+       was already dropped).
+    2. Runner notebooks -- ``runner_notebook_path`` and
+       ``snapshot_runner_path``. The sink pipeline reuses
+       ``runner_notebook_path``, so it's covered by the same delete.
+    3. Per-run schemas -- ``bronze_schema``, ``silver_schema``,
+       ``pipeline_target_schema``, ``uc_schema_name``. Each ``DROP
+       SCHEMA ... CASCADE`` removes every table, view, and (for
+       ``uc_schema_name``) the per-run config volume.
+
+    Each step is independent and errors are swallowed with a print so
+    a partial demo failure (e.g. snapshot pipeline never ran) doesn't
+    block cleanup of everything else.
+    """
+    print("=" * 78)
+    print(
+        f"Cleanup: dropping per-run resources for "
+        f"{uc_catalog_name}.{uc_schema_name}"
+    )
+    print("=" * 78)
+
+    pipeline_specs = [
+        ("main", pipeline_id_file, pipeline_name),
+        (
+            "snapshot",
+            snapshot_pipeline_id_file,
+            f"sdp_meta_demo_snapshot_{uc_schema_name}",
+        ),
+        ("sink", sink_pipeline_id_file, sink_pipeline_name),
+    ]
+    for label, pid_file, name in pipeline_specs:
+        pid = None
+        try:
+            with open(pid_file, "r") as fh:
+                pid = fh.read().strip()
+        except Exception:
+            for p in w.pipelines.list_pipelines():
+                if p.name == name:
+                    pid = p.pipeline_id
+                    break
+        if not pid:
+            print(f"  Skipping {label} pipeline: not found ({name})")
+            continue
+        try:
+            w.pipelines.delete(pipeline_id=pid)
+            print(f"  Deleted {label} pipeline: {pid} ({name})")
+        except Exception as exc:
+            print(f"  Could not delete {label} pipeline {pid}: {exc}")
+
+    for nb_path in [runner_notebook_path, snapshot_runner_path]:
+        try:
+            w.workspace.delete(nb_path)
+            print(f"  Deleted runner notebook: {nb_path}")
+        except Exception as exc:
+            print(f"  Could not delete notebook {nb_path}: {exc}")
+
+    for schema in [
+        bronze_schema,
+        silver_schema,
+        pipeline_target_schema,
+        uc_schema_name,
+    ]:
+        fqn = f"{uc_catalog_name}.{schema}"
+        try:
+            spark.sql(f"DROP SCHEMA IF EXISTS {fqn} CASCADE")
+            print(f"  Dropped schema: {fqn}")
+        except Exception as exc:
+            print(f"  Could not drop schema {fqn}: {exc}")
+
+    print(
+        f"Cleanup complete for run schema={uc_schema_name} "
+        f"(catalog {uc_catalog_name} preserved)."
+    )
+
+
+if cleanup:
+    _cleanup_demo_resources()
+else:
+    print(
+        "Cleanup skipped (cleanup widget = false). "
+        "Re-run with cleanup=true to drop per-run resources, "
+        "or call _cleanup_demo_resources() manually."
+    )

--- a/demo/launch_dab_template_demo.py
+++ b/demo/launch_dab_template_demo.py
@@ -95,6 +95,7 @@ from databricks.labs.sdp_meta.bundle import (  # noqa: E402
     bundle_prepare_wheel,
     bundle_validate,
 )
+from databricks.labs.sdp_meta.identifiers import validate_uc_identifier  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -1773,6 +1774,20 @@ def main() -> int:
                              "Defaults to 'staging'. Only used by scenarios whose "
                              "recipe references {uc_source_schema}.")
     args = parser.parse_args()
+
+    # Validate UC identifiers up-front so the demo fails fast with a clear
+    # error message rather than producing a bundle that breaks at deploy
+    # time on a hyphenated catalog (issue #261). Strict regular SQL
+    # identifier rule applied to every UC name the demo accepts.
+    validate_uc_identifier(args.uc_catalog_name, kind="--uc-catalog-name")
+    if args.uc_schema:
+        validate_uc_identifier(args.uc_schema, kind="--uc-schema")
+    if args.uc_volume:
+        validate_uc_identifier(args.uc_volume, kind="--uc-volume")
+    if args.uc_source_catalog:
+        validate_uc_identifier(args.uc_source_catalog, kind="--uc-source-catalog")
+    if args.uc_source_schema:
+        validate_uc_identifier(args.uc_source_schema, kind="--uc-source-schema")
 
     out_dir = Path(args.out_dir).resolve()
     out_dir.mkdir(parents=True, exist_ok=True)

--- a/demo/launch_interactive_demo.py
+++ b/demo/launch_interactive_demo.py
@@ -1,0 +1,616 @@
+"""Launch the SDP-META interactive demo as a one-time job in a Databricks workspace.
+
+Mirrors the pattern in ``integration_tests/run_integration_tests.py``:
+authenticates against a workspace, uploads the demo notebook to a per-run
+folder, submits a one-time **serverless** job with the demo notebook as a
+single task, and blocks on completion.
+
+Use this for:
+  * CI smoke runs — pass ``--validate-counts true`` (the default) so the
+    demo's final-validation cell asserts row counts and fails the job on
+    any regression (broken append flow, broken sink, broken quarantine
+    routing, etc.).
+  * Headless demos — let an SA kick the demo against a fresh workspace
+    without opening the notebook by hand.
+
+The demo notebook handles everything else internally: UC schema/volume
+creation, data generation/download, dataflowspec onboarding, and pipeline
+creation (all 3 pipelines run on serverless). This launcher just wires up
+the widgets and watches the run.
+
+Three ways to install sdp-meta in the demo job
+-----------------------------------------------
+
+1. ``--install-source git_branch`` (default) -- the demo runs
+   ``pip install git+https://github.com/databrickslabs/dlt-meta.git@<branch>``
+   inside the job. Fastest path; matches the interactive demo experience.
+2. ``--install-source whl_file --whl-file-path <UC volume path>`` -- you
+   already uploaded a wheel; the demo just installs from it. Use this
+   when the wheel is published by another job (e.g. release pipeline).
+3. ``--build-and-upload-whl --uc-schema-name <s> --uc-volume-name <v>``
+   -- the launcher builds the wheel from the local source tree, creates
+   the UC schema/volume if needed, uploads the wheel, and points the
+   demo at the resulting ``/Volumes/...`` path. Same machinery as
+   ``databricks labs sdp-meta bundle prepare-wheel``.
+
+Usage examples
+--------------
+::
+
+    # Smoke run against a fresh per-run schema, default git branch.
+    python demo/launch_interactive_demo.py \\
+        --uc-catalog-name main \\
+        --profile DEFAULT
+
+    # Build the wheel locally, upload it to a UC volume, then run the
+    # demo against it. One command, no manual `bundle prepare-wheel`.
+    python demo/launch_interactive_demo.py \\
+        --uc-catalog-name main \\
+        --profile DEFAULT \\
+        --build-and-upload-whl \\
+        --uc-schema-name sdp_meta_demo \\
+        --uc-volume-name sdp_meta_wheels
+
+    # Validate a wheel that's ALREADY on a UC volume.
+    python demo/launch_interactive_demo.py \\
+        --uc-catalog-name main \\
+        --profile DEFAULT \\
+        --install-source whl_file \\
+        --whl-file-path /Volumes/main/sdp_meta_demo/sdp_meta_wheels/\\
+databricks_labs_sdp_meta-0.1.0-py3-none-any.whl
+
+    # Deterministic data path (recommended for CI):
+    python demo/launch_interactive_demo.py \\
+        --uc-catalog-name main \\
+        --profile DEFAULT \\
+        --data-source github \\
+        --git-branch main
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import uuid
+import webbrowser
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+# Importing from src after path patching so the script runs without an
+# editable install (mirrors integration_tests/run_integration_tests.py).
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC = REPO_ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from databricks.sdk import WorkspaceClient  # noqa: E402
+from databricks.sdk.service import jobs  # noqa: E402
+from databricks.sdk.service.compute import Environment  # noqa: E402
+from databricks.sdk.service.workspace import (  # noqa: E402
+    ImportFormat,
+    Language,
+)
+
+from databricks.labs.sdp_meta.bundle import (  # noqa: E402
+    BundlePrepareWheelCommand,
+    bundle_prepare_wheel,
+)
+from databricks.labs.sdp_meta.identifiers import (  # noqa: E402
+    validate_uc_identifier,
+)
+
+DEMO_NOTEBOOK_SRC: Path = REPO_ROOT / "demo" / "SDP_META_INTERACTIVE_DEMO.py"
+DEMO_CONF_DIR: Path = REPO_ROOT / "demo" / "conf"
+
+# Files under ``demo/conf/`` excluded from the recursive co-upload.
+# Hidden files (``.DS_Store``, ``.gitkeep``) and editor backups don't
+# belong in the workspace; everything else under ``demo/conf/`` is
+# fair game because the demo notebook (or a future contributor adding
+# a new conf reference) might end up reading any of it via the
+# ``open(/Workspace/.../demo/conf/...)`` path. Walking the tree --
+# rather than maintaining an explicit allow-list -- means new conf
+# files added to the repo automatically work in headless launcher
+# runs without a follow-up commit here.
+_DEMO_CONF_EXCLUDE_NAMES: frozenset[str] = frozenset({".DS_Store", ".gitkeep"})
+_DEMO_CONF_EXCLUDE_SUFFIXES: tuple[str, ...] = (".pyc", ".swp", "~")
+
+
+def _upload_demo_notebook(ws: WorkspaceClient, target_path: str) -> None:
+    """Upload the demo notebook to ``target_path`` in the workspace.
+
+    The file already starts with ``# Databricks notebook source`` so the
+    workspace renders it as a notebook (not a plain .py file). Uses
+    ``ImportFormat.SOURCE`` + ``Language.PYTHON`` to match the convention
+    in ``integration_tests/run_integration_tests.py``'s
+    ``upload_files_to_databricks``.
+    """
+    if not DEMO_NOTEBOOK_SRC.is_file():
+        raise SystemExit(
+            f"Demo notebook source not found at {DEMO_NOTEBOOK_SRC}. "
+            "Did you delete demo/SDP_META_INTERACTIVE_DEMO.py?"
+        )
+    target_dir = "/".join(target_path.rstrip("/").split("/")[:-1])
+    ws.workspace.mkdirs(target_dir)
+    print(f"Uploading {DEMO_NOTEBOOK_SRC.name} to {target_path} ...")
+    ws.workspace.upload(
+        path=target_path,
+        content=DEMO_NOTEBOOK_SRC.read_bytes(),
+        format=ImportFormat.SOURCE,
+        language=Language.PYTHON,
+        overwrite=True,
+    )
+
+
+def _upload_demo_conf(ws: WorkspaceClient, repo_root_ws: str) -> None:
+    """Recursively co-upload every file under ``demo/conf/`` to the workspace.
+
+    The demo notebook resolves conf files via:
+
+        f"{repo_root_ws}/demo/conf/{onboarding_format}/sample_onboarding."
+        f"{conf_ext}"
+
+    where ``repo_root_ws`` is whatever is to the left of ``/demo/`` in
+    the notebook's workspace path. By uploading the entire ``demo/conf/``
+    subtree the launcher keeps the demo offline-friendly: no GitHub
+    fallback is needed, even when the local branch isn't pushed (issue
+    surfaced when running ``feature/sdp-meta`` locally — main doesn't
+    yet have these files).
+
+    We deliberately walk the tree rather than carry an allow-list: today
+    the notebook only reads ``sample_onboarding.{json,yml}``, but the
+    moment a contributor adds a new ``open(...demo/conf/<x>...)`` call
+    in the notebook, the launcher would silently fall through to the
+    GitHub raw-URL path (which fails for un-pushed branches and produces
+    the confusing "HTTP 404" error we already debugged once). Uploading
+    the whole subtree makes new conf files Just Work in headless runs.
+
+    Files are uploaded as workspace files (``ImportFormat.RAW``), not
+    notebooks, so the demo's ``open()`` call against ``/Workspace/...``
+    reads back the exact bytes we wrote. Hidden files / editor backups
+    are skipped via :data:`_DEMO_CONF_EXCLUDE_NAMES` /
+    :data:`_DEMO_CONF_EXCLUDE_SUFFIXES`.
+    """
+    if not DEMO_CONF_DIR.is_dir():
+        print(f"(no demo/conf dir at {DEMO_CONF_DIR}, skipping conf upload)")
+        return
+
+    uploaded = 0
+    for src in sorted(DEMO_CONF_DIR.rglob("*")):
+        if not src.is_file():
+            continue
+        if src.name in _DEMO_CONF_EXCLUDE_NAMES:
+            continue
+        if src.name.endswith(_DEMO_CONF_EXCLUDE_SUFFIXES):
+            continue
+        rel = src.relative_to(DEMO_CONF_DIR).as_posix()
+        target = f"{repo_root_ws}/demo/conf/{rel}"
+        target_dir = "/".join(target.rstrip("/").split("/")[:-1])
+        ws.workspace.mkdirs(target_dir)
+        print(f"Uploading {src.relative_to(REPO_ROOT)} to {target} ...")
+        ws.workspace.upload(
+            path=target,
+            content=src.read_bytes(),
+            format=ImportFormat.RAW,
+            overwrite=True,
+        )
+        uploaded += 1
+    print(f"Co-uploaded {uploaded} conf file(s) under {repo_root_ws}/demo/conf/")
+
+
+def _submit_demo_job(
+    ws: WorkspaceClient,
+    *,
+    run_id: str,
+    run_name: str,
+    target_notebook_path: str,
+    base_parameters: dict[str, str],
+    timeout_min: int,
+):
+    """Submit a one-time serverless job that runs the demo notebook.
+
+    Uses the same ``Environment(client="2")`` serverless pattern as
+    ``demo/launch_dab_template_demo.py::_run_delta_seed_notebook`` — the
+    user doesn't have to plumb a cluster id in for the launcher to work.
+    The demo creates its own pipelines internally (also on serverless),
+    so the only compute this launcher provisions is the driver task.
+
+    ``run_name`` is the user-facing label that shows up in the workspace
+    Jobs > Job Runs UI; the caller composes it from launch context
+    (timestamp + catalog + run_id) so concurrent runs don't visually
+    collide in the run history.
+    """
+    print(
+        f"Submitting one-time serverless job '{run_name}' "
+        f"(run_id={run_id}) ..."
+    )
+    waiter = ws.jobs.submit(
+        run_name=run_name,
+        tasks=[
+            jobs.SubmitTask(
+                task_key="run_demo",
+                notebook_task=jobs.NotebookTask(
+                    notebook_path=target_notebook_path,
+                    base_parameters=base_parameters,
+                ),
+                environment_key="demo_env",
+            ),
+        ],
+        environments=[
+            jobs.JobEnvironment(
+                environment_key="demo_env",
+                spec=Environment(client="2"),
+            ),
+        ],
+    )
+
+    # Resolve + open the run page URL in the browser BEFORE blocking on
+    # completion -- mirrors `integration_tests/run_integration_tests.py
+    # ::launch_workflow` so the user can watch the notebook run live
+    # instead of staring at the terminal. The Wait[Run] returned by
+    # `submit()` exposes the run_id immediately (without blocking) via
+    # an internal attribute; we look it up defensively across SDK
+    # versions and silently fall through if the SDK changes shape.
+    submitted_run_id = (
+        getattr(waiter, "run_id", None)
+        or getattr(getattr(waiter, "response", None), "run_id", None)
+    )
+    if submitted_run_id is not None:
+        try:
+            meta = ws.jobs.get_run(run_id=submitted_run_id)
+            page_url = getattr(meta, "run_page_url", None)
+            if page_url:
+                print(f"Run page: {page_url}")
+                # Open in the default browser. If we're headless / on CI,
+                # `webbrowser.open` may print a warning but won't raise --
+                # still tolerate that defensively so the launcher's main
+                # job (waiting for the run) is never blocked by the open.
+                try:
+                    webbrowser.open(page_url)
+                except Exception as exc:
+                    print(f"(could not auto-open browser: {exc})")
+        except Exception as exc:
+            print(f"(could not fetch run_page_url early: {exc})")
+
+    # Block on completion. We pick the timeout long enough to cover the
+    # slowest stage (4 pipeline runs on a cold workspace) but short
+    # enough that a hung run fails CI in reasonable time.
+    #
+    # When the run FAILS, ``waiter.result`` raises ``OperationFailed`` and
+    # we'd otherwise unwind without printing the run URL. Fall back to
+    # ``ws.jobs.get_run`` so main() can still report state + URL (which
+    # we already opened in the browser above) and exit non-zero cleanly.
+    print(
+        f"Waiting up to {timeout_min} minute(s) for job to complete ..."
+    )
+    try:
+        return waiter.result(timeout=timedelta(minutes=timeout_min))
+    except Exception as exc:
+        if submitted_run_id is None:
+            raise
+        print(f"(run finished with non-success state: {exc})")
+        return ws.jobs.get_run(run_id=submitted_run_id)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__.split("\n", maxsplit=1)[0]
+    )
+    parser.add_argument(
+        "--uc-catalog-name",
+        required=True,
+        help="Unity Catalog catalog the demo writes into. Substituted "
+             "into the demo's uc_catalog_name widget. Must be a regular "
+             "SQL identifier (issue #261).",
+    )
+    parser.add_argument(
+        "--uc-schema-name",
+        default=None,
+        help="UC schema name passed to the demo's uc_schema_name widget. "
+             "Defaults to ``sdp_meta_demo_<run_id>`` so concurrent runs "
+             "and CI runs don't collide on bronze/silver tables. Pass "
+             "this explicitly only if you want to reuse a previous run's "
+             "schema (rare).",
+    )
+    parser.add_argument(
+        "--profile",
+        default=None,
+        help="Databricks CLI profile name. When omitted, falls back to "
+             "the SDK's default (env vars / DEFAULT profile).",
+    )
+    parser.add_argument(
+        "--git-branch",
+        default="main",
+        help="Branch passed to the demo's git_branch widget. Drives BOTH "
+             "(a) ``pip install git+https://github.com/databrickslabs/"
+             "dlt-meta.git@<branch>`` when --install-source=git_branch, "
+             "AND (b) where the demo fetches sample CSVs and onboarding "
+             "templates from raw.githubusercontent.com (always — even "
+             "when installing from a wheel).",
+    )
+    parser.add_argument(
+        "--install-source",
+        default="git_branch",
+        choices=["git_branch", "whl_file"],
+        help="Where the demo installs sdp-meta from. Use 'whl_file' to "
+             "validate a local build before merging.",
+    )
+    parser.add_argument(
+        "--whl-file-path",
+        default="",
+        help="Wheel file path on a UC volume / Workspace. Required when "
+             "--install-source=whl_file. Example: ``/Volumes/<cat>/"
+             "<sch>/<vol>/sdp_meta-<version>-py3-none-any.whl``.",
+    )
+    parser.add_argument(
+        "--build-and-upload-whl",
+        action="store_true",
+        help="Build the sdp-meta wheel from the local source tree, "
+             "auto-create the UC schema/volume if needed, upload the "
+             "wheel, and point the demo at the resulting /Volumes/... "
+             "path. Implies --install-source=whl_file. Requires "
+             "--uc-schema-name and --uc-volume-name. Reuses the same "
+             "machinery as `databricks labs sdp-meta bundle "
+             "prepare-wheel`, so a private pypi mirror is honored via "
+             "$PIP_INDEX_URL / $PIP_EXTRA_INDEX_URL (or the explicit "
+             "--pip-index-url / --pip-extra-index-url flags below).",
+    )
+    parser.add_argument(
+        "--uc-volume-name",
+        default=None,
+        help="UC volume name used to upload the wheel when "
+             "--build-and-upload-whl is set. Auto-created under "
+             "<uc-catalog>.<uc-schema-name> if missing (catalogs are "
+             "never auto-created).",
+    )
+    parser.add_argument(
+        "--pip-index-url",
+        default=None,
+        help="Forwarded to `pip wheel` as --index-url when "
+             "--build-and-upload-whl is set. Defaults to "
+             "$PIP_INDEX_URL. Use this on networks where pypi.org is "
+             "not reachable.",
+    )
+    parser.add_argument(
+        "--pip-extra-index-url",
+        action="append",
+        default=None,
+        help="Forwarded to `pip wheel` as --extra-index-url. Pass "
+             "multiple times for multiple URLs. Defaults to "
+             "$PIP_EXTRA_INDEX_URL (space-separated).",
+    )
+    parser.add_argument(
+        "--no-create-missing-uc",
+        dest="create_missing_uc",
+        action="store_false",
+        help="Do NOT auto-create the UC schema/volume during "
+             "--build-and-upload-whl. Default: create them if missing "
+             "(catalogs are never auto-created).",
+    )
+    parser.set_defaults(create_missing_uc=True)
+    parser.add_argument(
+        "--data-source",
+        default="dbdatagen",
+        choices=["dbdatagen", "github"],
+        help="Demo data-source widget. 'github' downloads deterministic "
+             "CSVs from the dlt-meta repo (recommended for CI smoke). "
+             "'dbdatagen' generates random synthetic data (interactive "
+             "demos only — counts vary run-to-run).",
+    )
+    parser.add_argument(
+        "--onboarding-format",
+        default="json",
+        choices=["json", "yml"],
+        help="Demo onboarding-format widget.",
+    )
+    parser.add_argument(
+        "--validate-counts",
+        default="true",
+        choices=["true", "false"],
+        help="Demo validate_counts widget. When 'true' (default), the "
+             "demo's final-validation cell asserts row counts and the "
+             "job FAILS on regression. Set to 'false' to disable "
+             "assertions (interactive walkthrough mode).",
+    )
+    parser.add_argument(
+        "--cleanup",
+        default="false",
+        choices=["true", "false"],
+        help="Demo cleanup widget. When 'true', the demo's final cell "
+             "drops every per-run resource it created -- pipelines, "
+             "runner notebooks, and per-run schemas (bronze, silver, "
+             "pipeline target, config volume). The user-supplied UC "
+             "catalog is intentionally preserved (it's shared across "
+             "runs). Default 'false' so interactive runs leave tables "
+             "available for inspection. Set to 'true' for CI / smoke "
+             "runs that need to leave the workspace clean.",
+    )
+    parser.add_argument(
+        "--timeout-minutes",
+        type=int,
+        default=90,
+        help="Job-completion timeout. The demo runs 3+ pipelines "
+             "end-to-end on serverless; 90 minutes covers a cold "
+             "workspace with margin. Bump for slower clouds/regions.",
+    )
+    args = parser.parse_args()
+
+    # Validate UC identifiers up-front so the launcher fails fast with a
+    # clear message instead of crashing later inside the job's CREATE
+    # SCHEMA call (issue #261). The demo notebook itself re-validates
+    # these on first read AND again post-restartPython, but we mirror
+    # the check here so an obviously-broken --uc-catalog-name fails on
+    # the laptop before we burn workspace minutes.
+    validate_uc_identifier(args.uc_catalog_name, kind="--uc-catalog-name")
+    if args.uc_schema_name:
+        validate_uc_identifier(
+            args.uc_schema_name, kind="--uc-schema-name"
+        )
+    if args.install_source == "whl_file" and not args.whl_file_path \
+            and not args.build_and_upload_whl:
+        raise SystemExit(
+            "--install-source=whl_file requires --whl-file-path to be "
+            "set, e.g. --whl-file-path /Volumes/<cat>/<sch>/<vol>/"
+            "sdp_meta-<version>-py3-none-any.whl, OR re-run with "
+            "--build-and-upload-whl so the launcher builds and uploads "
+            "the wheel for you."
+        )
+    if args.build_and_upload_whl:
+        # --build-and-upload-whl needs both a schema (for the volume to
+        # live under) and a volume name; we don't fall back to the
+        # per-run uc_schema_name default here because that schema gets
+        # torn down with each demo run, which would orphan every wheel
+        # uploaded under it.
+        if not args.uc_schema_name:
+            raise SystemExit(
+                "--build-and-upload-whl requires --uc-schema-name "
+                "(an existing or new UC schema for the wheel volume; "
+                "do NOT reuse the per-run demo schema since it gets "
+                "torn down with each run)."
+            )
+        if not args.uc_volume_name:
+            raise SystemExit(
+                "--build-and-upload-whl requires --uc-volume-name "
+                "(the UC volume the wheel will be uploaded to)."
+            )
+        validate_uc_identifier(args.uc_volume_name, kind="--uc-volume-name")
+
+    # Per-run isolation. Mirrors the run_integration_tests.py pattern of
+    # baking a uuid into every workspace artifact so concurrent runs
+    # (laptop x CI x another developer) never clobber each other's
+    # bronze/silver tables, dataflowspecs, or pipelines.
+    run_id = uuid.uuid4().hex[:12]
+    # Human-scannable, globally-unique run name for the workspace's Job
+    # Runs UI. Combines an ISO-8601 UTC timestamp (sortable, identifies
+    # *when* the run was launched), the target catalog (identifies
+    # *where* it ran), and the per-run uuid suffix (guarantees
+    # uniqueness even if two launches share the same second + catalog).
+    # Example: ``sdp-meta-demo-20260427T201112Z-ravi_dlt_meta_uc-a2b35bc8aa93``
+    launch_ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    run_name = (
+        f"sdp-meta-demo-{launch_ts}-{args.uc_catalog_name}-{run_id}"
+    )
+    # The schema the demo writes to is intentionally distinct from the
+    # schema the optional wheel volume lives under (see the schema/volume
+    # check above). When --build-and-upload-whl is set,
+    # ``args.uc_schema_name`` is the wheel-volume schema; the demo still
+    # gets a fresh per-run schema so concurrent runs don't fight over
+    # bronze/silver tables.
+    if args.build_and_upload_whl:
+        demo_uc_schema_name = f"sdp_meta_demo_{run_id}"
+    else:
+        demo_uc_schema_name = (
+            args.uc_schema_name or f"sdp_meta_demo_{run_id}"
+        )
+    validate_uc_identifier(
+        demo_uc_schema_name, kind="resolved uc_schema_name"
+    )
+
+    if args.profile:
+        ws = WorkspaceClient(profile=args.profile)
+    else:
+        ws = WorkspaceClient()
+    me = ws.current_user.me().user_name
+    # Notebook lives under ``.../<run-id>/demo/`` so that the demo's
+    # workspace-co-located lookup (``"/demo/" in nb_path``) succeeds and
+    # finds the conf files we co-upload below at
+    # ``.../<run-id>/demo/conf/{fmt}/sample_onboarding.{ext}``.
+    repo_root_ws = f"/Users/{me}/sdp_meta_demo_runs/{run_id}"
+    target_notebook_path = (
+        f"{repo_root_ws}/demo/SDP_META_INTERACTIVE_DEMO"
+    )
+
+    # Optional STAGE 0: build + upload the wheel before submitting the
+    # job. We resolve install_source / whl_file_path AFTER this so the
+    # widgets the demo sees match what we actually want it to install.
+    install_source = args.install_source
+    whl_file_path = args.whl_file_path
+    if args.build_and_upload_whl:
+        import os as _os
+        extras = args.pip_extra_index_url
+        if not extras and _os.environ.get("PIP_EXTRA_INDEX_URL"):
+            extras = [
+                u for u in _os.environ["PIP_EXTRA_INDEX_URL"].split() if u
+            ]
+        print(
+            "Building sdp-meta wheel locally and uploading to "
+            f"/Volumes/{args.uc_catalog_name}/{args.uc_schema_name}/"
+            f"{args.uc_volume_name} ..."
+        )
+        whl_file_path = bundle_prepare_wheel(BundlePrepareWheelCommand(
+            uc_catalog=args.uc_catalog_name,
+            uc_schema=args.uc_schema_name,
+            uc_volume=args.uc_volume_name,
+            profile=args.profile,
+            pip_index_url=args.pip_index_url,
+            pip_extra_index_urls=extras,
+            create_if_missing=args.create_missing_uc,
+        ))
+        install_source = "whl_file"
+        print(f"Wheel uploaded to: {whl_file_path}")
+
+    _upload_demo_notebook(ws, target_notebook_path)
+    _upload_demo_conf(ws, repo_root_ws)
+
+    # ``base_parameters`` map 1:1 to the widgets defined at the top of
+    # SDP_META_INTERACTIVE_DEMO.py. When a notebook task launches with
+    # ``base_parameters``, the workspace pre-populates the matching
+    # ``dbutils.widgets`` so the demo reads them straight through.
+    base_parameters = {
+        "git_branch": args.git_branch,
+        "uc_catalog_name": args.uc_catalog_name,
+        "uc_schema_name": demo_uc_schema_name,
+        "data_source": args.data_source,
+        "onboarding_format": args.onboarding_format,
+        "install_source": install_source,
+        "whl_file_path": whl_file_path,
+        "validate_counts": args.validate_counts,
+        "cleanup": args.cleanup,
+    }
+    print("Demo run parameters:")
+    for k, v in base_parameters.items():
+        print(f"  {k}: {v!r}")
+    print(f"  run_id:    {run_id}")
+    print(f"  run_name:  {run_name}")
+    print(f"  notebook:  {target_notebook_path}")
+
+    run = _submit_demo_job(
+        ws,
+        run_id=run_id,
+        run_name=run_name,
+        target_notebook_path=target_notebook_path,
+        base_parameters=base_parameters,
+        timeout_min=args.timeout_minutes,
+    )
+
+    # Surface the run page first — even on success it's the most useful
+    # thing for the operator to bookmark, and on failure they need to
+    # click straight through to the workspace UI.
+    run_page_url = getattr(run, "run_page_url", None)
+    state = getattr(run, "state", None)
+    result_state = (
+        state.result_state.value
+        if state and state.result_state
+        else "UNKNOWN"
+    )
+    state_message = (
+        state.state_message
+        if state and getattr(state, "state_message", None)
+        else ""
+    )
+
+    print("")
+    print("=" * 78)
+    print(f"Demo run finished. result_state={result_state}")
+    if state_message:
+        print(f"  state_message: {state_message}")
+    if run_page_url:
+        print(f"  run_page_url:  {run_page_url}")
+    print("=" * 78)
+
+    if result_state != "SUCCESS":
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/integration_tests/run_integration_tests.py
+++ b/integration_tests/run_integration_tests.py
@@ -23,6 +23,7 @@ from databricks.sdk.service.catalog import SchemasAPI, VolumeInfo, VolumeType
 from databricks.sdk.service.pipelines import NotebookLibrary, PipelineLibrary
 from databricks.sdk.service.workspace import ImportFormat, Language
 
+from databricks.labs.sdp_meta.identifiers import validate_uc_identifier
 from databricks.labs.sdp_meta.install import WorkspaceInstaller
 
 # Dictionary mapping cloud providers to node types
@@ -1229,6 +1230,12 @@ def process_arguments() -> dict[str:str]:
                 f"--{arg[0]}", help=arg[1], type=arg[2], required=arg[3]
             )
     args = vars(parser.parse_args())
+
+    # Validate UC identifiers up-front so the run fails fast with a clear
+    # error message instead of crashing later inside CREATE SCHEMA / CREATE
+    # VOLUME / spark.read.table when a hyphenated catalog or other illegal
+    # name was passed (issue #261). Strictly regular SQL identifiers only.
+    validate_uc_identifier(args["uc_catalog_name"], kind="--uc_catalog_name")
 
     def check_cond_mandatory_arg(args, mandatory_args):
         """Post argument parsing check for conditionally required arguments"""

--- a/src/databricks/labs/sdp_meta/bundle.py
+++ b/src/databricks/labs/sdp_meta/bundle.py
@@ -29,6 +29,13 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import yaml
 
+from databricks.labs.sdp_meta.identifiers import (
+    SUPPORTED_SOURCE_FORMATS,
+    prompt_uc_identifier,
+    validate_source_format,
+    validate_uc_identifier,
+)
+
 logger = logging.getLogger("databricks.labs.sdp_meta")
 
 
@@ -145,6 +152,15 @@ class BundlePrepareWheelCommand:
     # Set False if your principal is read-only on the schema namespace and
     # you want a hard failure instead of an attempted CREATE SCHEMA.
     create_if_missing: bool = True
+
+    def __post_init__(self) -> None:
+        # Reject illegal UC names up-front so we never try to splice a
+        # hyphenated catalog into a CREATE SCHEMA / CREATE VOLUME later
+        # (issue #261). Must mirror the strict regular-identifier rule used
+        # by the rest of the input boundaries (CLI, DAB template).
+        validate_uc_identifier(self.uc_catalog, kind="uc_catalog")
+        validate_uc_identifier(self.uc_schema, kind="uc_schema")
+        validate_uc_identifier(self.uc_volume, kind="uc_volume")
 
 
 def bundle_prepare_wheel(cmd: BundlePrepareWheelCommand) -> str:
@@ -604,8 +620,6 @@ _CSV_FIELD_ALIASES = {
     "cloudfiles_format": ["cloudfiles_format", "cloudFiles.format", "format"],
 }
 
-_VALID_SOURCE_FORMATS = ("cloudFiles", "delta", "kafka", "eventhub", "snapshot")
-
 
 @dataclass
 class FlowSpec:
@@ -717,11 +731,11 @@ def _flow_to_dict(spec: FlowSpec, variables: Dict[str, Any], assigned_id: str) -
     onboarding_file_format, dataflow_group) from variables.yml so the new
     flow matches the surrounding bundle's conventions.
     """
-    if spec.source_format not in _VALID_SOURCE_FORMATS:
-        raise ValueError(
-            f"source_format={spec.source_format!r} is not supported. "
-            f"Use one of {_VALID_SOURCE_FORMATS}."
-        )
+    # Single source of truth lives in identifiers.py so the bundle CLI,
+    # DAB template, and onboarding pre-flight all agree on the supported
+    # set; ValueError message format is preserved for any caller that
+    # was matching on it.
+    validate_source_format(spec.source_format)
 
     layer = (_var_default(variables, "layer") or "bronze_silver").lower()
     onboarding_format = (_var_default(variables, "onboarding_file_format") or "yaml").lower()
@@ -729,6 +743,15 @@ def _flow_to_dict(spec: FlowSpec, variables: Dict[str, Any], assigned_id: str) -
     bronze_schema = _var_default(variables, "bronze_target_schema") or "sdp_meta_bronze"
     silver_schema = _var_default(variables, "silver_target_schema") or "sdp_meta_silver"
     bundle_group = _var_default(variables, "dataflow_group")
+
+    # Validate any UC identifiers we read out of the bundle's
+    # `variables.yml` before splicing them into onboarding rows. This
+    # catches the case where the bundle was scaffolded outside of
+    # `bundle-init` (e.g. hand-edited / generated from an older sdp-meta
+    # version) and a hyphenated catalog snuck through (issue #261).
+    validate_uc_identifier(catalog, kind="variables.yml uc_catalog_name")
+    validate_uc_identifier(bronze_schema, kind="variables.yml bronze_target_schema")
+    validate_uc_identifier(silver_schema, kind="variables.yml silver_target_schema")
 
     bronze_table = spec.bronze_table
     silver_table = spec.silver_table
@@ -743,6 +766,14 @@ def _flow_to_dict(spec: FlowSpec, variables: Dict[str, Any], assigned_id: str) -
             raise ValueError(
                 "silver_table is required when layer is `silver` (no bronze fallback)."
             )
+
+    # Bronze/silver table names eventually get spliced unquoted into SQL
+    # (`spark.read.table(...)`), so reject anything that isn't a regular
+    # SQL identifier here at the input boundary (issue #261).
+    if bronze_table:
+        validate_uc_identifier(bronze_table, kind="bronze_table")
+    if silver_table:
+        validate_uc_identifier(silver_table, kind="silver_table")
 
     table_for_paths = bronze_table or silver_table
     ext = "yml" if onboarding_format == "yaml" else "json"
@@ -1039,6 +1070,16 @@ def _ensure_silver_transformation_entries(
 # wiring helpers used by cli.py
 # ---------------------------------------------------------------------------
 
+# Backwards-compatible alias for the canonical prompt helper. Existing
+# bundle.py call sites read ``_ident_prompt(wsi, text, kind=...)``;
+# routing through :func:`prompt_uc_identifier` keeps the retry / error-
+# print behavior in lockstep with ``cli.py::SDPMeta._ident_question``
+# so a future tweak (e.g. softening the regex, changing the retry
+# count) updates both call paths at once. See identifiers.py for the
+# implementation.
+_ident_prompt = prompt_uc_identifier
+
+
 def _load_bundle_init_config(wsi) -> BundleInitCommand:
     """Interactive loader used by `databricks labs sdp-meta bundle init`."""
     output_dir = wsi._question("Output directory for the new bundle", default=".")
@@ -1090,9 +1131,14 @@ def write_quickstart_config_file(dest_dir: Path) -> Path:
 
 
 def _load_bundle_prepare_wheel_config(wsi) -> BundlePrepareWheelCommand:
-    uc_catalog = wsi._question("Unity Catalog catalog name")
-    uc_schema = wsi._question("UC schema for the wheel volume", default="sdp_meta_dataflowspecs")
-    uc_volume = wsi._question("UC volume name", default="sdp_meta_wheels")
+    uc_catalog = _ident_prompt(wsi, "Unity Catalog catalog name", kind="uc_catalog")
+    uc_schema = _ident_prompt(
+        wsi, "UC schema for the wheel volume",
+        kind="uc_schema", default="sdp_meta_dataflowspecs",
+    )
+    uc_volume = _ident_prompt(
+        wsi, "UC volume name", kind="uc_volume", default="sdp_meta_wheels",
+    )
     # Defaults come from the standard pip env vars so users on networks that
     # require an internal mirror (e.g. PIP_INDEX_URL=https://pypi.internal...)
     # don't have to type the URL again here.
@@ -1148,7 +1194,7 @@ def _load_bundle_add_flow_config(wsi) -> BundleAddFlowCommand:
             dry_run=dry_run,
         )
 
-    source_format = wsi._choice("Source format", list(_VALID_SOURCE_FORMATS))
+    source_format = wsi._choice("Source format", sorted(SUPPORTED_SOURCE_FORMATS))
     bronze_table = wsi._question("Bronze table name (leave blank if silver-only)", default="")
     silver_table = wsi._question("Silver table name (blank = same as bronze)", default="")
     data_flow_id = wsi._question("data_flow_id (use `auto` to auto-increment)", default="auto")

--- a/src/databricks/labs/sdp_meta/cli.py
+++ b/src/databricks/labs/sdp_meta/cli.py
@@ -14,6 +14,10 @@ from databricks.sdk.service.pipelines import PipelineLibrary, NotebookLibrary
 from databricks.sdk.core import DatabricksError
 from databricks.sdk.service.catalog import SchemasAPI, VolumeType
 from databricks.labs.sdp_meta import __about__
+from databricks.labs.sdp_meta.identifiers import (
+    prompt_uc_identifier,
+    validate_uc_identifier,
+)
 from databricks.labs.sdp_meta.install import WorkspaceInstaller
 
 logger = logging.getLogger('databricks.labs.sdp_meta')
@@ -105,6 +109,30 @@ class OnboardCommand:
             raise ValueError("version is required")
         if not self.env:
             raise ValueError("env is required")
+        # Validate UC identifiers up front (issue #261). Even when UC is
+        # disabled the *_schema and *_dataflowspec_table values are spliced
+        # unquoted into the onboarding template (see
+        # ``SDPMeta.update_ws_onboarding_paths``: the ``{bronze_schema}`` /
+        # ``{silver_schema}`` placeholders land inside identifier positions
+        # like ``bronze_database_<env>`` and from there into the deployed
+        # pipeline's SQL), so they have to be valid regardless of
+        # ``uc_enabled``. Only ``uc_catalog_name`` is gated because the
+        # non-UC code path never references it.
+        validate_uc_identifier(self.sdp_meta_schema, kind="sdp_meta_schema")
+        if self.bronze_dataflowspec_table:
+            validate_uc_identifier(
+                self.bronze_dataflowspec_table, kind="bronze_dataflowspec_table"
+            )
+        if self.silver_dataflowspec_table:
+            validate_uc_identifier(
+                self.silver_dataflowspec_table, kind="silver_dataflowspec_table"
+            )
+        if self.bronze_schema:
+            validate_uc_identifier(self.bronze_schema, kind="bronze_schema")
+        if self.silver_schema:
+            validate_uc_identifier(self.silver_schema, kind="silver_schema")
+        if self.uc_enabled:
+            validate_uc_identifier(self.uc_catalog_name, kind="uc_catalog_name")
 
 
 @dataclass
@@ -152,6 +180,29 @@ class DeployCommand:
             raise ValueError("pipeline_name is required")
         if not self.dlt_target_schema:
             raise ValueError("dlt_target_schema is required")
+        # Issue #261: catalog / schema / table names are spliced into SQL
+        # identifiers downstream (e.g. `spark.read.table(<dataflowspecTable>)`),
+        # so reject anything that can't be safely emitted before the pipeline
+        # is even created.
+        validate_uc_identifier(self.dlt_target_schema, kind="dlt_target_schema")
+        if self.uc_enabled:
+            validate_uc_identifier(self.uc_catalog_name, kind="uc_catalog_name")
+        if self.sdp_meta_bronze_schema:
+            validate_uc_identifier(
+                self.sdp_meta_bronze_schema, kind="sdp_meta_bronze_schema"
+            )
+        if self.sdp_meta_silver_schema:
+            validate_uc_identifier(
+                self.sdp_meta_silver_schema, kind="sdp_meta_silver_schema"
+            )
+        if self.dataflowspec_bronze_table:
+            validate_uc_identifier(
+                self.dataflowspec_bronze_table, kind="dataflowspec_bronze_table"
+            )
+        if self.dataflowspec_silver_table:
+            validate_uc_identifier(
+                self.dataflowspec_silver_table, kind="dataflowspec_silver_table"
+            )
 
 
 class SDPMeta:
@@ -161,6 +212,32 @@ class SDPMeta:
         self._ws = ws
         self._wsi = WorkspaceInstaller(ws)
         self.version = __about__.__version__
+
+    def _ident_question(
+        self,
+        text: str,
+        kind: str,
+        *,
+        default: str = None,
+        max_attempts: int = 10,
+    ) -> str:
+        """Prompt for a UC identifier with validation + re-prompt on bad input.
+
+        Thin wrapper over
+        :func:`databricks.labs.sdp_meta.identifiers.prompt_uc_identifier`
+        that supplies this CLI's :class:`WorkspaceInstaller` (``_wsi``)
+        as the prompter. Kept so existing call sites remain readable
+        (``self._ident_question(text, kind=...)``) while sharing the
+        retry / TTY-aware error-print logic with ``bundle.py``
+        (issue #261).
+        """
+        return prompt_uc_identifier(
+            self._wsi,
+            text,
+            kind=kind,
+            default=default,
+            max_attempts=max_attempts,
+        )
 
     @staticmethod
     def _get_schema_from_json(oc_json: dict) -> str:
@@ -471,8 +548,8 @@ class SDPMeta:
         onboard_cmd_dict["uc_enabled"] = True if onboard_cmd_dict["uc_enabled"] == "True" else False
         if onboard_cmd_dict["uc_enabled"]:
             onboard_cmd_dict["dbfs_path"] = None
-            onboard_cmd_dict["uc_catalog_name"] = self._wsi._question(
-                "Provide unity catalog name")
+            onboard_cmd_dict["uc_catalog_name"] = self._ident_question(
+                "Provide unity catalog name", kind="uc_catalog_name")
         else:
             onboard_cmd_dict["dbfs_path"] = self._wsi._question(
                 "Provide dbfs path", default=f"dbfs:/sdp-meta_cli_demo_{uuid.uuid4().hex}")
@@ -493,23 +570,33 @@ class SDPMeta:
         onboarding_files_dir_path = self._wsi._question(
             "Provide onboarding files local directory", default=f'{cwd}/demo/')
         onboard_cmd_dict["onboarding_files_dir_path"] = f"file:/{onboarding_files_dir_path}"
-        onboard_cmd_dict["sdp_meta_schema"] = self._wsi._question(
-            "Provide sdp meta schema name", default=f'sdp_meta_dataflowspecs_{uuid.uuid4().hex}')
-        onboard_cmd_dict["bronze_schema"] = self._wsi._question(
-            "Provide sdp meta bronze layer schema name", default=f'sdp_meta_bronze_{uuid.uuid4().hex}')
-        onboard_cmd_dict["silver_schema"] = self._wsi._question(
-            "Provide sdp meta silver layer schema name", default=f'sdp_meta_silver_{uuid.uuid4().hex}')
+        onboard_cmd_dict["sdp_meta_schema"] = self._ident_question(
+            "Provide sdp meta schema name",
+            kind="sdp_meta_schema",
+            default=f'sdp_meta_dataflowspecs_{uuid.uuid4().hex}')
+        onboard_cmd_dict["bronze_schema"] = self._ident_question(
+            "Provide sdp meta bronze layer schema name",
+            kind="bronze_schema",
+            default=f'sdp_meta_bronze_{uuid.uuid4().hex}')
+        onboard_cmd_dict["silver_schema"] = self._ident_question(
+            "Provide sdp meta silver layer schema name",
+            kind="silver_schema",
+            default=f'sdp_meta_silver_{uuid.uuid4().hex}')
         onboard_cmd_dict["onboard_layer"] = self._wsi._choice(
             "Provide sdp meta layer", ['bronze', 'silver', 'bronze_silver'])
         if onboard_cmd_dict["onboard_layer"] in ["bronze", "bronze_silver"]:
-            onboard_cmd_dict["bronze_dataflowspec_table"] = self._wsi._question(
-                "Provide bronze dataflow spec table name", default='bronze_dataflowspec')
+            onboard_cmd_dict["bronze_dataflowspec_table"] = self._ident_question(
+                "Provide bronze dataflow spec table name",
+                kind="bronze_dataflowspec_table",
+                default='bronze_dataflowspec')
             if not onboard_cmd_dict["uc_enabled"]:
                 onboard_cmd_dict["bronze_dataflowspec_path"] = self._wsi._question(
                     "Provide bronze dataflow spec path", default=f'{self._install_folder()}/bronze_dataflow_specs')
         if onboard_cmd_dict["onboard_layer"] in ["silver", "bronze_silver"]:
-            onboard_cmd_dict["silver_dataflowspec_table"] = self._wsi._question(
-                "Provide silver dataflow spec table name", default='silver_dataflowspec')
+            onboard_cmd_dict["silver_dataflowspec_table"] = self._ident_question(
+                "Provide silver dataflow spec table name",
+                kind="silver_dataflowspec_table",
+                default='silver_dataflowspec')
             if not onboard_cmd_dict["uc_enabled"]:
                 onboard_cmd_dict["silver_dataflowspec_path"] = self._wsi._question(
                     "Provide silver dataflow spec path", default=f'{self._install_folder()}/silver_dataflow_specs')
@@ -550,8 +637,8 @@ class SDPMeta:
                 "Deploy SDP-META with unity catalog enabled?", ["True", "False"])
             deploy_cmd_dict["uc_enabled"] = True if deploy_cmd_dict["uc_enabled"] == "True" else False
             if deploy_cmd_dict["uc_enabled"]:
-                deploy_cmd_dict["uc_catalog_name"] = self._wsi._question(
-                    "Provide unity catalog name")
+                deploy_cmd_dict["uc_catalog_name"] = self._ident_question(
+                    "Provide unity catalog name", kind="uc_catalog_name")
                 deploy_cmd_dict["serverless"] = self._wsi._choice(
                     "Deploy SDP-META with serverless?", ["True", "False"])
                 deploy_cmd_dict["serverless"] = True if deploy_cmd_dict["serverless"] == "True" else False
@@ -583,8 +670,8 @@ class SDPMeta:
                 "Deploy SDP-META with unity catalog enabled?", ["True", "False"])
             deploy_cmd_dict["uc_enabled"] = True if deploy_cmd_dict["uc_enabled"] == "True" else False
             if deploy_cmd_dict["uc_enabled"]:
-                deploy_cmd_dict["uc_catalog_name"] = self._wsi._question(
-                    "Provide unity catalog name")
+                deploy_cmd_dict["uc_catalog_name"] = self._ident_question(
+                    "Provide unity catalog name", kind="uc_catalog_name")
                 deploy_cmd_dict["serverless"] = self._wsi._choice(
                     "Deploy SDP-META with serverless?", ["True", "False"])
                 deploy_cmd_dict["serverless"] = True if deploy_cmd_dict["serverless"] == "True" else False
@@ -595,20 +682,26 @@ class SDPMeta:
             if deploy_cmd_dict["layer"] in ["bronze", "bronze_silver"]:
                 deploy_cmd_dict["onboard_bronze_group"] = self._wsi._question(
                     "Provide sdp meta onboard bronze group")
-                deploy_cmd_dict["sdp_meta_bronze_schema"] = self._wsi._question(
-                    "Provide sdp_meta bronze dataflowspec schema name")
-                deploy_cmd_dict["dataflowspec_bronze_table"] = self._wsi._question(
-                    "Provide bronze dataflowspec table name", default='bronze_dataflowspec')
+                deploy_cmd_dict["sdp_meta_bronze_schema"] = self._ident_question(
+                    "Provide sdp_meta bronze dataflowspec schema name",
+                    kind="sdp_meta_bronze_schema")
+                deploy_cmd_dict["dataflowspec_bronze_table"] = self._ident_question(
+                    "Provide bronze dataflowspec table name",
+                    kind="dataflowspec_bronze_table",
+                    default='bronze_dataflowspec')
                 if not deploy_cmd_dict["uc_enabled"]:
                     deploy_cmd_dict["dataflowspec_bronze_path"] = self._wsi._question(
                         "Provide bronze dataflowspec path", default=f'{self._install_folder()}/bronze_dataflow_specs')
             if deploy_cmd_dict["layer"] in ["silver", "bronze_silver"]:
                 deploy_cmd_dict["onboard_silver_group"] = self._wsi._question(
                     "Provide sdp meta silver onboard group")
-                deploy_cmd_dict["sdp_meta_silver_schema"] = self._wsi._question(
-                    "Provide sdp_meta silver dataflowspec schema name")
-                deploy_cmd_dict["dataflowspec_silver_table"] = self._wsi._question(
-                    "Provide silver dataflowspec table name", default='silver_dataflowspec')
+                deploy_cmd_dict["sdp_meta_silver_schema"] = self._ident_question(
+                    "Provide sdp_meta silver dataflowspec schema name",
+                    kind="sdp_meta_silver_schema")
+                deploy_cmd_dict["dataflowspec_silver_table"] = self._ident_question(
+                    "Provide silver dataflowspec table name",
+                    kind="dataflowspec_silver_table",
+                    default='silver_dataflowspec')
                 if not deploy_cmd_dict["uc_enabled"]:
                     deploy_cmd_dict["dataflowspec_path"] = self._wsi._question(
                         "Provide silver dataflowspec path",
@@ -619,8 +712,8 @@ class SDPMeta:
         layer = deploy_cmd_dict["layer"]
         deploy_cmd_dict["pipeline_name"] = self._wsi._question(
             "Provide sdp meta pipeline name", default=f"sdp_meta_{layer}_pipeline_{uuid.uuid4().hex}")
-        deploy_cmd_dict["dlt_target_schema"] = self._wsi._question(
-            "Provide dlt target schema name")
+        deploy_cmd_dict["dlt_target_schema"] = self._ident_question(
+            "Provide dlt target schema name", kind="dlt_target_schema")
         return DeployCommand(**deploy_cmd_dict)
 
     def _load_onboard_config_ui(self, form_data) -> OnboardCommand:

--- a/src/databricks/labs/sdp_meta/identifiers.py
+++ b/src/databricks/labs/sdp_meta/identifiers.py
@@ -1,0 +1,289 @@
+"""Unity Catalog / SQL identifier and onboarding-enum validation.
+
+`sdp-meta` accepts UC catalog / schema / table / volume names from many
+input boundaries (CLI prompts, ``OnboardCommand`` / ``DeployCommand``
+constructors, the DAB template, demo scripts, integration test runners).
+All of those names eventually get spliced into SQL identifiers downstream
+without backtick-quoting, so we reject anything that isn't a *regular*
+SQL identifier as defined in
+https://docs.databricks.com/aws/en/sql/language-manual/sql-ref-identifiers --
+i.e. ``[A-Za-z_][A-Za-z0-9_]*``.
+
+This is the entire contract: strict validation at every input boundary,
+and the rest of the codebase (``DataflowPipeline``, the rendered DAB
+pipeline, the onboarding job) can splice these names into SQL strings
+without further escaping (issue #261). Hyphenated catalog names that UC
+itself permits are rejected here with a clear, actionable error message
+instead of failing later as a cryptic Spark name-resolution error.
+
+This module also pins the bounded enums onboarding accepts —
+:data:`SUPPORTED_SOURCE_FORMATS` and :data:`SUPPORTED_SCD_TYPES` — so
+typos like ``"cloudfiles"`` or ``scd_type="3"`` fail at the onboarding
+boundary with a helpful "use one of …" message, instead of silently
+flowing into the DLT pipeline and failing there.
+"""
+from __future__ import annotations
+
+import ast
+import re
+import sys
+from typing import Optional
+
+_REGULAR_IDENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+_MAX_IDENT_LEN = 255
+
+# Source formats supported by the bronze readers in
+# ``dataflow_pipeline.py`` and ``pipeline_readers.py`` (the
+# ``if/elif source_format == ...`` chains). Pinned here so the bundle CLI,
+# DAB template, and onboarding pre-flight all agree on the same set; if
+# you add a reader, add the format here too.
+SUPPORTED_SOURCE_FORMATS = frozenset(
+    {"cloudFiles", "delta", "kafka", "eventhub", "snapshot"}
+)
+
+# SCD types DLT's apply_changes / apply_changes_from_snapshot accept.
+# DLT requires the value as a string ("1" or "2"); see
+# ``dlt.apply_changes(stored_as_scd_type=...)`` and the existing
+# ``cdc_apply_changes.scd_type == "2"`` comparison in
+# ``dataflow_pipeline.py``.
+SUPPORTED_SCD_TYPES = frozenset({"1", "2"})
+
+
+def is_regular_identifier(name) -> bool:
+    """Return True iff ``name`` is a regular SQL identifier
+    (``[A-Za-z_][A-Za-z0-9_]*``) and so safe to splice into SQL unquoted."""
+    return isinstance(name, str) and bool(_REGULAR_IDENT_RE.match(name))
+
+
+def validate_uc_identifier(name, *, kind: str = "identifier") -> str:
+    """Validate ``name`` as a UC identifier; return it unchanged on success.
+
+    Raises ``ValueError`` with an actionable message when ``name`` cannot be
+    safely used as a UC identifier inside the sdp-meta toolchain. The rule
+    is strict: regular SQL identifiers only (letters, digits, underscores;
+    must start with a letter or underscore; max 255 chars).
+
+    Hyphens, periods, spaces, leading digits and backticks are all
+    rejected. UC itself permits hyphens in catalog / schema names, but the
+    sdp-meta deployed pipeline reads ``bronze.dataflowspecTable`` /
+    ``silver.dataflowspecTable`` directly via ``spark.read.table(...)``
+    without backtick-quoting, so we reject hyphens at the input boundary
+    rather than letting users hit a confusing Spark error at runtime
+    (issue #261).
+    """
+    if not isinstance(name, str):
+        raise ValueError(
+            f"{kind} must be a non-empty string, got "
+            f"{type(name).__name__}: {name!r}"
+        )
+    if not name:
+        raise ValueError(f"{kind} must be a non-empty string")
+    if len(name) > _MAX_IDENT_LEN:
+        raise ValueError(
+            f"{kind} {name!r} is {len(name)} characters; maximum allowed is "
+            f"{_MAX_IDENT_LEN}"
+        )
+    if not _REGULAR_IDENT_RE.match(name):
+        raise ValueError(
+            f"{kind} {name!r} is not a valid Databricks SQL regular identifier. "
+            f"Names must match {_REGULAR_IDENT_RE.pattern} (letters, digits "
+            f"and underscores only; must start with a letter or underscore). "
+            f"Hyphens, periods, spaces and leading digits are not supported. "
+            f"See "
+            f"https://docs.databricks.com/aws/en/sql/language-manual/sql-ref-identifiers"
+        )
+    return name
+
+
+def validate_uc_full_name(name, *, kind: str = "identifier", max_parts: int = 3) -> str:
+    """Validate a dotted multi-part UC name, e.g. ``catalog.schema.table``.
+
+    Each segment must independently pass :func:`validate_uc_identifier`,
+    so the full name is safe to splice into SQL unquoted. Accepts 1, 2, or
+    3 parts (``table`` / ``schema.table`` / ``catalog.schema.table``);
+    callers can override ``max_parts`` if they want to be strict about a
+    specific arity.
+
+    Returns ``name`` unchanged on success. Raises ``ValueError`` with an
+    actionable message on failure.
+    """
+    if not isinstance(name, str) or not name:
+        raise ValueError(f"{kind} must be a non-empty string, got {name!r}")
+    parts = name.split(".")
+    if len(parts) < 1 or len(parts) > max_parts:
+        raise ValueError(
+            f"{kind} {name!r} has {len(parts)} dotted segments; expected "
+            f"between 1 and {max_parts}."
+        )
+    for i, part in enumerate(parts):
+        # Each segment gets a positional kind so the error message points
+        # at the offending one (e.g. "schema in database 'main.bad-name'").
+        validate_uc_identifier(part, kind=f"segment {i + 1} of {kind}")
+    return name
+
+
+def validate_uc_column_list(value, *, kind: str = "column list") -> list:
+    """Validate a column-name list/string and return the parsed column names.
+
+    Onboarding accepts column-name fields in several shapes that the
+    existing parser code in ``onboard_dataflowspec.py`` handles:
+
+    * a single column name string (``"col1"``)
+    * a comma-separated string (``"col1,col2"``) — used for
+      ``*_partition_columns`` / ``*_quarantine_table_partitions``
+    * a Python list (``["col1", "col2"]``) — used for ``*_cluster_by``
+    * a string representation of a list (``"[col1, col2]"``) — also
+      ``*_cluster_by``, parsed via ``ast.literal_eval``
+
+    Each resulting column name must be a regular SQL identifier so it can
+    be safely spliced into ``PARTITIONED BY`` / ``CLUSTER BY`` DDL or
+    passed to DLT's ``partition_cols`` / ``cluster_by`` kwargs without
+    surprising failures (issue #261).
+
+    ``None`` and empty strings are treated as "no columns" and return an
+    empty list rather than raising — matches the onboarding code's
+    "if present and truthy" pattern so optional fields don't trip the
+    pre-flight check.
+
+    Returns the validated list of column names. Raises ``ValueError`` if
+    any element fails :func:`validate_uc_identifier`.
+    """
+    if value is None or value == "":
+        return []
+
+    columns: list
+    if isinstance(value, list):
+        columns = list(value)
+    elif isinstance(value, str):
+        stripped = value.strip()
+        if stripped.startswith("[") and stripped.endswith("]"):
+            # Stringified list, e.g. "[col1, col2]". Use literal_eval so we
+            # accept the exact same shape the existing __parse_cluster_by_string
+            # parser does — no surprises if it parsed there but failed here.
+            try:
+                parsed = ast.literal_eval(stripped)
+            except (SyntaxError, ValueError) as exc:
+                raise ValueError(
+                    f"{kind} {value!r} looks like a list literal but could "
+                    f"not be parsed: {exc}"
+                ) from exc
+            if not isinstance(parsed, list):
+                raise ValueError(
+                    f"{kind} {value!r} parsed to {type(parsed).__name__}, "
+                    f"expected list"
+                )
+            columns = parsed
+        else:
+            columns = [c.strip() for c in stripped.split(",")]
+    else:
+        raise ValueError(
+            f"{kind} must be a string or list of column names, got "
+            f"{type(value).__name__}: {value!r}"
+        )
+
+    out = []
+    for i, col in enumerate(columns):
+        if not isinstance(col, str) or not col:
+            raise ValueError(
+                f"{kind} entry {i} is not a non-empty string: {col!r}"
+            )
+        validate_uc_identifier(col, kind=f"{kind} entry {i}")
+        out.append(col)
+    return out
+
+
+def validate_source_format(value, *, kind: str = "source_format") -> str:
+    """Validate ``value`` is one of :data:`SUPPORTED_SOURCE_FORMATS`.
+
+    The bronze readers branch on this string in
+    ``dataflow_pipeline.py``; an unknown value silently falls through
+    every ``elif`` and the pipeline starts with no input. Catching it
+    at onboarding turns that "pipeline runs but does nothing" failure
+    into a clear actionable error.
+
+    Match is case-sensitive on purpose — DLT and Spark both treat
+    ``"cloudFiles"`` and ``"cloudfiles"`` as different format names, so
+    accepting variants here would mask a real bug.
+    """
+    if not isinstance(value, str) or not value:
+        raise ValueError(
+            f"{kind} must be a non-empty string, got {value!r}"
+        )
+    if value not in SUPPORTED_SOURCE_FORMATS:
+        # Sort for deterministic, alphabetic error messages.
+        allowed = ", ".join(sorted(SUPPORTED_SOURCE_FORMATS))
+        raise ValueError(
+            f"{kind}={value!r} is not supported. Use one of: {allowed}."
+        )
+    return value
+
+
+def validate_scd_type(value, *, kind: str = "scd_type") -> str:
+    """Validate ``value`` is one of :data:`SUPPORTED_SCD_TYPES` (``"1"``/``"2"``).
+
+    DLT's ``apply_changes`` / ``apply_changes_from_snapshot`` accept the
+    SCD type as a string. Catching a typo (``"3"``, integer ``2``, etc.)
+    here surfaces it during onboarding with the allowed values inlined,
+    instead of bubbling up later as an opaque DLT runtime error.
+    """
+    # We deliberately reject ``int`` here even though Python's ``2 == "2"``
+    # is False — accepting both would mean the onboarding-spec dataclasses
+    # carry mixed types, and the existing ``cdc_apply_changes.scd_type
+    # == "2"`` comparisons in dataflow_pipeline.py would silently miss the
+    # int variant. The onboarding contract is "string", so we enforce it.
+    if not isinstance(value, str) or not value:
+        raise ValueError(
+            f"{kind} must be a non-empty string, got {type(value).__name__}: {value!r}"
+        )
+    if value not in SUPPORTED_SCD_TYPES:
+        allowed = ", ".join(sorted(SUPPORTED_SCD_TYPES))
+        raise ValueError(
+            f"{kind}={value!r} is not supported. Use one of: {allowed}."
+        )
+    return value
+
+
+def _format_prompt_error(message: str) -> str:
+    """Format an error message for an interactive UC-identifier prompt.
+
+    Uses ANSI red ONLY when stderr is a real TTY; piped/captured output
+    (CI logs, file redirects) gets plain text so the escape codes don't
+    end up rendered as garbage in build logs.
+    """
+    if sys.stderr.isatty():
+        return f"\033[31m[ERROR] {message}\033[0m"
+    return f"[ERROR] {message}"
+
+
+def prompt_uc_identifier(
+    wsi,
+    text: str,
+    *,
+    kind: str,
+    default: Optional[str] = None,
+    max_attempts: int = 10,
+) -> str:
+    """Interactively prompt for a UC identifier with validation + retry.
+
+    Wraps ``wsi._question`` (a
+    ``databricks.labs.blueprint.installer.WorkspaceInstaller`` method):
+    on each attempt, the user-supplied value is run through
+    :func:`validate_uc_identifier`. Validation failures print a clear
+    error message and re-prompt instead of crashing — matches the
+    behavior every CLI / DAB prompt expects (issue #261).
+
+    After ``max_attempts`` consecutive bad answers we raise so
+    non-interactive runs (e.g. piped stdin returning the same junk every
+    time) still terminate. The error stream is gated on
+    ``sys.stderr.isatty()`` so CI logs don't get ANSI escape garbage.
+    """
+    for _ in range(max_attempts):
+        value = wsi._question(text, default=default)
+        try:
+            return validate_uc_identifier(value, kind=kind)
+        except ValueError as exc:
+            print(_format_prompt_error(str(exc)) + "\n", file=sys.stderr)
+    raise ValueError(
+        f"Could not get a valid {kind} after {max_attempts} attempts"
+    )

--- a/src/databricks/labs/sdp_meta/onboard_dataflowspec.py
+++ b/src/databricks/labs/sdp_meta/onboard_dataflowspec.py
@@ -14,10 +14,60 @@ from pyspark.sql import functions as f
 from pyspark.sql.types import ArrayType, MapType, StringType, StructField, StructType
 
 from databricks.labs.sdp_meta.dataflow_spec import BronzeDataflowSpec, DataflowSpecUtils, SilverDataflowSpec
+from databricks.labs.sdp_meta.identifiers import (
+    SUPPORTED_SOURCE_FORMATS,
+    validate_scd_type,
+    validate_source_format,
+    validate_uc_column_list,
+    validate_uc_full_name,
+    validate_uc_identifier,
+)
 from databricks.labs.sdp_meta.metastore_ops import DeltaPipelinesInternalTableOps, DeltaPipelinesMetaStoreOps
 
 logger = logging.getLogger("databricks.labs.sdp_meta")
 logger.setLevel(logging.INFO)
+
+
+# Column-name fields inside ``<layer>_cdc_apply_changes`` that drive
+# DLT's ``apply_changes`` column-projection logic. Each entry must
+# resolve to (a list of) regular SQL identifier(s); a hyphenated entry
+# would fail at DLT runtime, so onboarding pre-flight catches it. The
+# expression-valued fields (``apply_as_deletes`` / ``apply_as_truncates``
+# / ``where``) are deliberately NOT in this list -- they go through
+# ``expr(...)`` rather than identifier slots.
+_CDC_COL_FIELDS = (
+    "keys",
+    "sequence_by",
+    "column_list",
+    "except_column_list",
+    "track_history_column_list",
+    "track_history_except_column_list",
+    "ignore_null_updates_column_list",
+    "ignore_null_updates_except_column_list",
+)
+
+# Same idea, but the ``<layer>_apply_changes_from_snapshot`` block
+# accepts a smaller set of column-name fields. Keeping the two tuples
+# separate -- rather than reusing _CDC_COL_FIELDS -- mirrors what DLT
+# itself accepts in each call.
+_SNAPSHOT_COL_FIELDS = (
+    "keys",
+    "track_history_column_list",
+    "track_history_except_column_list",
+)
+
+# Lower-cased mirror of :data:`SUPPORTED_SOURCE_FORMATS` for the
+# case-insensitive runtime check inside
+# ``__get_bronze_dataflow_spec_dataframe``. The canonical set
+# (``cloudFiles``, ``delta``, ``kafka``, ``eventhub``, ``snapshot``)
+# is case-sensitive because that's how DLT and Spark spell these
+# strings, but historically the per-row check here has been lenient
+# about ``"CloudFiles"`` / ``"cloudfiles"`` / ``"CLOUDFILES"`` and we
+# don't want to break callers who relied on that. Built once at module
+# scope so we're not rebuilding the set on every (row x layer) pass.
+_SUPPORTED_SOURCE_FORMATS_LOWER = frozenset(
+    s.lower() for s in SUPPORTED_SOURCE_FORMATS
+)
 
 
 class OnboardDataflowspec:
@@ -35,6 +85,20 @@ class OnboardDataflowspec:
         self.deltaPipelinesMetaStoreOps = DeltaPipelinesMetaStoreOps(self.spark)
         self.deltaPipelinesInternalTableOps = DeltaPipelinesInternalTableOps(self.spark)
         self.onboard_file_type = None
+        # Tracks which onboarding files have already been validated +
+        # printed by ``__get_onboarding_file_dataframe``. We deliberately
+        # do NOT cache the DataFrame itself -- reusing one lazy
+        # ``spark.read.json(...)`` plan across the pre-flight,
+        # ``onboard_bronze_dataflow_spec``, and ``onboard_silver_dataflow_spec``
+        # call paths interacts badly with the saveAsTable + read-back
+        # cycle in between (cached plan IDs end up referencing parquet
+        # files that have been overwritten, surfacing as
+        # ``SparkFileNotFoundException`` on the next ``.count()``; see
+        # ``test_onboardDataFlowSpecs_with_merge_uc``). Just gating the
+        # eager ``show()`` and ``groupBy().count()`` side-effects on a
+        # set of paths is enough to drop the perceived stdout / Spark-job
+        # noise from 3x to 1x without changing query semantics.
+        self._onboarding_files_processed: set = set()
 
     def __initialize_paths(self, uc_enabled):
         if "silver_dataflowspec_table" in self.bronze_dict_obj:
@@ -51,6 +115,62 @@ class OnboardDataflowspec:
                 del self.bronze_dict_obj["bronze_dataflowspec_path"]
             if "silver_dataflowspec_path" in self.silver_dict_obj:
                 del self.silver_dict_obj["silver_dataflowspec_path"]
+
+    @staticmethod
+    def __validate_row_uc_names(onboarding_row, env, layer):
+        """Validate every UC identifier in a single onboarding row.
+
+        ``database`` may be 1- or 2-part (`schema` or `catalog.schema`);
+        ``table`` and ``catalog`` are always single identifiers. We
+        reject anything that isn't a regular SQL identifier here so the
+        deployed pipeline can splice these names directly into Spark
+        SQL without further escaping (issue #261). ``layer`` is either
+        ``"bronze"`` or ``"silver"`` and only affects the field prefix /
+        error message.
+        """
+        flow_id = onboarding_row["data_flow_id"] if "data_flow_id" in onboarding_row else "<unknown>"
+        db_field = f"{layer}_database_{env}"
+        table_field = f"{layer}_table"
+        catalog_field = f"{layer}_catalog_{env}"
+        validate_uc_full_name(
+            onboarding_row[db_field],
+            kind=f"flow {flow_id} {db_field}",
+            max_parts=2,
+        )
+        validate_uc_identifier(
+            onboarding_row[table_field],
+            kind=f"flow {flow_id} {table_field}",
+        )
+        if catalog_field in onboarding_row and onboarding_row[catalog_field]:
+            validate_uc_identifier(
+                onboarding_row[catalog_field],
+                kind=f"flow {flow_id} {catalog_field}",
+            )
+        # Quarantine UC identifiers ride the same SQL-splice path as the
+        # main bronze/silver targets (see __get_quarantine_details ->
+        # dataflow_pipeline.py:570 where they're concatenated into the
+        # dlt.create_streaming_table name unquoted), so any hyphens / dots
+        # / leading digits there fail the same way (issue #261). Optional
+        # fields — only validate when present and non-empty.
+        q_db_field = f"{layer}_database_quarantine_{env}"
+        q_table_field = f"{layer}_quarantine_table"
+        q_catalog_field = f"{layer}_catalog_quarantine_{env}"
+        if q_db_field in onboarding_row and onboarding_row[q_db_field]:
+            validate_uc_full_name(
+                onboarding_row[q_db_field],
+                kind=f"flow {flow_id} {q_db_field}",
+                max_parts=2,
+            )
+        if q_table_field in onboarding_row and onboarding_row[q_table_field]:
+            validate_uc_identifier(
+                onboarding_row[q_table_field],
+                kind=f"flow {flow_id} {q_table_field}",
+            )
+        if q_catalog_field in onboarding_row and onboarding_row[q_catalog_field]:
+            validate_uc_identifier(
+                onboarding_row[q_catalog_field],
+                kind=f"flow {flow_id} {q_catalog_field}",
+            )
 
     @staticmethod
     def __validate_dict_attributes(attributes, dict_obj):
@@ -119,8 +239,204 @@ class OnboardDataflowspec:
             attributes.append("bronze_dataflowspec_path")
             attributes.append("silver_dataflowspec_path")
             self.__validate_dict_attributes(attributes, self.dict_obj)
+        # Validate the metadata-table identifiers up-front. These get
+        # spliced unquoted into CREATE DATABASE / saveAsTable / register-
+        # in-metastore calls below, so a hyphenated catalog or schema
+        # would only fail much later with a confusing Spark error
+        # (issue #261). `database` may be 1- or 2-part (`schema` or
+        # `catalog.schema`); the table names are single identifiers.
+        validate_uc_full_name(
+            self.dict_obj["database"], kind="dict_obj['database']", max_parts=2,
+        )
+        validate_uc_identifier(
+            self.dict_obj["bronze_dataflowspec_table"],
+            kind="dict_obj['bronze_dataflowspec_table']",
+        )
+        validate_uc_identifier(
+            self.dict_obj["silver_dataflowspec_table"],
+            kind="dict_obj['silver_dataflowspec_table']",
+        )
+        # Walk the onboarding file once and surface ALL UC-identifier
+        # errors before doing any Spark side-effects (CREATE DATABASE,
+        # saveAsTable, register-in-metastore). Otherwise a hyphenated
+        # catalog on row 5 would fail mid-onboarding with the bronze
+        # dataflowspec table already half-written, which is hard to clean
+        # up. Aggregating errors also gives the user the full picture in
+        # one shot instead of fix-rerun-fix-rerun (issue #261).
+        self.__pre_validate_onboarding_uc_names()
         self.onboard_bronze_dataflow_spec()
         self.onboard_silver_dataflow_spec()
+
+    def __pre_validate_onboarding_uc_names(self):
+        """Pre-flight validate every UC identifier in the onboarding file.
+
+        Loads the onboarding file once, walks every row, and validates:
+
+        * Per layer (``bronze`` / ``silver``):
+            - ``<layer>_database_<env>`` (1- or 2-part full name)
+            - ``<layer>_table`` (single identifier)
+            - ``<layer>_catalog_<env>`` (single identifier)
+            - ``<layer>_database_quarantine_<env>`` (full name)
+            - ``<layer>_quarantine_table`` (single identifier)
+            - ``<layer>_catalog_quarantine_<env>`` (single identifier)
+            - ``<layer>_partition_columns`` (column-name list)
+            - ``<layer>_quarantine_table_partitions`` (column-name list)
+            - ``<layer>_cluster_by`` (column-name list)
+            - ``<layer>_quarantine_table_cluster_by`` (column-name list)
+
+        Aggregates all failures into a single ``ValueError`` so the user
+        sees every bad name in one shot instead of fixing them one at a
+        time. Runs *before* any Spark side-effect (CREATE DATABASE,
+        saveAsTable) so a bad row never half-onboards (issue #261).
+
+        The per-row validators (:py:meth:`__validate_row_uc_names`) inside
+        :py:meth:`onboard_bronze_dataflow_spec` and
+        :py:meth:`onboard_silver_dataflow_spec` are kept as
+        defence-in-depth for callers that bypass
+        :py:meth:`onboard_dataflow_specs`.
+        """
+        env = self.dict_obj["env"]
+        onboarding_df = self.__get_onboarding_file_dataframe(
+            self.dict_obj["onboarding_file_path"]
+        )
+        errors = []
+
+        def _check(validator, value, kind, **kwargs):
+            """Run ``validator(value, kind=kind, **kwargs)`` and stash the
+            error string instead of raising, so we can collect every
+            problem in one pass."""
+            try:
+                validator(value, kind=kind, **kwargs)
+            except ValueError as exc:
+                errors.append(str(exc))
+
+        for row in onboarding_df.collect():
+            # Recursive=True so nested Row objects (cdc_apply_changes,
+            # apply_changes_from_snapshot, append_flows entries) come
+            # through as plain dicts; the enum checks below need to peek
+            # inside them without re-doing asDict() at every level.
+            if hasattr(row, "asDict"):
+                row_dict = row.asDict(recursive=True)
+            else:
+                row_dict = dict(row)
+            flow_id = row_dict.get("data_flow_id", "<unknown>")
+
+            # Top-level source_format applies to the bronze read path
+            # regardless of layer; check it once per row.
+            if row_dict.get("source_format"):
+                _check(
+                    validate_source_format,
+                    row_dict["source_format"],
+                    kind=f"flow {flow_id} source_format",
+                )
+
+            for layer in ("bronze", "silver"):
+                # (field, validator, validator_kwargs) tuples for every UC
+                # identifier on this layer. Listed in roughly the order they
+                # show up in the onboarding row so error messages read
+                # naturally top-to-bottom.
+                checks = [
+                    (
+                        f"{layer}_database_{env}",
+                        validate_uc_full_name,
+                        {"max_parts": 2},
+                    ),
+                    (f"{layer}_table", validate_uc_identifier, {}),
+                    (f"{layer}_catalog_{env}", validate_uc_identifier, {}),
+                    (
+                        f"{layer}_database_quarantine_{env}",
+                        validate_uc_full_name,
+                        {"max_parts": 2},
+                    ),
+                    (f"{layer}_quarantine_table", validate_uc_identifier, {}),
+                    (
+                        f"{layer}_catalog_quarantine_{env}",
+                        validate_uc_identifier,
+                        {},
+                    ),
+                    (f"{layer}_partition_columns", validate_uc_column_list, {}),
+                    (
+                        f"{layer}_quarantine_table_partitions",
+                        validate_uc_column_list,
+                        {},
+                    ),
+                    (f"{layer}_cluster_by", validate_uc_column_list, {}),
+                    (
+                        f"{layer}_quarantine_table_cluster_by",
+                        validate_uc_column_list,
+                        {},
+                    ),
+                ]
+                for field, validator, kwargs in checks:
+                    if row_dict.get(field):
+                        _check(
+                            validator,
+                            row_dict[field],
+                            kind=f"flow {flow_id} {field}",
+                            **kwargs,
+                        )
+
+                # scd_type lives inside the cdc_apply_changes /
+                # apply_changes_from_snapshot blocks; bad values silently
+                # flow into ``dlt.apply_changes(stored_as_scd_type=...)``
+                # without this check. The column-name fields in those
+                # blocks (keys, sequence_by, column_list, etc.) drive
+                # DLT's apply_changes / apply_changes_from_snapshot
+                # column-projection logic, so a hyphenated entry there
+                # fails at DLT runtime — pre-flight catches it here.
+                #
+                # ``apply_as_deletes`` / ``apply_as_truncates`` / ``where``
+                # are deliberately NOT validated: they are SQL expressions
+                # that go through ``expr(...)``, not column names, so
+                # regular-identifier rules do not apply. The two field
+                # tuples consumed below live at module scope (above the
+                # class) so we don't rebuild them on every (row x layer)
+                # iteration.
+                cdc_blocks = (
+                    (f"{layer}_cdc_apply_changes", _CDC_COL_FIELDS),
+                    (f"{layer}_apply_changes_from_snapshot", _SNAPSHOT_COL_FIELDS),
+                )
+                for cdc_field, col_fields in cdc_blocks:
+                    cdc_block = row_dict.get(cdc_field)
+                    if not isinstance(cdc_block, dict):
+                        continue
+                    if cdc_block.get("scd_type") is not None:
+                        _check(
+                            validate_scd_type,
+                            cdc_block["scd_type"],
+                            kind=f"flow {flow_id} {cdc_field}.scd_type",
+                        )
+                    for col_field in col_fields:
+                        if cdc_block.get(col_field):
+                            _check(
+                                validate_uc_column_list,
+                                cdc_block[col_field],
+                                kind=f"flow {flow_id} {cdc_field}.{col_field}",
+                            )
+
+                # Each append flow has its own source_format which drives
+                # a separate read path; validate every one.
+                append_flows = row_dict.get(f"{layer}_append_flows")
+                if isinstance(append_flows, list):
+                    for af_idx, af in enumerate(append_flows):
+                        if isinstance(af, dict) and af.get("source_format"):
+                            _check(
+                                validate_source_format,
+                                af["source_format"],
+                                kind=(
+                                    f"flow {flow_id} {layer}_append_flows[{af_idx}]"
+                                    f".source_format"
+                                ),
+                            )
+
+        if errors:
+            bullets = "\n  - ".join(errors)
+            raise ValueError(
+                f"Onboarding file "
+                f"{self.dict_obj['onboarding_file_path']!r} has "
+                f"{len(errors)} validation error(s); fix these and "
+                f"re-run:\n  - {bullets}"
+            )
 
     def register_bronze_dataflow_spec_tables(self):
         """Register bronze/silver dataflow specs tables."""
@@ -526,9 +842,18 @@ class OnboardDataflowspec:
         filesystem as the source for serverless compatibility); see that
         method's docstring for the exact write strategy and why bare
         ``/tmp/...`` paths cannot be used on serverless / Spark Connect.
+
+        Subsequent calls with the same path skip the eager ``show()``
+        and duplicate-id check (tracked in
+        ``self._onboarding_files_processed``) so ``onboard_dataflow_specs``
+        doesn't print the dataframe + run the dupe groupBy three times
+        (pre-flight + bronze + silver). A fresh DataFrame is still
+        returned on each call -- see the field-level comment for why we
+        intentionally do not cache the DataFrame object itself.
         """
         if not onboarding_file_path:
             raise Exception("Onboarding file path is empty")
+        first_read = onboarding_file_path not in self._onboarding_files_processed
         lower_path = onboarding_file_path.lower()
         if not lower_path.endswith((".json", ".yml", ".yaml")):
             raise Exception(
@@ -542,15 +867,17 @@ class OnboardDataflowspec:
             json_path = self.convert_yml_to_json(onboarding_file_path)
 
         onboarding_df = self.spark.read.option("multiline", "true").json(json_path)
-        onboarding_df.show()
         self.onboard_file_type = "json"
 
-        onboarding_df_dupes = (
-            onboarding_df.groupBy("data_flow_id").count().filter("count > 1")
-        )
-        if len(onboarding_df_dupes.head(1)) > 0:
-            onboarding_df_dupes.show()
-            raise Exception("onboarding file have duplicated data_flow_ids! ")
+        if first_read:
+            onboarding_df.show()
+            onboarding_df_dupes = (
+                onboarding_df.groupBy("data_flow_id").count().filter("count > 1")
+            )
+            if len(onboarding_df_dupes.head(1)) > 0:
+                onboarding_df_dupes.show()
+                raise Exception("onboarding file have duplicated data_flow_ids! ")
+            self._onboarding_files_processed.add(onboarding_file_path)
         return onboarding_df
 
     def __add_audit_columns(self, df, dict_obj):
@@ -684,19 +1011,14 @@ class OnboardDataflowspec:
             except ValueError:
                 mandatory_fields.append(f"bronze_table_path_{env}")
                 self.__validate_mandatory_fields(onboarding_row, mandatory_fields)
+            self.__validate_row_uc_names(onboarding_row, env, "bronze")
             bronze_data_flow_spec_id = onboarding_row["data_flow_id"]
             bronze_data_flow_spec_group = onboarding_row["data_flow_group"]
             if "source_format" not in onboarding_row:
                 raise Exception(f"Source format not provided for row={onboarding_row}")
 
             source_format = onboarding_row["source_format"]
-            if source_format.lower() not in [
-                "cloudfiles",
-                "eventhub",
-                "kafka",
-                "delta",
-                "snapshot"
-            ]:
+            if source_format.lower() not in _SUPPORTED_SOURCE_FORMATS_LOWER:
                 raise Exception(
                     f"Source format {source_format} not supported in SDP-META! row={onboarding_row}"
                 )
@@ -1330,6 +1652,16 @@ class OnboardDataflowspec:
             except ValueError:
                 mandatory_fields.append(f"silver_table_path_{env}")
                 self.__validate_mandatory_fields(onboarding_row, mandatory_fields)
+            # Silver rows reference both the bronze source AND the silver
+            # target, so validate both. Bronze fields are optional in the
+            # silver-only mandatory list above, but if present they must
+            # still be safe SQL identifiers.
+            self.__validate_row_uc_names(onboarding_row, env, "silver")
+            if (
+                f"bronze_database_{env}" in onboarding_row
+                and onboarding_row[f"bronze_database_{env}"]
+            ):
+                self.__validate_row_uc_names(onboarding_row, env, "bronze")
             silver_data_flow_spec_id = onboarding_row["data_flow_id"]
             silver_data_flow_spec_group = onboarding_row["data_flow_group"]
             silver_reader_config_options = {}

--- a/src/databricks/labs/sdp_meta/templates/dab/databricks_template_schema.json
+++ b/src/databricks/labs/sdp_meta/templates/dab/databricks_template_schema.json
@@ -13,25 +13,33 @@
       "order": 2,
       "type": "string",
       "default": "main",
-      "description": "Unity Catalog catalog name where the sdp-meta metadata schema and target bronze/silver schemas live."
+      "description": "Unity Catalog catalog name where the sdp-meta metadata schema and target bronze/silver schemas live.",
+      "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+      "pattern_match_failure_message": "uc_catalog_name must be a regular SQL identifier (letters, digits, underscores; must start with a letter or underscore). Hyphens and other special characters are not supported by sdp-meta — see https://docs.databricks.com/aws/en/sql/language-manual/sql-ref-identifiers"
     },
     "sdp_meta_schema": {
       "order": 3,
       "type": "string",
       "default": "sdp_meta_dataflowspecs",
-      "description": "Schema (inside `uc_catalog_name`) where the sdp-meta bronze_dataflowspec / silver_dataflowspec tables are written."
+      "description": "Schema (inside `uc_catalog_name`) where the sdp-meta bronze_dataflowspec / silver_dataflowspec tables are written.",
+      "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+      "pattern_match_failure_message": "sdp_meta_schema must be a regular SQL identifier (letters, digits, underscores; must start with a letter or underscore)."
     },
     "bronze_target_schema": {
       "order": 4,
       "type": "string",
       "default": "sdp_meta_bronze",
-      "description": "Schema where the bronze LDP pipeline writes its tables."
+      "description": "Schema where the bronze LDP pipeline writes its tables.",
+      "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+      "pattern_match_failure_message": "bronze_target_schema must be a regular SQL identifier (letters, digits, underscores; must start with a letter or underscore)."
     },
     "silver_target_schema": {
       "order": 5,
       "type": "string",
       "default": "sdp_meta_silver",
-      "description": "Schema where the silver LDP pipeline writes its tables."
+      "description": "Schema where the silver LDP pipeline writes its tables.",
+      "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+      "pattern_match_failure_message": "silver_target_schema must be a regular SQL identifier (letters, digits, underscores; must start with a letter or underscore)."
     },
     "layer": {
       "order": 6,

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -886,6 +886,103 @@ class BundlePrepareWheelUnitTests(unittest.TestCase):
                 wheel_path.unlink()
 
 
+class BundleIdentifierValidationTests(unittest.TestCase):
+    """Strict UC-identifier validation at every bundle input boundary.
+
+    The bundle module accepts UC names from three places: the
+    ``BundlePrepareWheelCommand`` constructor, the bundle's own
+    ``variables.yml`` (read by ``_flow_to_dict``), and the per-flow
+    ``FlowSpec`` (bronze/silver table). We must reject anything that
+    isn't a regular SQL identifier at every one of them so a hyphenated
+    catalog or other illegal name can't sneak through to the deployed
+    pipeline (issue #261).
+    """
+
+    def test_prepare_wheel_rejects_hyphenated_catalog(self):
+        with self.assertRaisesRegex(ValueError, r"regular identifier"):
+            BundlePrepareWheelCommand(
+                uc_catalog="my-cat", uc_schema="schema", uc_volume="vol",
+            )
+
+    def test_prepare_wheel_rejects_dotted_schema(self):
+        with self.assertRaisesRegex(ValueError, r"regular identifier"):
+            BundlePrepareWheelCommand(
+                uc_catalog="cat", uc_schema="bad.name", uc_volume="vol",
+            )
+
+    def test_prepare_wheel_rejects_leading_digit_volume(self):
+        with self.assertRaisesRegex(ValueError, r"regular identifier"):
+            BundlePrepareWheelCommand(
+                uc_catalog="cat", uc_schema="schema", uc_volume="9vol",
+            )
+
+    def test_prepare_wheel_accepts_regular_identifiers(self):
+        # Sanity: the validation is strict but not over-eager. Plain
+        # underscore-separated names continue to work.
+        cmd = BundlePrepareWheelCommand(
+            uc_catalog="my_cat", uc_schema="my_schema", uc_volume="my_volume",
+        )
+        self.assertEqual(cmd.uc_catalog, "my_cat")
+
+    def test_flow_to_dict_rejects_hyphenated_variables(self):
+        # Hand-edited variables.yml could carry a hyphenated catalog from
+        # an older sdp-meta version; we must reject when reading too.
+        from databricks.labs.sdp_meta.bundle import _flow_to_dict
+        variables = {
+            "uc_catalog_name": {"default": "my-cat"},
+            "bronze_target_schema": {"default": "bronze"},
+            "silver_target_schema": {"default": "silver"},
+            "layer": {"default": "bronze"},
+            "onboarding_file_format": {"default": "yaml"},
+        }
+        with self.assertRaisesRegex(ValueError, r"regular identifier"):
+            _flow_to_dict(
+                FlowSpec(source_format="cloudFiles", bronze_table="t"),
+                variables,
+                assigned_id="100",
+            )
+
+    def test_flow_to_dict_rejects_hyphenated_bronze_table(self):
+        from databricks.labs.sdp_meta.bundle import _flow_to_dict
+        variables = {
+            "uc_catalog_name": {"default": "main"},
+            "bronze_target_schema": {"default": "bronze"},
+            "silver_target_schema": {"default": "silver"},
+            "layer": {"default": "bronze"},
+            "onboarding_file_format": {"default": "yaml"},
+        }
+        with self.assertRaisesRegex(ValueError, r"regular identifier"):
+            _flow_to_dict(
+                FlowSpec(source_format="cloudFiles", bronze_table="bad-name"),
+                variables,
+                assigned_id="100",
+            )
+
+    def test_flow_to_dict_rejects_unknown_source_format(self):
+        # The five-format set is pinned in identifiers.SUPPORTED_SOURCE_FORMATS;
+        # _flow_to_dict must reject anything outside it (e.g. "parquet")
+        # so a hand-edited bundle can't ship a flow that the bronze
+        # readers in dataflow_pipeline.py have no branch for.
+        from databricks.labs.sdp_meta.bundle import _flow_to_dict
+        variables = {
+            "uc_catalog_name": {"default": "main"},
+            "bronze_target_schema": {"default": "bronze"},
+            "silver_target_schema": {"default": "silver"},
+            "layer": {"default": "bronze"},
+            "onboarding_file_format": {"default": "yaml"},
+        }
+        with self.assertRaises(ValueError) as ctx:
+            _flow_to_dict(
+                FlowSpec(source_format="parquet", bronze_table="t"),
+                variables,
+                assigned_id="100",
+            )
+        msg = str(ctx.exception)
+        # Allowed values must be inlined for the user.
+        self.assertIn("parquet", msg)
+        self.assertIn("cloudFiles", msg)
+
+
 class BundleValidateUnitTests(unittest.TestCase):
     """bundle_validate shells out to `databricks bundle validate` plus sanity."""
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1745,6 +1745,136 @@ class CliTests(unittest.TestCase):
             )
         self.assertIn("bronze_dataflowspec_path is required", str(context.exception))
 
+    def _build_onboard_kwargs(self, **overrides):
+        """Minimal valid `OnboardCommand` kwargs for identifier-validation tests.
+
+        Centralised so each test only has to declare the *one* field it
+        wants to mutate (e.g. `uc_catalog_name="my-cat"`) rather than
+        re-typing the full happy-path constructor every time.
+        """
+        kwargs = dict(
+            onboarding_file_path="tests/resources/onboarding.json",
+            onboarding_files_dir_path="tests/resources/",
+            onboard_layer="bronze",
+            env="dev",
+            import_author="John Doe",
+            version="1.0",
+            cloud="aws",
+            sdp_meta_schema="sdp_meta",
+            bronze_dataflowspec_path="tests/resources/bronze_dataflowspec",
+            silver_dataflowspec_path="tests/resources/silver_dataflowspec",
+            uc_enabled=True,
+            uc_catalog_name="uc_catalog",
+            uc_volume_path="uc_catalog/sdp_meta/files",
+            overwrite=True,
+            bronze_dataflowspec_table="bronze_dataflowspec",
+            silver_dataflowspec_table="silver_dataflowspec",
+            update_paths=True,
+        )
+        kwargs.update(overrides)
+        return kwargs
+
+    def test_onboard_command_rejects_hyphenated_uc_catalog(self):
+        # Hyphens are legal in UC but not in regular SQL identifiers; we
+        # reject at construction time so users see a clear error instead
+        # of a Spark name-resolution failure later (issue #261).
+        with self.assertRaisesRegex(ValueError, r"regular identifier"):
+            OnboardCommand(**self._build_onboard_kwargs(uc_catalog_name="my-cat"))
+
+    def test_onboard_command_rejects_hyphenated_sdp_meta_schema(self):
+        with self.assertRaisesRegex(ValueError, r"regular identifier"):
+            OnboardCommand(**self._build_onboard_kwargs(sdp_meta_schema="bad-schema"))
+
+    def test_onboard_command_rejects_dotted_table_name(self):
+        # A period inside a single identifier is forbidden (it's the
+        # multi-part separator). We must reject it here so it can't be
+        # spliced into a SQL identifier downstream.
+        with self.assertRaisesRegex(ValueError, r"regular identifier"):
+            OnboardCommand(**self._build_onboard_kwargs(
+                bronze_dataflowspec_table="bad.name",
+            ))
+
+    def test_onboard_command_rejects_leading_digit_table_name(self):
+        with self.assertRaisesRegex(ValueError, r"regular identifier"):
+            OnboardCommand(**self._build_onboard_kwargs(
+                silver_dataflowspec_table="9bronze",
+            ))
+
+    def test_onboard_command_skips_uc_validation_when_uc_disabled(self):
+        # When uc_enabled=False we don't read uc_catalog_name, so the
+        # validator must not be triggered for it. (Bronze schema is
+        # still validated since it's used in non-UC paths too.)
+        cmd = OnboardCommand(**self._build_onboard_kwargs(
+            uc_enabled=False,
+            uc_catalog_name="any-thing-goes",
+            uc_volume_path=None,
+            dbfs_path="/dbfs",
+        ))
+        self.assertFalse(cmd.uc_enabled)
+
+    def test_onboard_command_rejects_hyphenated_bronze_schema_even_without_uc(self):
+        # ``bronze_schema`` / ``silver_schema`` get spliced into the
+        # rendered onboarding template (see ``update_ws_onboarding_paths``)
+        # and from there into pipeline SQL identifiers regardless of
+        # whether UC is enabled. Reject hyphens at the input boundary so
+        # the failure mode is "obvious validation error here" instead of
+        # "confusing Spark identifier-resolution error five minutes into
+        # the pipeline run" (issue #261).
+        with self.assertRaisesRegex(ValueError, r"regular identifier"):
+            OnboardCommand(**self._build_onboard_kwargs(
+                uc_enabled=False,
+                uc_volume_path=None,
+                dbfs_path="/dbfs",
+                bronze_schema="bad-schema",
+            ))
+
+    def test_onboard_command_rejects_hyphenated_silver_schema_even_without_uc(self):
+        with self.assertRaisesRegex(ValueError, r"regular identifier"):
+            OnboardCommand(**self._build_onboard_kwargs(
+                uc_enabled=False,
+                uc_volume_path=None,
+                dbfs_path="/dbfs",
+                silver_schema="bad-schema",
+            ))
+
+    def _build_deploy_kwargs(self, **overrides):
+        kwargs = dict(
+            layer="bronze_silver",
+            onboard_bronze_group="A1",
+            onboard_silver_group="A1",
+            sdp_meta_bronze_schema="dlt_bronze_schema",
+            sdp_meta_silver_schema="dlt_silver_schema",
+            dataflowspec_bronze_table="bronze_dataflowspec_table",
+            dataflowspec_silver_table="silver_dataflowspec_table",
+            num_workers=1,
+            uc_catalog_name="uc_catalog",
+            pipeline_name="unittest_dlt_pipeline",
+            dlt_target_schema="dlt_target_schema",
+            uc_enabled=True,
+            serverless=False,
+            dbfs_path="/dbfs",
+        )
+        kwargs.update(overrides)
+        return kwargs
+
+    def test_deploy_command_rejects_hyphenated_uc_catalog(self):
+        with self.assertRaisesRegex(ValueError, r"regular identifier"):
+            DeployCommand(**self._build_deploy_kwargs(uc_catalog_name="my-cat"))
+
+    def test_deploy_command_rejects_hyphenated_dlt_target_schema(self):
+        # `dlt_target_schema` is spliced unquoted into pipeline target
+        # configuration, so the same strict rule applies.
+        with self.assertRaisesRegex(ValueError, r"regular identifier"):
+            DeployCommand(**self._build_deploy_kwargs(
+                dlt_target_schema="bad-schema",
+            ))
+
+    def test_deploy_command_rejects_dotted_dataflowspec_table(self):
+        with self.assertRaisesRegex(ValueError, r"regular identifier"):
+            DeployCommand(**self._build_deploy_kwargs(
+                dataflowspec_bronze_table="bad.name",
+            ))
+
     def test_get_schema_from_json_with_sdp_meta_key(self):
         """Test _get_schema_from_json returns value for sdp_meta_schema key."""
         oc_json = {"sdp_meta_schema": "my_schema"}

--- a/tests/test_identifiers.py
+++ b/tests/test_identifiers.py
@@ -1,0 +1,297 @@
+"""Tests for `databricks.labs.sdp_meta.identifiers`.
+
+The helper rejects anything that isn't a regular SQL identifier so the
+rest of the codebase can splice these names into SQL strings without
+having to think about quoting (issue #261). The tests pin both the
+acceptance set (regular identifiers) and the rejection set (hyphens,
+periods, spaces, leading digits, backticks, control chars, empty,
+oversized, non-string).
+"""
+from __future__ import annotations
+
+import unittest
+
+from databricks.labs.sdp_meta.identifiers import (
+    SUPPORTED_SCD_TYPES,
+    SUPPORTED_SOURCE_FORMATS,
+    is_regular_identifier,
+    validate_scd_type,
+    validate_source_format,
+    validate_uc_column_list,
+    validate_uc_identifier,
+)
+
+
+class IsRegularIdentifierTests(unittest.TestCase):
+    def test_simple_lowercase(self):
+        self.assertTrue(is_regular_identifier("main"))
+
+    def test_underscore_prefix(self):
+        self.assertTrue(is_regular_identifier("_priv"))
+
+    def test_alnum(self):
+        self.assertTrue(is_regular_identifier("Schema123"))
+
+    def test_hyphen_is_not_regular(self):
+        self.assertFalse(is_regular_identifier("my-catalog"))
+
+    def test_leading_digit_is_not_regular(self):
+        self.assertFalse(is_regular_identifier("9lives"))
+
+    def test_space_is_not_regular(self):
+        self.assertFalse(is_regular_identifier("data lake"))
+
+    def test_empty_is_not_regular(self):
+        self.assertFalse(is_regular_identifier(""))
+
+    def test_non_string_is_not_regular(self):
+        self.assertFalse(is_regular_identifier(None))
+        self.assertFalse(is_regular_identifier(123))
+
+
+class ValidateUcIdentifierAcceptsTests(unittest.TestCase):
+    def test_returns_input_on_valid(self):
+        self.assertEqual(validate_uc_identifier("main"), "main")
+        self.assertEqual(validate_uc_identifier("_x"), "_x")
+        self.assertEqual(validate_uc_identifier("Schema123"), "Schema123")
+        self.assertEqual(validate_uc_identifier("a_b_c"), "a_b_c")
+
+    def test_max_length_accepted(self):
+        validate_uc_identifier("a" * 255, kind="catalog")
+
+
+class ValidateUcIdentifierRejectsTests(unittest.TestCase):
+    def test_hyphen_rejected(self):
+        with self.assertRaisesRegex(ValueError, r"regular identifier"):
+            validate_uc_identifier("my-catalog", kind="uc_catalog_name")
+
+    def test_period_rejected(self):
+        with self.assertRaisesRegex(ValueError, r"regular identifier"):
+            validate_uc_identifier("bad.name", kind="uc_catalog_name")
+
+    def test_space_rejected(self):
+        with self.assertRaisesRegex(ValueError, r"regular identifier"):
+            validate_uc_identifier("data lake", kind="uc_catalog_name")
+
+    def test_leading_digit_rejected(self):
+        with self.assertRaisesRegex(ValueError, r"regular identifier"):
+            validate_uc_identifier("9lives", kind="uc_catalog_name")
+
+    def test_backtick_rejected(self):
+        with self.assertRaisesRegex(ValueError, r"regular identifier"):
+            validate_uc_identifier("bad`name", kind="uc_catalog_name")
+
+    def test_control_char_rejected(self):
+        with self.assertRaisesRegex(ValueError, r"regular identifier"):
+            validate_uc_identifier("bad\x00name", kind="uc_catalog_name")
+
+    def test_too_long_rejected(self):
+        with self.assertRaisesRegex(ValueError, r"255"):
+            validate_uc_identifier("a" * 256, kind="uc_catalog_name")
+
+    def test_empty_rejected(self):
+        with self.assertRaisesRegex(ValueError, r"non-empty"):
+            validate_uc_identifier("", kind="uc_catalog_name")
+
+    def test_none_rejected(self):
+        with self.assertRaisesRegex(ValueError, r"non-empty"):
+            validate_uc_identifier(None, kind="uc_catalog_name")
+
+    def test_non_string_rejected(self):
+        with self.assertRaisesRegex(ValueError, r"non-empty"):
+            validate_uc_identifier(123, kind="uc_catalog_name")
+
+    def test_kind_appears_in_message(self):
+        with self.assertRaisesRegex(ValueError, r"my custom kind"):
+            validate_uc_identifier("", kind="my custom kind")
+
+    def test_error_links_to_docs(self):
+        # Make the error message actionable by pointing to the upstream
+        # SQL identifier rules so the user knows the *why*.
+        with self.assertRaises(ValueError) as ctx:
+            validate_uc_identifier("my-cat", kind="uc_catalog_name")
+        self.assertIn("sql-ref-identifiers", str(ctx.exception))
+
+
+class ValidateUcColumnListTests(unittest.TestCase):
+    """Pinning the four input shapes the onboarding parser already accepts.
+
+    The helper has to round-trip every shape ``__parse_cluster_by_string``
+    and the ``*_partition_columns`` parser handle, otherwise we'd reject
+    onboarding files that were valid before this validation existed.
+    """
+
+    def test_none_returns_empty(self):
+        self.assertEqual(validate_uc_column_list(None), [])
+
+    def test_empty_string_returns_empty(self):
+        self.assertEqual(validate_uc_column_list(""), [])
+
+    def test_single_string(self):
+        self.assertEqual(validate_uc_column_list("col1"), ["col1"])
+
+    def test_comma_separated_string(self):
+        self.assertEqual(
+            validate_uc_column_list("col1,col2,col3"),
+            ["col1", "col2", "col3"],
+        )
+
+    def test_comma_separated_strips_whitespace(self):
+        self.assertEqual(
+            validate_uc_column_list(" col1 , col2 "),
+            ["col1", "col2"],
+        )
+
+    def test_python_list(self):
+        self.assertEqual(
+            validate_uc_column_list(["col1", "col2"]),
+            ["col1", "col2"],
+        )
+
+    def test_stringified_list(self):
+        # __parse_cluster_by_string accepts this shape via ast.literal_eval,
+        # so we have to as well.
+        self.assertEqual(
+            validate_uc_column_list("['col1', 'col2']"),
+            ["col1", "col2"],
+        )
+
+    def test_hyphen_in_comma_string_rejected(self):
+        with self.assertRaisesRegex(ValueError, r"regular identifier"):
+            validate_uc_column_list(
+                "col1,bad-col", kind="bronze_partition_columns"
+            )
+
+    def test_hyphen_in_list_rejected(self):
+        with self.assertRaisesRegex(ValueError, r"regular identifier"):
+            validate_uc_column_list(
+                ["col1", "bad-col"], kind="bronze_cluster_by"
+            )
+
+    def test_leading_digit_in_stringified_list_rejected(self):
+        with self.assertRaisesRegex(ValueError, r"regular identifier"):
+            validate_uc_column_list(
+                "['1col', 'col2']", kind="bronze_cluster_by"
+            )
+
+    def test_empty_list_returns_empty(self):
+        self.assertEqual(validate_uc_column_list([]), [])
+
+    def test_list_with_empty_string_rejected(self):
+        with self.assertRaisesRegex(ValueError, r"non-empty"):
+            validate_uc_column_list(["col1", ""], kind="bronze_cluster_by")
+
+    def test_list_with_non_string_rejected(self):
+        with self.assertRaisesRegex(ValueError, r"non-empty"):
+            validate_uc_column_list(["col1", 42], kind="bronze_cluster_by")
+
+    def test_unparseable_list_literal_rejected(self):
+        with self.assertRaisesRegex(ValueError, r"could not be parsed"):
+            validate_uc_column_list("[col1, col2]", kind="bronze_cluster_by")
+
+    def test_non_str_non_list_rejected(self):
+        with self.assertRaisesRegex(
+            ValueError, r"string or list of column names"
+        ):
+            validate_uc_column_list(42, kind="bronze_cluster_by")
+
+    def test_kind_appears_in_error(self):
+        with self.assertRaisesRegex(ValueError, r"silver_cluster_by"):
+            validate_uc_column_list("bad-col", kind="silver_cluster_by")
+
+
+class ValidateSourceFormatTests(unittest.TestCase):
+    """Pin the bronze-reader format set so a typo (``cloudfiles``) fails at
+    onboarding instead of silently falling through every if/elif branch
+    in ``DataflowPipeline`` and starting a pipeline with no input."""
+
+    def test_supported_set_matches_expected(self):
+        # Hard-coded so any drift between this module and dataflow_pipeline.py
+        # / pipeline_readers.py shows up as a test failure rather than a
+        # silently broken pipeline.
+        self.assertEqual(
+            SUPPORTED_SOURCE_FORMATS,
+            frozenset({"cloudFiles", "delta", "kafka", "eventhub", "snapshot"}),
+        )
+
+    def test_each_supported_format_accepted(self):
+        for fmt in SUPPORTED_SOURCE_FORMATS:
+            self.assertEqual(validate_source_format(fmt), fmt)
+
+    def test_typo_rejected(self):
+        with self.assertRaisesRegex(ValueError, r"cloudfiles"):
+            validate_source_format("cloudfiles")
+
+    def test_case_sensitive(self):
+        # DLT/Spark are case-sensitive on format name; this catches the
+        # common ``CloudFiles`` typo.
+        with self.assertRaisesRegex(ValueError, r"is not supported"):
+            validate_source_format("CloudFiles")
+
+    def test_empty_rejected(self):
+        with self.assertRaisesRegex(ValueError, r"non-empty"):
+            validate_source_format("")
+
+    def test_none_rejected(self):
+        with self.assertRaisesRegex(ValueError, r"non-empty"):
+            validate_source_format(None)
+
+    def test_error_lists_allowed_values(self):
+        # Allowed values must appear in the error so the user can fix it
+        # without going to docs.
+        with self.assertRaises(ValueError) as ctx:
+            validate_source_format("parquet")
+        msg = str(ctx.exception)
+        for fmt in SUPPORTED_SOURCE_FORMATS:
+            self.assertIn(fmt, msg)
+
+    def test_kind_appears_in_error(self):
+        with self.assertRaisesRegex(ValueError, r"my_field"):
+            validate_source_format("nope", kind="my_field")
+
+
+class ValidateScdTypeTests(unittest.TestCase):
+    """``stored_as_scd_type`` is a string in DLT's apply_changes API; reject
+    integers, ``"3"``, etc., to catch typos at onboarding."""
+
+    def test_supported_set_matches_expected(self):
+        self.assertEqual(SUPPORTED_SCD_TYPES, frozenset({"1", "2"}))
+
+    def test_one_accepted(self):
+        self.assertEqual(validate_scd_type("1"), "1")
+
+    def test_two_accepted(self):
+        self.assertEqual(validate_scd_type("2"), "2")
+
+    def test_int_rejected(self):
+        # ``2 == "2"`` is False in Python, but we want to fail loudly
+        # rather than silently coerce — see the comment in the validator.
+        with self.assertRaisesRegex(ValueError, r"non-empty string"):
+            validate_scd_type(2)
+
+    def test_three_rejected(self):
+        with self.assertRaisesRegex(ValueError, r"is not supported"):
+            validate_scd_type("3")
+
+    def test_empty_rejected(self):
+        with self.assertRaisesRegex(ValueError, r"non-empty"):
+            validate_scd_type("")
+
+    def test_none_rejected(self):
+        with self.assertRaisesRegex(ValueError, r"non-empty"):
+            validate_scd_type(None)
+
+    def test_error_lists_allowed_values(self):
+        with self.assertRaises(ValueError) as ctx:
+            validate_scd_type("scd_2")
+        msg = str(ctx.exception)
+        self.assertIn("1", msg)
+        self.assertIn("2", msg)
+
+    def test_kind_appears_in_error(self):
+        with self.assertRaisesRegex(ValueError, r"silver scd"):
+            validate_scd_type("0", kind="silver scd")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_onboard_dataflowspec.py
+++ b/tests/test_onboard_dataflowspec.py
@@ -416,6 +416,442 @@ class OnboardDataflowspecTests(SDPFrameworkTestCase):
         assert mock_bronze.called
         assert mock_silver.called
 
+    def test_onboardDataFlowSpecs_pre_validates_uc_names_and_aggregates_errors(self):
+        """Pre-flight UC validation must surface every bad row at once.
+
+        Issue #261: a hyphenated catalog or schema in the onboarding file
+        only blew up mid-onboarding with a confusing Spark error, leaving
+        the bronze dataflowspec table half-written. The pre-flight
+        validator added to ``onboard_dataflow_specs`` walks the file
+        once before any Spark side-effects and aggregates *all* identifier
+        errors into a single ``ValueError`` so the user can fix everything
+        in one pass.
+
+        This test exercises every category the validator covers:
+          - main bronze/silver UC name (``database`` / ``table``)
+          - quarantine UC name (database / table / catalog)
+          - partition / cluster column lists (single string + comma + list
+            literal forms — every shape the parser accepts)
+
+        so a regression in any one of them breaks this test.
+        """
+        # Every row uses a valid ``source_format`` so this test stays
+        # focused on UC-identifier violations. ``source_format`` /
+        # ``scd_type`` enum coverage lives in the dedicated enum test
+        # below.
+        bad_rows = [
+            {
+                # Main UC name violations.
+                "data_flow_id": "100",
+                "data_flow_group": "A1",
+                "source_format": "cloudFiles",
+                "source_details": {"source_path_dev": "/tmp/x"},
+                "bronze_database_dev": "bad-db",
+                "bronze_table": "ok_table",
+                "bronze_reader_options": {},
+                "bronze_table_path_dev": "/tmp/bronze/x",
+            },
+            {
+                # Bronze table + silver table violations.
+                "data_flow_id": "101",
+                "data_flow_group": "A1",
+                "source_format": "cloudFiles",
+                "source_details": {"source_path_dev": "/tmp/y"},
+                "bronze_database_dev": "ok_db",
+                "bronze_table": "1bad_table",
+                "bronze_reader_options": {},
+                "bronze_table_path_dev": "/tmp/bronze/y",
+                "silver_database_dev": "ok_db",
+                "silver_table": "ok.dotted",
+                "silver_table_path_dev": "/tmp/silver/y",
+            },
+            {
+                # Quarantine UC name violations + a bad partition column
+                # in comma-separated form. These are the new cases Phase 1
+                # added; main UC fields are deliberately valid here so we
+                # know the new checks are what surfaced these errors.
+                "data_flow_id": "102",
+                "data_flow_group": "A1",
+                "source_format": "cloudFiles",
+                "source_details": {"source_path_dev": "/tmp/z"},
+                "bronze_database_dev": "ok_db",
+                "bronze_table": "ok_table",
+                "bronze_reader_options": {},
+                "bronze_table_path_dev": "/tmp/bronze/z",
+                "bronze_database_quarantine_dev": "bad-q-db",
+                "bronze_quarantine_table": "1bad_q_table",
+                "bronze_partition_columns": "ok_col,bad-col",
+            },
+            {
+                # cluster_by violations — list literal (silver) and python
+                # list (bronze) — covers the two cluster_by shapes the
+                # parser accepts.
+                "data_flow_id": "103",
+                "data_flow_group": "A1",
+                "source_format": "cloudFiles",
+                "source_details": {"source_path_dev": "/tmp/w"},
+                "bronze_database_dev": "ok_db",
+                "bronze_table": "ok_table_b",
+                "bronze_reader_options": {},
+                "bronze_table_path_dev": "/tmp/bronze/w",
+                "bronze_cluster_by": "['ok_col', '1bad_col']",
+                "silver_database_dev": "ok_db",
+                "silver_table": "ok_table_s",
+                "silver_table_path_dev": "/tmp/silver/w",
+                "silver_cluster_by": ["ok_col", "bad-col"],
+            },
+        ]
+        tmp_dir = tempfile.mkdtemp(prefix="sdp_meta_prevalidate_")
+        try:
+            bad_file = os.path.join(tmp_dir, "onboarding_bad.json")
+            with open(bad_file, "w") as f:
+                json.dump(bad_rows, f)
+
+            params = copy.deepcopy(self.onboarding_bronze_silver_params_map)
+            params["onboarding_file_path"] = bad_file
+
+            with self.assertRaises(ValueError) as ctx:
+                OnboardDataflowspec(self.spark, params).onboard_dataflow_specs()
+
+            msg = str(ctx.exception)
+            # Every distinct violation should be reported in a single error.
+            # Pin the field names so a regression in any one validator path
+            # (main / quarantine / partition / cluster) is immediately obvious.
+            for needle in (
+                "flow 100 bronze_database_dev",
+                "flow 101 bronze_table",
+                "flow 101 silver_table",
+                "flow 102 bronze_database_quarantine_dev",
+                "flow 102 bronze_quarantine_table",
+                "flow 102 bronze_partition_columns",
+                "flow 103 bronze_cluster_by",
+                "flow 103 silver_cluster_by",
+            ):
+                self.assertIn(needle, msg)
+            self.assertIn("validation error(s)", msg)
+        finally:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+
+    def test_onboardDataFlowSpecs_pre_validates_source_format_and_scd_type(self):
+        """Pre-flight enum validation must surface bad source_format / scd_type.
+
+        A typo'd ``source_format`` like ``"cloudfiles"`` (lowercase 'f')
+        falls through every ``elif source_format == ...`` branch in
+        ``DataflowPipeline``, leaving the bronze read with no input. A
+        bad ``scd_type`` reaches DLT's apply_changes and fails opaquely.
+        Pre-flight catches both at onboarding with the allowed values
+        inlined in the error.
+
+        Includes a valid row to confirm the validator only flags the
+        bogus values.
+        """
+        rows = [
+            {
+                # Bogus top-level source_format + bogus CDC scd_type, both
+                # for bronze. UC names valid so they don't add noise.
+                "data_flow_id": "200",
+                "data_flow_group": "A1",
+                "source_format": "cloudfiles",  # lowercase 'f' typo
+                "source_details": {"source_path_dev": "/tmp/a"},
+                "bronze_database_dev": "ok_db",
+                "bronze_table": "ok_table",
+                "bronze_reader_options": {},
+                "bronze_table_path_dev": "/tmp/bronze/a",
+                "bronze_cdc_apply_changes": {
+                    "keys": ["id"],
+                    "sequence_by": "ts",
+                    "scd_type": "3",  # not "1" or "2"
+                },
+            },
+            {
+                # Bogus apply_changes_from_snapshot.scd_type on silver +
+                # bogus source_format on a silver append flow. Tests both
+                # the ``apply_changes_from_snapshot`` branch and the
+                # per-append-flow source_format branch.
+                "data_flow_id": "201",
+                "data_flow_group": "A1",
+                "source_format": "snapshot",
+                "source_details": {"source_path_dev": "/tmp/b"},
+                "bronze_database_dev": "ok_db",
+                "bronze_table": "ok_table_b",
+                "bronze_reader_options": {},
+                "bronze_table_path_dev": "/tmp/bronze/b",
+                "silver_database_dev": "ok_db",
+                "silver_table": "ok_table_s",
+                "silver_table_path_dev": "/tmp/silver/b",
+                "silver_apply_changes_from_snapshot": {
+                    "keys": ["id"],
+                    "scd_type": "scd_2",  # bad
+                },
+                "silver_append_flows": [
+                    {
+                        "name": "af1",
+                        "source_format": "csv",  # not in supported set
+                        "create_streaming_table": False,
+                        "source_details": {"source_path_dev": "/tmp/af"},
+                    },
+                ],
+            },
+            {
+                # Fully valid row — must NOT contribute to the error list.
+                "data_flow_id": "202",
+                "data_flow_group": "A1",
+                "source_format": "delta",
+                "source_details": {
+                    "source_database_dev": "ok_src_db",
+                    "source_table": "ok_src_tbl",
+                },
+                "bronze_database_dev": "ok_db",
+                "bronze_table": "ok_table_v",
+                "bronze_reader_options": {},
+                "bronze_table_path_dev": "/tmp/bronze/v",
+            },
+        ]
+        tmp_dir = tempfile.mkdtemp(prefix="sdp_meta_prevalidate_enum_")
+        try:
+            f_path = os.path.join(tmp_dir, "onboarding_enum_bad.json")
+            with open(f_path, "w") as fh:
+                json.dump(rows, fh)
+
+            params = copy.deepcopy(self.onboarding_bronze_silver_params_map)
+            params["onboarding_file_path"] = f_path
+
+            with self.assertRaises(ValueError) as ctx:
+                OnboardDataflowspec(self.spark, params).onboard_dataflow_specs()
+
+            msg = str(ctx.exception)
+            for needle in (
+                "flow 200 source_format",
+                "flow 200 bronze_cdc_apply_changes.scd_type",
+                "flow 201 silver_apply_changes_from_snapshot.scd_type",
+                "flow 201 silver_append_flows[0].source_format",
+            ):
+                self.assertIn(needle, msg)
+            # Valid row 202 must not appear anywhere in the error list.
+            self.assertNotIn("flow 202", msg)
+            # Allowed-values list should be inlined so the user can fix
+            # without going to docs.
+            self.assertIn("cloudFiles", msg)  # in source_format error
+        finally:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+
+    def test_onboardDataFlowSpecs_pre_validates_cdc_column_names(self):
+        """Pre-flight CDC column-name validation must catch bad column refs.
+
+        Column-name fields inside ``*_cdc_apply_changes`` /
+        ``*_apply_changes_from_snapshot`` (``keys``, ``sequence_by``,
+        ``column_list``, ``track_history_column_list``, etc.) drive
+        DLT's apply_changes column projection. A hyphenated or
+        leading-digit entry there fails at DLT runtime; pre-flight
+        catches it here.
+
+        Critically: ``apply_as_deletes`` and ``apply_as_truncates`` are
+        SQL expressions (``expr(...)``), not column names, and must NOT
+        be validated as identifiers. This test pins that contract by
+        feeding a SQL expression in those fields and asserting they
+        don't trip the validator.
+        """
+        rows = [
+            {
+                # Bronze cdc_apply_changes with bad ``keys`` (Python list
+                # form) and bad ``sequence_by`` (comma-separated string
+                # form). All other UC fields valid so the only errors
+                # we should see come from the column-list validator.
+                "data_flow_id": "300",
+                "data_flow_group": "A1",
+                "source_format": "cloudFiles",
+                "source_details": {"source_path_dev": "/tmp/p"},
+                "bronze_database_dev": "ok_db",
+                "bronze_table": "ok_table",
+                "bronze_reader_options": {},
+                "bronze_table_path_dev": "/tmp/bronze/p",
+                "bronze_cdc_apply_changes": {
+                    "keys": ["id", "bad-col"],
+                    "sequence_by": "ts,1bad",
+                    "scd_type": "1",
+                    # SQL expressions — must NOT be identifier-validated.
+                    "apply_as_deletes": "operation = 'DELETE'",
+                    "apply_as_truncates": "operation = 'TRUNCATE'",
+                    "where": "id IS NOT NULL",
+                },
+            },
+            {
+                # Silver apply_changes_from_snapshot with bad
+                # ``track_history_column_list``. Use stringified-list
+                # shape to exercise that branch of validate_uc_column_list.
+                "data_flow_id": "301",
+                "data_flow_group": "A1",
+                "source_format": "snapshot",
+                "source_details": {"source_path_dev": "/tmp/q"},
+                "bronze_database_dev": "ok_db",
+                "bronze_table": "ok_table_b",
+                "bronze_reader_options": {},
+                "bronze_table_path_dev": "/tmp/bronze/q",
+                "silver_database_dev": "ok_db",
+                "silver_table": "ok_table_s",
+                "silver_table_path_dev": "/tmp/silver/q",
+                "silver_apply_changes_from_snapshot": {
+                    "keys": ["id"],
+                    "scd_type": "2",
+                    "track_history_column_list": ["ok_col", "bad.col"],
+                },
+            },
+            {
+                # Fully valid CDC block — must NOT contribute errors.
+                # Includes apply_as_deletes / apply_as_truncates with
+                # SQL expressions to confirm they aren't identifier-
+                # validated even when other column-name fields exist.
+                "data_flow_id": "302",
+                "data_flow_group": "A1",
+                "source_format": "cloudFiles",
+                "source_details": {"source_path_dev": "/tmp/r"},
+                "bronze_database_dev": "ok_db",
+                "bronze_table": "ok_table_v",
+                "bronze_reader_options": {},
+                "bronze_table_path_dev": "/tmp/bronze/r",
+                "bronze_cdc_apply_changes": {
+                    "keys": ["id", "tenant_id"],
+                    "sequence_by": "ts",
+                    "scd_type": "2",
+                    "column_list": ["col_a", "col_b"],
+                    "track_history_except_column_list": ["audit_ts"],
+                    "apply_as_deletes": "op = 'D'",
+                },
+            },
+        ]
+        tmp_dir = tempfile.mkdtemp(prefix="sdp_meta_prevalidate_cdc_")
+        try:
+            f_path = os.path.join(tmp_dir, "onboarding_cdc_bad.json")
+            with open(f_path, "w") as fh:
+                json.dump(rows, fh)
+
+            params = copy.deepcopy(self.onboarding_bronze_silver_params_map)
+            params["onboarding_file_path"] = f_path
+
+            with self.assertRaises(ValueError) as ctx:
+                OnboardDataflowspec(self.spark, params).onboard_dataflow_specs()
+
+            msg = str(ctx.exception)
+            for needle in (
+                "flow 300 bronze_cdc_apply_changes.keys",
+                "flow 300 bronze_cdc_apply_changes.sequence_by",
+                "flow 301 silver_apply_changes_from_snapshot.track_history_column_list",
+            ):
+                self.assertIn(needle, msg)
+            # Pin the apply_as_deletes / apply_as_truncates / where
+            # contract: SQL expressions don't get identifier-validated,
+            # so the validator must never emit an error pointed at those
+            # fields, even though they contain characters (``=``, ``'``,
+            # spaces) that would fail the regular-identifier check.
+            # Match on the qualified path (``<block>.<field>``) so we
+            # don't false-positive on the words appearing elsewhere in
+            # the message (e.g. "where" inside "fix these and rerun").
+            self.assertNotIn("bronze_cdc_apply_changes.apply_as_deletes", msg)
+            self.assertNotIn("bronze_cdc_apply_changes.apply_as_truncates", msg)
+            self.assertNotIn("bronze_cdc_apply_changes.where", msg)
+            # Valid row 302 must not appear at all.
+            self.assertNotIn("flow 302", msg)
+        finally:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+
+    def test_onboardDataFlowSpecs_pre_validation_reports_every_category_in_one_error(self):
+        """End-to-end: one onboarding file, one violation per category.
+
+        The pre-flight contract is "tell the user everything that's
+        wrong in a single shot so they can fix the file once". This
+        test pins that contract by seeding a single onboarding row
+        that intentionally violates one rule from each validation
+        category we've added (Phases 1-3):
+
+          - UC catalog/schema/table identifier (with hyphen)
+          - Quarantine UC name (with leading digit)
+          - Partition-column list (with hyphen)
+          - Cluster-by list (with period)
+          - Top-level ``source_format`` enum (typo)
+          - CDC ``scd_type`` enum (numeric instead of string)
+          - CDC column-name field (``keys`` with hyphen)
+          - Append-flow ``source_format`` enum (unsupported value)
+
+        We assert that ALL of them surface in the single aggregated
+        ``ValueError``. If a future refactor short-circuits on the
+        first error, this test fails loudly.
+        """
+        bad_row = {
+            "data_flow_id": "999",
+            "data_flow_group": "A1",
+            # Top-level source_format typo.
+            "source_format": "cloudFile",
+            "source_details": {"source_path_dev": "/tmp/p"},
+            # Bronze: bad catalog (hyphen) + bad table (period).
+            "bronze_catalog_dev": "bad-catalog",
+            "bronze_database_dev": "ok_db",
+            "bronze_table": "ok.table",
+            "bronze_reader_options": {},
+            "bronze_table_path_dev": "/tmp/bronze/p",
+            # Quarantine name with leading digit.
+            "bronze_quarantine_table": "1bad_quarantine",
+            # Partition columns + clusterBy with bad entries.
+            "bronze_partition_columns": "ok_col,bad-col",
+            "bronze_cluster_by": ["ok_col", "bad.col"],
+            "bronze_cdc_apply_changes": {
+                # ``scd_type`` must be a string; numeric trips the enum
+                # validator. ``keys`` has a hyphen — column-list error.
+                "scd_type": 1,
+                "keys": ["id", "bad-key"],
+                "sequence_by": "ts",
+            },
+            "bronze_append_flows": [
+                {
+                    "name": "af1",
+                    # Unsupported append-flow source_format.
+                    "source_format": "parquet",
+                    "source_details": {"source_path_dev": "/tmp/af"},
+                }
+            ],
+        }
+        tmp_dir = tempfile.mkdtemp(prefix="sdp_meta_prevalidate_e2e_")
+        try:
+            f_path = os.path.join(tmp_dir, "onboarding_e2e_bad.json")
+            with open(f_path, "w") as fh:
+                json.dump([bad_row], fh)
+
+            params = copy.deepcopy(self.onboarding_bronze_silver_params_map)
+            params["onboarding_file_path"] = f_path
+            # Bronze-only run keeps the test tightly scoped: every
+            # error surfaced must come from this one row's bronze
+            # fields, so a missing error means the validator is
+            # short-circuiting (the bug we're guarding against).
+            params["bronze_dataflowspec_table"] = "bronze_dataflowspec_table"
+            params["silver_dataflowspec_table"] = "silver_dataflowspec_table"
+
+            with self.assertRaises(ValueError) as ctx:
+                OnboardDataflowspec(self.spark, params).onboard_dataflow_specs()
+
+            msg = str(ctx.exception)
+            expected_needles = [
+                # Identifier categories (Phase 1).
+                "flow 999 bronze_catalog_dev",
+                "flow 999 bronze_table",
+                "flow 999 bronze_quarantine_table",
+                "flow 999 bronze_partition_columns",
+                "flow 999 bronze_cluster_by",
+                # Enum categories (Phase 2).
+                "flow 999 source_format",
+                "flow 999 bronze_cdc_apply_changes.scd_type",
+                # CDC column-list (Phase 3).
+                "flow 999 bronze_cdc_apply_changes.keys",
+                # Append-flow source_format (Phase 2).
+                "flow 999 bronze_append_flows[0].source_format",
+            ]
+            missing = [n for n in expected_needles if n not in msg]
+            self.assertFalse(
+                missing,
+                f"pre-flight short-circuited; missing categories in error message: "
+                f"{missing}\nfull message:\n{msg}",
+            )
+        finally:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+
     def test_onboardDataFlowSpecs_with_merge(self):
         """Test for onboardDataflowspec with merge scenario."""
         onboardDataFlowSpecs = OnboardDataflowspec(self.spark, self.onboarding_bronze_silver_params_map)


### PR DESCRIPTION
Closes #261. Adds a single-source-of-truth UC/SQL identifier-validation
layer and wires it into every onboarding entry point (CLI, DAB bundle
prompts, the onboarding pre-flight, and the interactive demo) so bad
catalog / schema / table / column names fail fast at the boundary with
an actionable message — instead of silently flowing through and blowing
up much later inside Spark or DLT with a confusing error.
Also ships a headless launcher + cleanup function for
`SDP_META_INTERACTIVE_DEMO.py` so the demo can be exercised as an
integration test.
## What changed
### 1. New `identifiers.py` — canonical validation
`src/databricks/labs/sdp_meta/identifiers.py` is the single source of
truth for:
- `validate_uc_identifier` — regular SQL identifier
  (`^[A-Za-z_][A-Za-z0-9_]*$`, max 255 chars)
- `validate_uc_full_name` — 1-/2-/3-part names (`schema`,
  `catalog.schema`, `catalog.schema.table`)
- `validate_uc_column_list` — list-of-identifiers (also accepts the
  stringified-list form Spark Rows produce)
- `validate_source_format` — `cloudFiles` | `delta` | `kafka` |
  `eventhub` | `snapshot` (canonical case)
- `validate_scd_type` — `"1"` | `"2"`
- `prompt_uc_identifier` — interactive retry helper with TTY-aware
  error formatting (used by both `cli.py` and `bundle.py`)
### 2. Validation wired into every entry point
- **CLI** (`cli.py`) — `OnboardCommand` / `DeployCommand` validate
  catalogs, schemas, dataflowspec tables, and pipeline targets in
  `__post_init__`. `bronze_schema` / `silver_schema` are now validated
  unconditionally (not gated on `uc_enabled`) since they are spliced
  into SQL by the deployed pipeline either way.
- **DAB bundle** (`bundle.py`) — bundle-init / add-flow prompts run the
  same validators via `_ident_prompt = prompt_uc_identifier`.
- **Onboarding** (`onboard_dataflowspec.py`) — new
  `__pre_validate_onboarding_uc_names` walks the onboarding file once
  and aggregates **every** UC-identifier / source-format / scd-type
  failure into a single `ValueError` with a bulleted list, **before**
  any Spark side-effect (no half-onboarded `bronze_dataflowspec_cdc`
  table to clean up). Per-row defence-in-depth checks remain on the
  bronze and silver paths for callers that bypass
  `onboard_dataflow_specs`.
- **Demo notebook** (`SDP_META_INTERACTIVE_DEMO.py`) — first cell
  inlines the regex for the pre-`%pip install` widget check (with a
  `# KEEP IN SYNC WITH src/databricks/labs/sdp_meta/identifiers.py`
  marker); the canonical `validate_uc_identifier` re-runs in cell 2
  after install as belt-and-braces.
### 3. `demo/launch_interactive_demo.py` (new, 617 LOC)
Headless launcher that uploads the demo notebook + `demo/conf/**` into
a workspace, creates a serverless job, and tails the run. Supports:
- `--git-branch` *or* `--build-and-upload-whl` (the latter builds the
  wheel locally and uploads it to a UC Volume so the demo runs from a
  pinned local artifact)
- `--cleanup {true,false}` — drives a new `_cleanup_demo_resources()`
  function in the notebook for tearing down the catalog/schema/volume/pipeline
  after the run
- Unique scannable run names
  (`sdp-meta-demo-<UTC-ts>-<uc_catalog>-<run-id>`)
- Recursive `demo/conf/` walk (replaces the previous brittle allow-list
  of two files)
- `--timeout-minutes`, `--profile`, `--data-source` (`github` |
  `dbdatagen`), and an auto `webbrowser.open()` to the run URL
### 4. Quality / cleanup
- De-duplicated `_ident_question` (cli.py) and `_ident_prompt`
  (bundle.py) into one helper in `identifiers.py` so a future tweak
  (regex, retry count, error formatting) updates both call paths at
  once.
- TTY-aware ANSI-red error formatting (clean logs in CI / file
  redirects, `sys.stderr` instead of stdout).
- Hoisted `_CDC_COL_FIELDS` / `_SNAPSHOT_COL_FIELDS` to module level
  (no more re-defining tuples inside the per-row × per-layer loop).
- Switched the inline source-format list inside
  `__get_bronze_dataflow_spec_dataframe` to use the canonical
  `SUPPORTED_SOURCE_FORMATS` set (single source of truth), preserving
  the historic case-insensitive comparison via a module-level
  `_SUPPORTED_SOURCE_FORMATS_LOWER` mirror.
- Gated the eager `onboarding_df.show()` + duplicate-`data_flow_id`
  check on first-read-per-file (was firing 3× per
  `onboard_dataflow_specs` call: pre-flight + bronze + silver).
  Intentionally does **not** cache the lazy DataFrame itself —
  reusing one plan across the saveAsTable→read-back→saveAsTable cycle
  caused `SparkFileNotFoundException` on overwritten parquet files.
## Tests
- New `tests/test_identifiers.py` (297 LOC) — full coverage of every
  validator, including edge cases (None, Spark `Row`, stringified
  lists, hyphens, leading digits, length cap, dotted names per
  `max_parts`).
- `tests/test_onboard_dataflowspec.py` (+436 LOC) — pre-flight
  aggregates errors across UC names, CDC column names, source format,
  scd_type; per-row defence-in-depth on direct
  `onboard_bronze/silver_dataflow_spec` calls.
- `tests/test_cli.py` (+130 LOC) — `OnboardCommand` / `DeployCommand`
  rejection cases, including the regression tests for hyphenated
  `bronze_schema` / `silver_schema` *without* UC enabled.
- `tests/test_bundle.py` (+97 LOC) — bundle prompt validation +
  bundle-init schema rejection.

