### PR TITLE
Fix cross-platform file URI handling in cli and update cloudFiles dem…

### DIFF
--- a/demo/conf/json/cloudfiles-onboarding.template
+++ b/demo/conf/json/cloudfiles-onboarding.template
@@ -29,7 +29,7 @@
    "bronze_table_properties": {
          "pipelines.autoOptimize.managed": "true"
    },
-   "bronze_table_cluster_by":["id", "email"],   
+   "bronze_cluster_by":["id", "email"],
    "bronze_data_quality_expectations_json_demo": "{uc_volume_path}/demo/conf/json/dqe/customers/bronze_data_quality_expectations.json",
    "bronze_catalog_quarantine_demo": "{uc_catalog_name}",
    "bronze_database_quarantine_demo": "{bronze_schema}",
@@ -106,7 +106,7 @@
    "bronze_table_properties": {
          "pipelines.reset.allowed": "true"
    },
-   "bronze_table_cluster_by":["id", "customer_id"],   
+   "bronze_cluster_by":["id", "customer_id"],
    "bronze_data_quality_expectations_json_demo": "{uc_volume_path}/demo/conf/json/dqe/transactions/bronze_data_quality_expectations.json",
    "bronze_catalog_quarantine_demo": "{uc_catalog_name}",
    "bronze_database_quarantine_demo": "{bronze_schema}",

--- a/src/databricks/labs/sdp_meta/cli.py
+++ b/src/databricks/labs/sdp_meta/cli.py
@@ -23,6 +23,72 @@ from databricks.labs.sdp_meta.install import WorkspaceInstaller
 logger = logging.getLogger('databricks.labs.sdp_meta')
 
 
+def _normalize_file_uri_to_path(file_uri: str) -> str:
+    """Convert a file URI to a normalized local filesystem path.
+
+    Handles both Unix and Windows paths correctly.
+    Examples:
+    - 'file:/path/to/dir' -> '/path/to/dir' (Unix)
+    - 'file:/C:\\projects\\dir' -> 'C:\\projects\\dir' (Windows)
+    - 'file:///C:/projects/dir' -> 'C:/projects/dir' (Windows)
+    - '/path/to/dir' -> '/path/to/dir' (already a path)
+
+    Args:
+        file_uri: A file URI or local path
+
+    Returns:
+        A normalized local filesystem path
+    """
+    if not file_uri.startswith('file:'):
+        return file_uri
+
+    # Remove 'file:' prefix
+    path = file_uri[5:]
+
+    # Remove leading slashes for file:// or file:/// URIs
+    while path.startswith('//'):
+        path = path[1:]
+
+    # Handle Windows paths: /C:\... or /C:/... -> C:\... or C:/...
+    # After removing 'file:', we may have '/C:\path' or '/C:/path'
+    if len(path) > 2 and path[0] == '/' and path[2] in (':', '|'):
+        path = path[1:]
+        # Normalize pipe to colon (file URI spec allows C| instead of C:)
+        if path[1] == '|':
+            path = path[0] + ':' + path[2:]
+
+    return path
+
+
+def _path_to_file_uri(local_path: str) -> str:
+    """Convert a local filesystem path to a file URI.
+
+    Handles both Unix and Windows paths correctly.
+    Examples:
+    - '/path/to/dir' -> 'file:/path/to/dir' (Unix)
+    - 'C:\\projects\\dir' -> 'file:///C:/projects/dir' (Windows)
+    - 'C:/projects/dir' -> 'file:///C:/projects/dir' (Windows)
+
+    Args:
+        local_path: A local filesystem path
+
+    Returns:
+        A properly formatted file URI
+    """
+    # Check if it's already a file URI
+    if local_path.startswith('file:'):
+        return local_path
+
+    # Check for Windows absolute path (e.g., C:\... or C:/...)
+    if len(local_path) > 1 and local_path[1] == ':':
+        # Windows path - use file:/// format with forward slashes
+        normalized = local_path.replace('\\', '/')
+        return f"file:///{normalized}"
+
+    # Unix path - use file: format
+    return f"file:{local_path}"
+
+
 # Runner notebook template for DLT pipeline
 SDP_META_RUNNER_NOTEBOOK = """
 # Databricks notebook source
@@ -277,7 +343,7 @@ class SDPMeta:
         return _me.user_name
 
     def copy_to_uc_volume(self, src, dst):
-        main_dir = src.replace('file:', '')
+        main_dir = _normalize_file_uri_to_path(src)
         base_dir_name = os.path.basename(os.path.normpath(main_dir))
         for root, dirs, files in os.walk(main_dir):
             for filename in files:
@@ -288,7 +354,7 @@ class SDPMeta:
 
     def copy_to_dbfs(self, src, dst):
         dst = dst.replace('//', '/')
-        main_dir = src.replace('file:', '')
+        main_dir = _normalize_file_uri_to_path(src)
         main_dir = main_dir.replace('//', '/')
         base_dir_name = None
         if main_dir.endswith('/'):
@@ -569,7 +635,7 @@ class SDPMeta:
         cwd = os.getcwd()
         onboarding_files_dir_path = self._wsi._question(
             "Provide onboarding files local directory", default=f'{cwd}/demo/')
-        onboard_cmd_dict["onboarding_files_dir_path"] = f"file:/{onboarding_files_dir_path}"
+        onboard_cmd_dict["onboarding_files_dir_path"] = _path_to_file_uri(onboarding_files_dir_path)
         onboard_cmd_dict["sdp_meta_schema"] = self._ident_question(
             "Provide sdp meta schema name",
             kind="sdp_meta_schema",
@@ -742,7 +808,7 @@ class SDPMeta:
             'onboarding_file_path', 'demo/conf/json/onboarding.template'
         )
         onboarding_files_dir_path = form_data.get('local_directory', f'{os.getcwd()}/demo/')
-        onboard_cmd_dict["onboarding_files_dir_path"] = f"file:/{onboarding_files_dir_path}"
+        onboard_cmd_dict["onboarding_files_dir_path"] = _path_to_file_uri(onboarding_files_dir_path)
 
         # Get schema names
         onboard_cmd_dict["sdp_meta_schema"] = form_data.get(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -315,7 +315,7 @@ class CliTests(unittest.TestCase):
         mock_ws_installer._choice.side_effect = ['True', 'True', 'bronze_silver', 'False', 'True', 'False']
         mock_ws_installer._question.side_effect = [
             "uc_catalog", "demo/conf/onboarding.template",
-            "file:/demo/", "sdp_meta_dataflowspecs", "sdp_meta_bronze", "sdp_meta_silver",
+            "/demo/", "sdp_meta_dataflowspecs", "sdp_meta_bronze", "sdp_meta_silver",
             "bronze_dataflowspec", "silver_dataflowspec", "v1", "prod", "author", "True"
         ]
         sdp_meta = SDPMeta(mock_workspace_client)
@@ -325,7 +325,7 @@ class CliTests(unittest.TestCase):
         self.assertEqual(cmd.uc_catalog_name, "uc_catalog")
         self.assertEqual(cmd.dbfs_path, None)
         self.assertEqual(cmd.onboarding_file_path, "demo/conf/onboarding.template")
-        self.assertEqual(cmd.onboarding_files_dir_path, "file:/file:/demo/")
+        self.assertEqual(cmd.onboarding_files_dir_path, "file:/demo/")
         self.assertEqual(cmd.sdp_meta_schema, "sdp_meta_dataflowspecs")
         self.assertEqual(cmd.bronze_schema, "sdp_meta_bronze")
         self.assertEqual(cmd.silver_schema, "sdp_meta_silver")
@@ -347,7 +347,7 @@ class CliTests(unittest.TestCase):
                                                  'bronze_silver', 'False', 'True', 'False']
         mock_ws_installer._question.side_effect = [
             'dbfs_path', "dbrx", "demo/conf/onboarding.template",
-            "file:/demo/", "sdp_meta_dataflowspecs", "sdp_meta_bronze",
+            "/demo/", "sdp_meta_dataflowspecs", "sdp_meta_bronze",
             "sdp_meta_silver", "bronze_dataflowspec_table",
             "bronze_dataflowspec_path", "silver_dataflowspec_table",
             "silver_dataflowspec_path", "v1", "prod", "author", "True"
@@ -359,7 +359,7 @@ class CliTests(unittest.TestCase):
         self.assertFalse(cmd.serverless)
         self.assertEqual(cmd.dbfs_path, "dbfs_path")
         self.assertEqual(cmd.onboarding_file_path, "demo/conf/onboarding.template")
-        self.assertEqual(cmd.onboarding_files_dir_path, "file:/file:/demo/")
+        self.assertEqual(cmd.onboarding_files_dir_path, "file:/demo/")
         self.assertEqual(cmd.sdp_meta_schema, "sdp_meta_dataflowspecs")
         self.assertEqual(cmd.bronze_schema, "sdp_meta_bronze")
         self.assertEqual(cmd.silver_schema, "sdp_meta_silver")
@@ -2106,6 +2106,123 @@ class BundleInitQuickstartFlagTests(unittest.TestCase):
             cli_bundle_init(sdp_meta, flags={"output-dir": "/cli/wins"})
             cmd = fake_run.call_args[0][0]
             self.assertEqual(cmd.output_dir, "/cli/wins")
+
+
+class TestFileUriHelpers(unittest.TestCase):
+    """Test cases for file URI helper functions (Issue #251)."""
+
+    def test_normalize_file_uri_unix_path(self):
+        """Test normalizing Unix file URIs."""
+        from databricks.labs.sdp_meta.cli import _normalize_file_uri_to_path
+
+        self.assertEqual(_normalize_file_uri_to_path("file:/path/to/dir"), "/path/to/dir")
+        self.assertEqual(_normalize_file_uri_to_path("/path/to/dir"), "/path/to/dir")
+        self.assertEqual(_normalize_file_uri_to_path("file:///path/to/dir"), "/path/to/dir")
+
+    def test_normalize_file_uri_windows_path(self):
+        """Test normalizing Windows file URIs (Issue #251)."""
+        from databricks.labs.sdp_meta.cli import _normalize_file_uri_to_path
+
+        self.assertEqual(
+            _normalize_file_uri_to_path("file:/C:\\projects\\dlt-meta\\conf"),
+            "C:\\projects\\dlt-meta\\conf",
+        )
+        self.assertEqual(
+            _normalize_file_uri_to_path("file:/C:/projects/dlt-meta/conf"),
+            "C:/projects/dlt-meta/conf",
+        )
+        self.assertEqual(
+            _normalize_file_uri_to_path("file:///C:/projects/dlt-meta/conf"),
+            "C:/projects/dlt-meta/conf",
+        )
+        self.assertEqual(
+            _normalize_file_uri_to_path("file:///C:\\projects\\dlt-meta\\conf"),
+            "C:\\projects\\dlt-meta\\conf",
+        )
+
+    def test_path_to_file_uri_unix(self):
+        """Test creating file URIs from Unix paths."""
+        from databricks.labs.sdp_meta.cli import _path_to_file_uri
+
+        self.assertEqual(_path_to_file_uri("/path/to/dir"), "file:/path/to/dir")
+        self.assertEqual(_path_to_file_uri("file:/path/to/dir"), "file:/path/to/dir")
+
+    def test_path_to_file_uri_windows(self):
+        """Test creating file URIs from Windows paths (Issue #251)."""
+        from databricks.labs.sdp_meta.cli import _path_to_file_uri
+
+        self.assertEqual(
+            _path_to_file_uri("C:\\projects\\dlt-meta\\conf"),
+            "file:///C:/projects/dlt-meta/conf",
+        )
+        self.assertEqual(
+            _path_to_file_uri("C:/projects/dlt-meta/conf"),
+            "file:///C:/projects/dlt-meta/conf",
+        )
+        self.assertEqual(
+            _path_to_file_uri("file:///C:/projects/dir"),
+            "file:///C:/projects/dir",
+        )
+
+    def test_roundtrip_unix(self):
+        """Test that Unix paths round-trip correctly through URI conversion."""
+        from databricks.labs.sdp_meta.cli import _normalize_file_uri_to_path, _path_to_file_uri
+
+        original_path = "/home/user/projects/demo"
+        uri = _path_to_file_uri(original_path)
+        restored_path = _normalize_file_uri_to_path(uri)
+        self.assertEqual(original_path, restored_path)
+
+    def test_roundtrip_windows(self):
+        """Test that Windows paths round-trip correctly through URI conversion (Issue #251)."""
+        from databricks.labs.sdp_meta.cli import _normalize_file_uri_to_path, _path_to_file_uri
+
+        original_path = "C:/projects/dlt-meta/conf"
+        uri = _path_to_file_uri(original_path)
+        restored_path = _normalize_file_uri_to_path(uri)
+        self.assertEqual(original_path, restored_path)
+
+    @patch("os.walk")
+    @patch("builtins.open", new_callable=mock_open)
+    def test_copy_to_uc_volume_windows_path(self, mock_open_func, mock_os_walk):
+        """Test that copy_to_uc_volume handles Windows paths correctly (Issue #251)."""
+        mock_ws = MagicMock()
+        sdp_meta = SDPMeta(mock_ws)
+        windows_src = "file:///C:/projects/dlt-meta/conf"
+        mock_os_walk.return_value = [
+            ("C:/projects/dlt-meta/conf", [], ["file1.json"]),
+        ]
+        mock_ws.files.upload = MagicMock()
+
+        sdp_meta.copy_to_uc_volume(windows_src, "/Volumes/catalog/schema/volume/")
+
+        walk_call_arg = mock_os_walk.call_args[0][0]
+        self.assertFalse(
+            walk_call_arg.startswith('/C:'),
+            f"Invalid Windows path passed to os.walk: {walk_call_arg}",
+        )
+        self.assertEqual(walk_call_arg, "C:/projects/dlt-meta/conf")
+
+    @patch("os.walk")
+    @patch("builtins.open", new_callable=mock_open)
+    def test_copy_to_dbfs_windows_path(self, mock_open_func, mock_os_walk):
+        """Test that copy_to_dbfs handles Windows paths correctly (Issue #251)."""
+        mock_ws = MagicMock()
+        sdp_meta = SDPMeta(mock_ws)
+        windows_src = "file:///C:/projects/dlt-meta/conf"
+        mock_os_walk.return_value = [
+            ("C:/projects/dlt-meta/conf", [], ["file1.json"]),
+        ]
+        mock_ws.dbfs.upload = MagicMock()
+
+        sdp_meta.copy_to_dbfs(windows_src, "dbfs:/dlt-meta/conf/")
+
+        walk_call_arg = mock_os_walk.call_args[0][0]
+        self.assertFalse(
+            walk_call_arg.startswith('/C:'),
+            f"Invalid Windows path passed to os.walk: {walk_call_arg}",
+        )
+        self.assertEqual(walk_call_arg, "C:/projects/dlt-meta/conf")
 
 
 class LabsYmlFlagDeclarationTests(unittest.TestCase):


### PR DESCRIPTION
Fix onboarding path handling for file URIs and update cloudFiles clustering metadata.

Adds cross-platform file URI normalization for local onboarding directories, covering Unix and Windows paths, and updates the cloudFiles JSON demo template to use bronze_cluster_by instead of the legacy bronze_table_cluster_by key.