### PR TITLE
security: replace eval() on uc_enabled widget with strict parse

### DIFF
--- a/demo/notebooks/afam_cloudfiles_runners/validate.py
+++ b/demo/notebooks/afam_cloudfiles_runners/validate.py
@@ -2,7 +2,7 @@
 import pandas as pd
 
 run_id = dbutils.widgets.get("run_id")
-uc_enabled = eval(dbutils.widgets.get("uc_enabled"))
+uc_enabled = dbutils.widgets.get("uc_enabled").strip().lower() == "true"
 uc_catalog_name = dbutils.widgets.get("uc_catalog_name")
 bronze_schema = dbutils.widgets.get("bronze_schema")
 silver_schema = dbutils.widgets.get("silver_schema")

--- a/demo/notebooks/afam_eventhub_runners/validate.py
+++ b/demo/notebooks/afam_eventhub_runners/validate.py
@@ -2,7 +2,7 @@
 import pandas as pd
 
 run_id = dbutils.widgets.get("run_id")
-uc_enabled = eval(dbutils.widgets.get("uc_enabled"))
+uc_enabled = dbutils.widgets.get("uc_enabled").strip().lower() == "true"
 uc_catalog_name = dbutils.widgets.get("uc_catalog_name")
 output_file_path = dbutils.widgets.get("output_file_path")
 bronze_schema = dbutils.widgets.get("bronze_schema")

--- a/demo/notebooks/snapshot_runners/validate.py
+++ b/demo/notebooks/snapshot_runners/validate.py
@@ -2,7 +2,7 @@
 import pandas as pd
 
 run_id = dbutils.widgets.get("run_id")
-uc_enabled = eval(dbutils.widgets.get("uc_enabled"))
+uc_enabled = dbutils.widgets.get("uc_enabled").strip().lower() == "true"
 uc_catalog_name = dbutils.widgets.get("uc_catalog_name")
 output_file_path = dbutils.widgets.get("output_file_path")
 bronze_schema = dbutils.widgets.get("bronze_schema")

--- a/integration_tests/notebooks/cloudfile_runners/validate.py
+++ b/integration_tests/notebooks/cloudfile_runners/validate.py
@@ -2,7 +2,7 @@
 import pandas as pd
 
 run_id = dbutils.widgets.get("run_id")
-uc_enabled = eval(dbutils.widgets.get("uc_enabled"))
+uc_enabled = dbutils.widgets.get("uc_enabled").strip().lower() == "true"
 uc_catalog_name = dbutils.widgets.get("uc_catalog_name")
 bronze_schema = dbutils.widgets.get("bronze_schema")
 silver_schema = dbutils.widgets.get("silver_schema")

--- a/integration_tests/notebooks/eventhub_runners/validate.py
+++ b/integration_tests/notebooks/eventhub_runners/validate.py
@@ -2,7 +2,7 @@
 import pandas as pd
 
 run_id = dbutils.widgets.get("run_id")
-uc_enabled = eval(dbutils.widgets.get("uc_enabled"))
+uc_enabled = dbutils.widgets.get("uc_enabled").strip().lower() == "true"
 uc_catalog_name = dbutils.widgets.get("uc_catalog_name")
 output_file_path = dbutils.widgets.get("output_file_path")
 bronze_schema = dbutils.widgets.get("bronze_schema")

--- a/integration_tests/notebooks/snapshot_runners/validate.py
+++ b/integration_tests/notebooks/snapshot_runners/validate.py
@@ -2,7 +2,7 @@
 import pandas as pd
 
 run_id = dbutils.widgets.get("run_id")
-uc_enabled = eval(dbutils.widgets.get("uc_enabled"))
+uc_enabled = dbutils.widgets.get("uc_enabled").strip().lower() == "true"
 uc_catalog_name = dbutils.widgets.get("uc_catalog_name")
 output_file_path = dbutils.widgets.get("output_file_path")
 bronze_schema = dbutils.widgets.get("bronze_schema")


### PR DESCRIPTION
  Six runner notebooks parsed the uc_enabled widget via eval(), which
  executes arbitrary Python from a widget value. Replace with
  `.strip().lower() == "true"` -- behaviourally identical for the only
  values the launchers ever send ("True"/"False"), and removes the
  arbitrary-code-execution surface.