### PR TITLE
feat(mcp): expose sdp-meta as an MCP server

### DIFF
--- a/docs/content/getting_started/mcp.md
+++ b/docs/content/getting_started/mcp.md
@@ -1,0 +1,99 @@
+---
+title: "SDP-META MCP Server"
+date: 2026-04-29
+weight: 10
+draft: false
+---
+
+### What is the MCP server?
+
+The sdp-meta MCP (Model Context Protocol) server exposes a curated subset of
+sdp-meta operations as MCP tools so an MCP-capable client — Claude Code,
+Cursor, Claude Desktop, or any other MCP host — can drive sdp-meta scaffolding
+and inspection on your behalf.
+
+The server runs locally over stdio. It is launched by the
+`databricks labs sdp-meta mcp` command and shipped as the optional `mcp` extra
+of `databricks-labs-sdp-meta`.
+
+### Prerequisites
+
+- Python 3.8 +
+- [Databricks CLI](https://docs.databricks.com/en/dev-tools/cli/tutorial.html)
+- An MCP-capable client (e.g. Claude Code, Claude Desktop, Cursor)
+
+### Install
+
+```commandline
+pip install 'databricks-labs-sdp-meta[mcp]'
+databricks labs install sdp-meta
+```
+
+### Run
+
+```commandline
+databricks labs sdp-meta mcp
+```
+
+The process reads/writes JSON-RPC framed messages on stdio and blocks until
+the client disconnects. Most users do not run this command directly; their
+MCP client launches it for them via the configuration below.
+
+### Wire it into Claude Desktop / Claude Code / Cursor
+
+Add an entry to the client's MCP server configuration. The shape varies per
+client but the launch command is always the same.
+
+**Claude Desktop** (`claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "sdp-meta": {
+      "command": "databricks",
+      "args": ["labs", "sdp-meta", "mcp"]
+    }
+  }
+}
+```
+
+**Claude Code** (`.mcp.json` in your project, or via `claude mcp add`):
+
+```commandline
+claude mcp add sdp-meta -- databricks labs sdp-meta mcp
+```
+
+**Cursor** — same `mcpServers` shape as Claude Desktop in your Cursor settings.
+
+### Tools (v0)
+
+| Tool | Description |
+|------|-------------|
+| `sdp_meta_bundle_init` | Scaffold a new sdp-meta DAB. Pass `quickstart=true` for developer defaults; otherwise supply `config_file` (the server cannot run interactive prompts). |
+| `sdp_meta_bundle_validate` | Run `databricks bundle validate` plus sdp-meta sanity checks against a scaffolded bundle. |
+| `sdp_meta_bundle_add_flow` | Append one or more flow entries to a scaffolded bundle's onboarding file. Flows are dicts matching `FlowSpec` in `bundle.py`. |
+| `sdp_meta_list_templates` | List the names of every packaged onboarding / DQE / silver-transformation template. |
+| `sdp_meta_get_onboarding_template` | Return the raw text of a packaged template by name (use `list_templates` to discover names). |
+
+### Resources
+
+The server exposes packaged templates as MCP resources:
+
+```
+sdp-meta://templates/<format>/<filename>
+```
+
+For example: `sdp-meta://templates/json/cloudfiles-onboarding.template` or
+`sdp-meta://templates/yml/eventhub-onboarding.template.yml`. A client can
+fetch any of these as additional context when authoring a configuration.
+
+
+### Troubleshooting
+
+- `ImportError: The mcp extra is not installed` — install with
+  `pip install 'databricks-labs-sdp-meta[mcp]'`.
+- The server exits immediately when launched manually — that is expected;
+  stdio transport waits for an MCP client. Launch via your MCP host instead.
+- Tool calls return `returncode != 0` — the underlying `databricks bundle ...`
+  invocation failed; the captured stdout is in the `output` field of the
+  response payload.

--- a/labs.yml
+++ b/labs.yml
@@ -23,3 +23,5 @@ commands:
     description: Run `databricks bundle validate` plus sdp-meta sanity checks (layer/topology consistency, wheel_source vs sdp_meta_dependency, onboarding placeholders, dataflow_group references) against a scaffolded bundle
   - name: bundle-add-flow
     description: Append flow entries to a bundle's conf/onboarding.{yml,json} (interactive single-flow prompts or batch from CSV); auto-increments data_flow_id and seeds silver_transformations.* for new silver flows
+  - name: mcp
+    description: Run the sdp-meta Model Context Protocol (MCP) server over stdio so an MCP-capable client (Claude Code, Cursor, Claude Desktop) can drive sdp-meta scaffolding and inspection. Requires the `mcp` extra (`pip install databricks-labs-sdp-meta[mcp]`).

--- a/setup.py
+++ b/setup.py
@@ -22,13 +22,15 @@ DEV_REQUIREMENTS = [
 
 IT_REQUIREMENTS = ["typer[all]==0.6.1"]
 
+MCP_REQUIREMENTS = ["mcp>=1.0,<2.0"]
+
 setup(
     name="databricks-labs-sdp-meta",
     version="0.0.11",
     python_requires=">=3.8",
     setup_requires=["wheel>=0.37.1,<=0.42.0"],
     install_requires=INSTALL_REQUIRES,
-    extras_require={"dev": DEV_REQUIREMENTS, "IT": IT_REQUIREMENTS},
+    extras_require={"dev": DEV_REQUIREMENTS, "IT": IT_REQUIREMENTS, "mcp": MCP_REQUIREMENTS},
     author="Ravi Gawai",
     author_email="databrickslabs@databricks.com",
     license="Databricks License",

--- a/src/databricks/labs/sdp_meta/cli.py
+++ b/src/databricks/labs/sdp_meta/cli.py
@@ -1062,6 +1062,25 @@ def bundle_add_flow(sdp_meta: SDPMeta, flags: dict = None):
         sys.exit(rc)
 
 
+def mcp(sdp_meta: SDPMeta, flags: dict = None):
+    """Run the sdp-meta MCP server over stdio.
+
+    Requires the `mcp` extra. The server exposes a curated subset of
+    sdp-meta operations as MCP tools so an MCP client (Claude Code,
+    Cursor, Claude Desktop) can drive sdp-meta workflows.
+    """
+    del flags
+    try:
+        from databricks.labs.sdp_meta.mcp.server import run_stdio
+    except ImportError as exc:
+        msg = (
+            "The `mcp` extra is not installed. "
+            "Install it with: pip install 'databricks-labs-sdp-meta[mcp]'"
+        )
+        raise ImportError(msg) from exc
+    run_stdio(sdp_meta)
+
+
 MAPPING = {
     "onboard": onboard,
     "deploy": deploy,
@@ -1071,6 +1090,7 @@ MAPPING = {
     "bundle-prepare-wheel": bundle_prepare_wheel,
     "bundle-validate": bundle_validate,
     "bundle-add-flow": bundle_add_flow,
+    "mcp": mcp,
 }
 
 

--- a/src/databricks/labs/sdp_meta/mcp/__init__.py
+++ b/src/databricks/labs/sdp_meta/mcp/__init__.py
@@ -1,0 +1,11 @@
+"""sdp-meta Model Context Protocol (MCP) server.
+
+Exposes a curated subset of sdp-meta operations as MCP tools so an MCP-capable
+client (Claude Code, Cursor, Claude Desktop) can drive sdp-meta workflows.
+
+Entrypoint: :func:`databricks.labs.sdp_meta.mcp.server.run_stdio`.
+
+Requires the ``mcp`` extra::
+
+    pip install 'databricks-labs-sdp-meta[mcp]'
+"""

--- a/src/databricks/labs/sdp_meta/mcp/server.py
+++ b/src/databricks/labs/sdp_meta/mcp/server.py
@@ -1,0 +1,512 @@
+"""sdp-meta MCP server (stdio transport).
+
+The server exposes four scaffolding/inspection tools plus a templates resource
+namespace. It deliberately does NOT expose ``onboard``/``deploy`` in v0 — those
+require a live workspace and proper integration testing (tracked as a follow-up
+under issue #231).
+
+Architecture:
+- The lowlevel :class:`mcp.server.Server` is wrapped by :func:`build_server`
+  which registers tool/resource handlers against a captured ``SDPMeta`` instance
+  (so future tools that need the ``WorkspaceClient`` can reach it).
+- :func:`run_stdio` is the entrypoint called by the ``mcp`` CLI command.
+- Tool dispatch is split into pure handlers (``_handle_*``) so unit tests can
+  call them directly without spinning up the asyncio stdio plumbing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import json
+import logging
+import os
+from contextlib import redirect_stdout
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from mcp.server import Server
+from mcp.server.stdio import stdio_server
+from mcp.types import Resource, TextContent, Tool
+from pydantic import AnyUrl
+
+logger = logging.getLogger("databricks.labs.sdp_meta.mcp")
+
+
+# ---------------------------------------------------------------------------
+# Templates: locate the onboarding/DQE/transformation examples directory.
+#
+# Resolution order (first match wins):
+#   1. ``SDP_META_EXAMPLES_DIR`` environment variable — explicit override for
+#      installed/containerised deployments and tests.
+#   2. ``importlib.resources`` against ``databricks.labs.sdp_meta._packaged_examples``
+#      — populated for true wheel installs once #231 packages templates.
+#   3. Repo-tree walk (``parents[5]/examples``) — the developer/source-checkout
+#      path. This is the path the unit tests exercise today.
+#
+# Returns ``None`` if no strategy resolves a directory; callers surface a
+# clear error pointing at strategy 1 as the recommended workaround.
+# ---------------------------------------------------------------------------
+
+_EXAMPLES_ENV_VAR = "SDP_META_EXAMPLES_DIR"
+_PACKAGED_EXAMPLES_MODULE = "databricks.labs.sdp_meta._packaged_examples"
+
+
+def _locate_examples_dir() -> Optional[Path]:
+    """Resolve the examples directory or return ``None`` if not found."""
+    env_override = os.environ.get(_EXAMPLES_ENV_VAR)
+    if env_override:
+        candidate = Path(env_override).expanduser().resolve()
+        if candidate.is_dir():
+            return candidate
+        logger.warning(
+            "%s=%r is set but the path does not exist or is not a directory; "
+            "falling back to packaged/source-tree resolution.",
+            _EXAMPLES_ENV_VAR,
+            env_override,
+        )
+
+    try:
+        from importlib.resources import files
+
+        pkg_root = files(_PACKAGED_EXAMPLES_MODULE)
+        # ``files()`` returns a Traversable; convert to a real Path when we can.
+        pkg_path = Path(str(pkg_root))
+        if pkg_path.is_dir():
+            return pkg_path
+    except (ModuleNotFoundError, ImportError):
+        pass
+
+    repo_candidate = Path(__file__).resolve().parents[5] / "examples"
+    if repo_candidate.is_dir():
+        return repo_candidate
+
+    return None
+
+
+def _list_template_files() -> List[Tuple[str, Path]]:
+    """Return ``[(logical_name, absolute_path)]`` for every shipped template.
+
+    ``logical_name`` is what callers pass to ``get_onboarding_template`` and
+    what appears in the ``sdp-meta://templates/<name>`` resource URI. We use
+    ``<format>/<filename>`` (e.g. ``json/cloudfiles-onboarding.template``) so
+    the JSON and YAML variants of the same template don't collide.
+
+    Returns an empty list if no examples directory could be resolved (see
+    :func:`_locate_examples_dir`); callers should produce an actionable error
+    pointing the user at the ``SDP_META_EXAMPLES_DIR`` workaround.
+    """
+    out: List[Tuple[str, Path]] = []
+    examples_dir = _locate_examples_dir()
+    if examples_dir is None:
+        return out
+    for fmt in ("json", "yml"):
+        fmt_dir = examples_dir / fmt
+        if not fmt_dir.is_dir():
+            continue
+        for path in sorted(fmt_dir.rglob("*")):
+            if not path.is_file():
+                continue
+            name = f"{fmt}/{path.relative_to(fmt_dir).as_posix()}"
+            out.append((name, path))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Tool input schemas (JSON Schema). Kept as plain dicts so we don't pull in
+# pydantic just for tool signatures.
+# ---------------------------------------------------------------------------
+
+_BUNDLE_INIT_SCHEMA: Dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "output_dir": {
+            "type": "string",
+            "description": "Directory where the bundle will be scaffolded. Created if missing.",
+            "default": ".",
+        },
+        "quickstart": {
+            "type": "boolean",
+            "description": (
+                "Use the developer-friendly quickstart defaults "
+                "(cloudFiles + bronze_silver + split + pypi). "
+                "When true, no further prompts are answered."
+            ),
+            "default": True,
+        },
+        "config_file": {
+            "type": "string",
+            "description": (
+                "Optional path to a JSON config file with pre-answered "
+                "template prompts. Ignored when quickstart=true."
+            ),
+        },
+        "profile": {
+            "type": "string",
+            "description": "Optional Databricks CLI profile to forward to `databricks bundle init`.",
+        },
+    },
+    "additionalProperties": False,
+}
+
+_BUNDLE_VALIDATE_SCHEMA: Dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "bundle_dir": {
+            "type": "string",
+            "description": "Path to the scaffolded bundle directory (must contain databricks.yml).",
+            "default": ".",
+        },
+        "target": {
+            "type": "string",
+            "description": "Optional bundle target (e.g. dev, prod) to forward to validate.",
+        },
+        "profile": {
+            "type": "string",
+            "description": "Optional Databricks CLI profile.",
+        },
+    },
+    "required": ["bundle_dir"],
+    "additionalProperties": False,
+}
+
+_FLOW_SPEC_SCHEMA: Dict[str, Any] = {
+    "type": "object",
+    "description": "A single flow entry. Field names match FlowSpec in bundle.py.",
+    "properties": {
+        "source_format": {"type": "string", "default": "cloudFiles"},
+        "source_path": {"type": "string"},
+        "source_database": {"type": "string"},
+        "source_table": {"type": "string"},
+        "source_schema_path": {"type": "string"},
+        "kafka_bootstrap_servers": {"type": "string"},
+        "kafka_topic": {"type": "string"},
+        "starting_offsets": {"type": "string", "default": "earliest"},
+        "snapshot_format": {"type": "string", "default": "delta"},
+        "bronze_table": {"type": "string"},
+        "silver_table": {"type": "string"},
+        "data_flow_id": {"type": "string", "default": "auto"},
+        "data_flow_group": {"type": "string"},
+        "source_system": {"type": "string", "default": "auto_added"},
+        "cloudfiles_format": {"type": "string", "default": "json"},
+    },
+    "additionalProperties": False,
+}
+
+_BUNDLE_ADD_FLOW_SCHEMA: Dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "bundle_dir": {
+            "type": "string",
+            "description": "Path to the scaffolded bundle directory.",
+            "default": ".",
+        },
+        "flows": {
+            "type": "array",
+            "description": "One or more flow entries to append.",
+            "items": _FLOW_SPEC_SCHEMA,
+            "minItems": 1,
+        },
+        "onboarding_file": {
+            "type": "string",
+            "description": (
+                "Optional override for the onboarding file name. "
+                "Auto-detected from resources/variables.yml when omitted."
+            ),
+        },
+        "dry_run": {
+            "type": "boolean",
+            "description": "Show the resulting onboarding file without writing it.",
+            "default": False,
+        },
+    },
+    "required": ["bundle_dir", "flows"],
+    "additionalProperties": False,
+}
+
+_GET_TEMPLATE_SCHEMA: Dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string",
+            "description": (
+                "Template identifier of the form '<format>/<filename>', e.g. "
+                "'json/cloudfiles-onboarding.template' or "
+                "'yml/eventhub-onboarding.template.yml'. "
+                "Use the list_templates tool to discover names."
+            ),
+        },
+    },
+    "required": ["name"],
+    "additionalProperties": False,
+}
+
+_LIST_TEMPLATES_SCHEMA: Dict[str, Any] = {
+    "type": "object",
+    "properties": {},
+    "additionalProperties": False,
+}
+
+
+# ---------------------------------------------------------------------------
+# Tool handlers (pure functions; tests call these directly)
+# ---------------------------------------------------------------------------
+
+
+def _ok(payload: Any) -> List[TextContent]:
+    """Wrap a tool result as the single TextContent block MCP expects."""
+    if isinstance(payload, str):
+        return [TextContent(type="text", text=payload)]
+    return [TextContent(type="text", text=json.dumps(payload, indent=2, default=str))]
+
+
+def _handle_bundle_init(args: Dict[str, Any]) -> List[TextContent]:
+    from databricks.labs.sdp_meta.bundle import (
+        BundleInitCommand,
+        bundle_init,
+        write_quickstart_config_file,
+    )
+
+    output_dir = args.get("output_dir", ".")
+    quickstart = bool(args.get("quickstart", True))
+    profile = args.get("profile")
+    config_file = args.get("config_file")
+
+    if quickstart:
+        cfg_dir = Path(output_dir).resolve()
+        cfg_dir.mkdir(parents=True, exist_ok=True)
+        cfg_path = write_quickstart_config_file(cfg_dir)
+        cmd = BundleInitCommand(
+            output_dir=output_dir, config_file=str(cfg_path), profile=profile
+        )
+    else:
+        if not config_file:
+            raise ValueError(
+                "config_file is required when quickstart=false (the MCP server "
+                "cannot run interactive prompts)."
+            )
+        cmd = BundleInitCommand(
+            output_dir=output_dir, config_file=config_file, profile=profile
+        )
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = bundle_init(cmd)
+    return _ok({"returncode": rc, "output": buf.getvalue(), "output_dir": str(Path(output_dir).resolve())})
+
+
+def _handle_bundle_validate(args: Dict[str, Any]) -> List[TextContent]:
+    from databricks.labs.sdp_meta.bundle import BundleValidateCommand, bundle_validate
+
+    cmd = BundleValidateCommand(
+        bundle_dir=args.get("bundle_dir", "."),
+        target=args.get("target"),
+        profile=args.get("profile"),
+    )
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = bundle_validate(cmd)
+    return _ok({"returncode": rc, "output": buf.getvalue()})
+
+
+def _handle_bundle_add_flow(args: Dict[str, Any]) -> List[TextContent]:
+    from databricks.labs.sdp_meta.bundle import (
+        BundleAddFlowCommand,
+        FlowSpec,
+        bundle_add_flow,
+    )
+
+    raw_flows = args.get("flows") or []
+    if not raw_flows:
+        raise ValueError("`flows` must contain at least one entry.")
+    flows = [FlowSpec(**f) for f in raw_flows]
+    cmd = BundleAddFlowCommand(
+        bundle_dir=args.get("bundle_dir", "."),
+        onboarding_file=args.get("onboarding_file"),
+        flows=flows,
+        dry_run=bool(args.get("dry_run", False)),
+    )
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = bundle_add_flow(cmd)
+    return _ok({"returncode": rc, "output": buf.getvalue(), "flows_added": [asdict(f) for f in flows]})
+
+
+def _handle_list_templates(args: Dict[str, Any]) -> List[TextContent]:
+    del args
+    examples_dir = _locate_examples_dir()
+    names = [name for name, _ in _list_template_files()]
+    return _ok(
+        {
+            "templates": names,
+            "examples_dir": str(examples_dir) if examples_dir else None,
+            "hint": (
+                None
+                if examples_dir
+                else (
+                    f"No examples directory resolved. Set {_EXAMPLES_ENV_VAR}=<path> "
+                    "or run from a source checkout with examples/ at the repo root."
+                )
+            ),
+        }
+    )
+
+
+def _handle_get_onboarding_template(args: Dict[str, Any]) -> List[TextContent]:
+    name = args.get("name")
+    if not name:
+        raise ValueError("`name` is required.")
+    matches = [path for n, path in _list_template_files() if n == name]
+    if not matches:
+        available = [n for n, _ in _list_template_files()]
+        if not available:
+            raise FileNotFoundError(
+                f"Template '{name}' not found and no examples directory could be "
+                f"resolved. Set {_EXAMPLES_ENV_VAR}=<path> or run from a source "
+                "checkout with examples/ at the repo root."
+            )
+        raise FileNotFoundError(
+            f"Template '{name}' not found. Available: {available}"
+        )
+    text = matches[0].read_text()
+    return _ok({"name": name, "path": str(matches[0]), "content": text})
+
+
+_DISPATCH = {
+    "sdp_meta_bundle_init": (_handle_bundle_init, _BUNDLE_INIT_SCHEMA,
+                             "Scaffold a new sdp-meta DAB. With quickstart=true, "
+                             "uses developer-friendly defaults; otherwise requires "
+                             "config_file."),
+    "sdp_meta_bundle_validate": (_handle_bundle_validate, _BUNDLE_VALIDATE_SCHEMA,
+                                 "Run `databricks bundle validate` plus sdp-meta "
+                                 "sanity checks against a scaffolded bundle."),
+    "sdp_meta_bundle_add_flow": (_handle_bundle_add_flow, _BUNDLE_ADD_FLOW_SCHEMA,
+                                 "Append one or more flow entries to a scaffolded "
+                                 "bundle's onboarding file."),
+    "sdp_meta_list_templates": (_handle_list_templates, _LIST_TEMPLATES_SCHEMA,
+                                "List the names of every packaged onboarding / DQE "
+                                "/ silver-transformation template."),
+    "sdp_meta_get_onboarding_template": (_handle_get_onboarding_template, _GET_TEMPLATE_SCHEMA,
+                                         "Return the raw text of a packaged template "
+                                         "by name (see list_templates)."),
+}
+
+
+def list_tools() -> List[Tool]:
+    """Public for tests: build the Tool descriptors served over MCP."""
+    return [
+        Tool(name=name, description=desc, inputSchema=schema)
+        for name, (_, schema, desc) in _DISPATCH.items()
+    ]
+
+
+def call_tool(name: str, arguments: Optional[Dict[str, Any]]) -> List[TextContent]:
+    """Public for tests: synchronous tool dispatch."""
+    if name not in _DISPATCH:
+        raise ValueError(f"Unknown tool: {name}. Available: {list(_DISPATCH)}")
+    handler, _schema, _desc = _DISPATCH[name]
+    return handler(arguments or {})
+
+
+# ---------------------------------------------------------------------------
+# Resources (read-only template assets)
+# ---------------------------------------------------------------------------
+
+_RESOURCE_PREFIX = "sdp-meta://templates/"
+
+
+def _mime_for_template(name: str) -> str:
+    """Pick the mimetype for a template name.
+
+    ``*.template`` files contain handlebars-style ``{{ ... }}`` placeholders
+    around JSON or YAML and are therefore *not* valid JSON/YAML on their own
+    — clients that try to parse them will fail. Surface those as plain text
+    and reserve the structured mimetypes for the literal ``*.json`` /
+    ``*.yml`` resources.
+    """
+    if ".template" in name:
+        return "text/plain"
+    if name.startswith("json/"):
+        return "application/json"
+    if name.startswith("yml/"):
+        return "text/yaml"
+    return "text/plain"
+
+
+def list_resources() -> List[Resource]:
+    out: List[Resource] = []
+    examples_dir = _locate_examples_dir()
+    for name, path in _list_template_files():
+        try:
+            rel = (
+                path.relative_to(examples_dir)
+                if examples_dir is not None
+                else path.name
+            )
+        except ValueError:
+            rel = path.name
+        out.append(
+            Resource(
+                uri=AnyUrl(f"{_RESOURCE_PREFIX}{name}"),
+                name=name,
+                description=f"Packaged sdp-meta template at examples/{rel}",
+                mimeType=_mime_for_template(name),
+            )
+        )
+    return out
+
+
+def read_resource(uri: str) -> str:
+    if not uri.startswith(_RESOURCE_PREFIX):
+        raise ValueError(
+            f"Unsupported resource URI scheme: {uri}. Expected prefix {_RESOURCE_PREFIX}"
+        )
+    name = uri[len(_RESOURCE_PREFIX):]
+    matches = [path for n, path in _list_template_files() if n == name]
+    if not matches:
+        raise FileNotFoundError(f"Template not found: {name}")
+    return matches[0].read_text()
+
+
+# ---------------------------------------------------------------------------
+# Server wiring
+# ---------------------------------------------------------------------------
+
+
+def build_server(_sdp_meta) -> Server:
+    """Build (but do not run) the MCP Server with all handlers registered.
+
+    The ``sdp_meta`` argument is captured for forward-compatibility with v1
+    tools that will need a live ``WorkspaceClient``; v0 tools don't read it.
+    """
+    server: Server = Server("sdp-meta")
+
+    @server.list_tools()
+    async def _list_tools() -> List[Tool]:
+        return list_tools()
+
+    @server.call_tool()
+    async def _call_tool(name: str, arguments: Optional[Dict[str, Any]]) -> List[TextContent]:
+        return call_tool(name, arguments)
+
+    @server.list_resources()
+    async def _list_resources() -> List[Resource]:
+        return list_resources()
+
+    @server.read_resource()
+    async def _read_resource(uri: AnyUrl) -> str:
+        return read_resource(str(uri))
+
+    return server
+
+
+def run_stdio(sdp_meta) -> None:
+    """Run the MCP server over stdio. Blocks until the client disconnects."""
+    server = build_server(sdp_meta)
+
+    async def _run() -> None:
+        async with stdio_server() as (read, write):
+            await server.run(read, write, server.create_initialization_options())
+
+    asyncio.run(_run())

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,258 @@
+"""Unit tests for the sdp-meta MCP server (issue #231).
+
+These tests exercise the synchronous tool/resource dispatchers directly
+(``call_tool`` / ``read_resource``) so we don't have to spin up the asyncio
+stdio plumbing. Live workspace calls and the actual ``databricks bundle ...``
+subprocesses are mocked at the bundle.py boundary.
+"""
+
+import json
+import unittest
+from unittest.mock import MagicMock, patch
+
+try:
+    from databricks.labs.sdp_meta.mcp import server as mcp_server  # noqa: F401
+    _MCP_AVAILABLE = True
+except ImportError:  # pragma: no cover - skip path
+    _MCP_AVAILABLE = False
+
+
+@unittest.skipUnless(_MCP_AVAILABLE, "mcp extra not installed")
+class ListToolsTests(unittest.TestCase):
+    """Lock-in: the v0 tool surface."""
+
+    def test_lists_v0_tools(self):
+        names = {t.name for t in mcp_server.list_tools()}
+        self.assertEqual(
+            names,
+            {
+                "sdp_meta_bundle_init",
+                "sdp_meta_bundle_validate",
+                "sdp_meta_bundle_add_flow",
+                "sdp_meta_list_templates",
+                "sdp_meta_get_onboarding_template",
+            },
+        )
+
+    def test_every_tool_has_schema_and_description(self):
+        for tool in mcp_server.list_tools():
+            self.assertTrue(tool.description, f"{tool.name} missing description")
+            self.assertEqual(tool.inputSchema.get("type"), "object")
+
+    def test_unknown_tool_raises(self):
+        with self.assertRaisesRegex(ValueError, "Unknown tool"):
+            mcp_server.call_tool("does_not_exist", {})
+
+
+@unittest.skipUnless(_MCP_AVAILABLE, "mcp extra not installed")
+class TemplateToolTests(unittest.TestCase):
+    """list_templates + get_onboarding_template hit real packaged files."""
+
+    def test_list_templates_returns_packaged_names(self):
+        result = mcp_server.call_tool("sdp_meta_list_templates", {})
+        payload = json.loads(result[0].text)
+        names = payload["templates"]
+        self.assertIn("json/cloudfiles-onboarding.template", names)
+        self.assertIn("yml/cloudfiles-onboarding.template.yml", names)
+        # Both formats should be represented.
+        self.assertTrue(any(n.startswith("json/") for n in names))
+        self.assertTrue(any(n.startswith("yml/") for n in names))
+
+    def test_get_onboarding_template_returns_content(self):
+        result = mcp_server.call_tool(
+            "sdp_meta_get_onboarding_template",
+            {"name": "json/cloudfiles-onboarding.template"},
+        )
+        payload = json.loads(result[0].text)
+        self.assertEqual(payload["name"], "json/cloudfiles-onboarding.template")
+        # Content is real JSON template text, not empty.
+        self.assertGreater(len(payload["content"]), 100)
+
+    def test_get_onboarding_template_unknown_name_raises(self):
+        with self.assertRaisesRegex(FileNotFoundError, "Template 'no/such.json' not found"):
+            mcp_server.call_tool(
+                "sdp_meta_get_onboarding_template", {"name": "no/such.json"}
+            )
+
+    def test_get_onboarding_template_requires_name(self):
+        with self.assertRaisesRegex(ValueError, "`name` is required"):
+            mcp_server.call_tool("sdp_meta_get_onboarding_template", {})
+
+
+@unittest.skipUnless(_MCP_AVAILABLE, "mcp extra not installed")
+class BundleInitToolTests(unittest.TestCase):
+    """bundle_init delegates to bundle.bundle_init with a quickstart config."""
+
+    @patch("databricks.labs.sdp_meta.bundle.bundle_init")
+    @patch("databricks.labs.sdp_meta.bundle.write_quickstart_config_file")
+    def test_quickstart_writes_config_and_calls_bundle_init(
+        self, mock_write_cfg, mock_bundle_init
+    ):
+        mock_write_cfg.return_value = "/tmp/qs/config.json"
+        mock_bundle_init.return_value = 0
+
+        result = mcp_server.call_tool(
+            "sdp_meta_bundle_init",
+            {"output_dir": "/tmp/qs", "quickstart": True},
+        )
+        payload = json.loads(result[0].text)
+        self.assertEqual(payload["returncode"], 0)
+        # write_quickstart_config_file is called with the resolved Path.
+        mock_write_cfg.assert_called_once()
+        # bundle_init received a BundleInitCommand pointing at our config.
+        cmd = mock_bundle_init.call_args[0][0]
+        self.assertEqual(cmd.config_file, "/tmp/qs/config.json")
+        self.assertEqual(cmd.output_dir, "/tmp/qs")
+
+    @patch("databricks.labs.sdp_meta.bundle.bundle_init")
+    def test_non_quickstart_requires_config_file(self, mock_bundle_init):
+        with self.assertRaisesRegex(ValueError, "config_file is required"):
+            mcp_server.call_tool(
+                "sdp_meta_bundle_init",
+                {"output_dir": ".", "quickstart": False},
+            )
+        mock_bundle_init.assert_not_called()
+
+    @patch("databricks.labs.sdp_meta.bundle.bundle_init")
+    def test_non_quickstart_with_config_file_calls_bundle_init(self, mock_bundle_init):
+        mock_bundle_init.return_value = 0
+        mcp_server.call_tool(
+            "sdp_meta_bundle_init",
+            {
+                "output_dir": "/tmp/x",
+                "quickstart": False,
+                "config_file": "/tmp/x/cfg.json",
+                "profile": "myprofile",
+            },
+        )
+        cmd = mock_bundle_init.call_args[0][0]
+        self.assertEqual(cmd.config_file, "/tmp/x/cfg.json")
+        self.assertEqual(cmd.profile, "myprofile")
+
+
+@unittest.skipUnless(_MCP_AVAILABLE, "mcp extra not installed")
+class BundleValidateToolTests(unittest.TestCase):
+
+    @patch("databricks.labs.sdp_meta.bundle.bundle_validate")
+    def test_validate_forwards_args_and_returns_rc(self, mock_validate):
+        mock_validate.return_value = 0
+        result = mcp_server.call_tool(
+            "sdp_meta_bundle_validate",
+            {"bundle_dir": "/tmp/b", "target": "dev", "profile": "p"},
+        )
+        cmd = mock_validate.call_args[0][0]
+        self.assertEqual(cmd.bundle_dir, "/tmp/b")
+        self.assertEqual(cmd.target, "dev")
+        self.assertEqual(cmd.profile, "p")
+        payload = json.loads(result[0].text)
+        self.assertEqual(payload["returncode"], 0)
+
+    @patch("databricks.labs.sdp_meta.bundle.bundle_validate")
+    def test_validate_propagates_non_zero_rc(self, mock_validate):
+        mock_validate.return_value = 2
+        result = mcp_server.call_tool(
+            "sdp_meta_bundle_validate", {"bundle_dir": "/tmp/b"}
+        )
+        payload = json.loads(result[0].text)
+        self.assertEqual(payload["returncode"], 2)
+
+
+@unittest.skipUnless(_MCP_AVAILABLE, "mcp extra not installed")
+class BundleAddFlowToolTests(unittest.TestCase):
+
+    @patch("databricks.labs.sdp_meta.bundle.bundle_add_flow")
+    def test_add_flow_builds_flow_specs_from_dicts(self, mock_add):
+        mock_add.return_value = 0
+        flows_in = [
+            {
+                "source_format": "cloudFiles",
+                "source_path": "/Volumes/c/s/v/in",
+                "bronze_table": "raw_orders",
+                "data_flow_group": "demo",
+            }
+        ]
+        result = mcp_server.call_tool(
+            "sdp_meta_bundle_add_flow",
+            {"bundle_dir": "/tmp/b", "flows": flows_in, "dry_run": True},
+        )
+        cmd = mock_add.call_args[0][0]
+        self.assertEqual(cmd.bundle_dir, "/tmp/b")
+        self.assertTrue(cmd.dry_run)
+        self.assertEqual(len(cmd.flows), 1)
+        self.assertEqual(cmd.flows[0].source_path, "/Volumes/c/s/v/in")
+        self.assertEqual(cmd.flows[0].bronze_table, "raw_orders")
+        payload = json.loads(result[0].text)
+        self.assertEqual(payload["returncode"], 0)
+        self.assertEqual(payload["flows_added"][0]["bronze_table"], "raw_orders")
+
+    def test_add_flow_rejects_empty_flows(self):
+        with self.assertRaisesRegex(ValueError, "at least one entry"):
+            mcp_server.call_tool(
+                "sdp_meta_bundle_add_flow",
+                {"bundle_dir": "/tmp/b", "flows": []},
+            )
+
+
+@unittest.skipUnless(_MCP_AVAILABLE, "mcp extra not installed")
+class ResourceTests(unittest.TestCase):
+
+    def test_list_resources_includes_packaged_templates(self):
+        resources = mcp_server.list_resources()
+        uris = {str(r.uri) for r in resources}
+        self.assertTrue(
+            any(u.endswith("json/cloudfiles-onboarding.template") for u in uris),
+            f"missing cloudfiles template in resources: {sorted(uris)[:5]}",
+        )
+
+    def test_read_resource_returns_template_text(self):
+        text = mcp_server.read_resource(
+            "sdp-meta://templates/json/cloudfiles-onboarding.template"
+        )
+        self.assertIn("data_flow_id", text)
+
+    def test_read_resource_rejects_unknown_scheme(self):
+        with self.assertRaisesRegex(ValueError, "Unsupported resource URI"):
+            mcp_server.read_resource("https://example.com/foo")
+
+    def test_read_resource_rejects_missing_template(self):
+        with self.assertRaisesRegex(FileNotFoundError, "Template not found"):
+            mcp_server.read_resource("sdp-meta://templates/json/nope.template")
+
+
+@unittest.skipUnless(_MCP_AVAILABLE, "mcp extra not installed")
+class BuildServerTests(unittest.TestCase):
+    """Smoke-test that build_server registers handlers without crashing."""
+
+    def test_build_server_returns_named_server(self):
+        srv = mcp_server.build_server(MagicMock())
+        self.assertEqual(srv.name, "sdp-meta")
+
+
+class CliWiringTests(unittest.TestCase):
+    """The `mcp` command must be reachable from the CLI dispatcher."""
+
+    def test_mcp_command_in_mapping(self):
+        from databricks.labs.sdp_meta.cli import MAPPING
+
+        self.assertIn("mcp", MAPPING)
+
+    def test_mcp_command_in_labs_yml(self):
+        import yaml
+
+        with open("labs.yml") as f:
+            doc = yaml.safe_load(f)
+        commands = {c["name"] for c in doc["commands"]}
+        self.assertIn("mcp", commands)
+
+    def test_mcp_handler_raises_useful_error_when_extra_missing(self):
+        """If `mcp` extra is missing, the CLI handler should ImportError clearly."""
+        from databricks.labs.sdp_meta.cli import mcp as mcp_cmd
+
+        with patch.dict("sys.modules", {"databricks.labs.sdp_meta.mcp.server": None}):
+            with self.assertRaises(ImportError) as ctx:
+                mcp_cmd(MagicMock())
+            self.assertIn("mcp", str(ctx.exception).lower())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Expose sdp-meta as an MCP server

**Closes #231**
**Base:** `main` ← **Head:** `issue_231`

## Summary

Adds an opt-in MCP (Model Context Protocol) stdio server so any MCP-capable
client — Claude Code, Cursor, Claude Desktop — can drive `sdp-meta`
scaffolding and inspection without shelling out to the interactive CLI.

## Why

`sdp-meta` is currently driven via interactive CLI prompts or programmatic
Python. Neither path is callable from an LLM agent, so operators who want an
agent to scaffold or modify `sdp-meta` pipelines have no clean integration
point. This PR ships the v0 surface from the design in #231.

## What's in v0

### CLI

```bash
pip install 'databricks-labs-sdp-meta[mcp]'
databricks labs install sdp-meta
databricks labs sdp-meta mcp        # launched by the MCP host, not directly
```

The new `mcp` subcommand is wired into both `labs.yml` and the cli `MAPPING`.
A clear `ImportError` is raised if the user runs `mcp` without the extra
installed.

### MCP tools (5)

| Tool | Purpose |
|---|---|
| `sdp_meta_bundle_init` | Scaffold a new sdp-meta DAB. `quickstart=true` uses developer-friendly defaults; otherwise requires `config_file` (the server cannot run interactive prompts). |
| `sdp_meta_bundle_validate` | `databricks bundle validate` + sdp-meta sanity checks against a scaffolded bundle. |
| `sdp_meta_bundle_add_flow` | Append one or more `FlowSpec` entries to a scaffolded bundle's onboarding file. Supports `dry_run`. |
| `sdp_meta_list_templates` | List the names of every packaged onboarding / DQE / silver-transformation template. |
| `sdp_meta_get_onboarding_template` | Return the raw text of a packaged template by name. |

### MCP resources

Every shipped JSON + YAML template is exposed as a read-only resource:

```
sdp-meta://templates/<format>/<filename>
```

e.g. `sdp-meta://templates/json/cloudfiles-onboarding.template`,
`sdp-meta://templates/yml/eventhub-onboarding.template.yml`. Mimetypes are
`application/json` / `text/yaml` for literal configs and `text/plain` for
`*.template` files (handlebars placeholders aren't valid JSON/YAML).

## Architecture

```
  ┌──────────────────────┐
  │  MCP client          │
  │  (Claude Code, etc.) │
  └──────────┬───────────┘
             │ JSON-RPC over stdio
             ▼
 ┌─────────────────────────────────┐
 │  databricks labs sdp-meta mcp   │
 │  src/.../sdp_meta/mcp/server.py │
 │   • list_tools / call_tool      │
 │   • list_resources / read_*     │
 │  thin handlers ──────────────►  │
 └────────────┬────────────────────┘
              │ in-process import
              ▼
 ┌─────────────────────────────────┐
 │  bundle.py                      │
 │   • BundleInitCommand           │
 │   • BundleValidateCommand       │
 │   • BundleAddFlowCommand        │
 │   (subprocess: databricks CLI)  │
 └─────────────────────────────────┘
```

- **Transport:** stdio only (v0). Server is launched by the MCP host and is
  not network-exposed.
- **Auth:** reuses `WorkspaceClient`'s default credential chain — no new auth
  code.
- **Implementation:** lowlevel `mcp.server.Server` (Python SDK). Handlers are
  pure `_handle_*` functions so unit tests dispatch synchronously without
  asyncio.
- **Templates resolution:** `SDP_META_EXAMPLES_DIR` env override →
  `importlib.resources` against the packaged `_packaged_examples` module →
  repo-tree `examples/` walk (developer/source-checkout). `list_templates`
  surfaces an actionable hint when none resolves.

## Out of scope (deferred from #231)

- `onboard` / `deploy` tools — require a live workspace and proper
  integration testing; will land as a follow-up.
- MCP `prompts` surface.
- Network transports (SSE / HTTP).

## Files changed

```
docs/content/getting_started/mcp.md          | +99   (new — install, wiring, troubleshooting)
labs.yml                                     | +3 -1 (registers `mcp` subcommand)
setup.py                                     | +3 -1 (adds `mcp` extra: mcp>=1.0,<2.0)
src/databricks/labs/sdp_meta/cli.py          | +20   (mcp() handler + MAPPING entry)
src/databricks/labs/sdp_meta/mcp/__init__.py | +11   (new)
src/databricks/labs/sdp_meta/mcp/server.py   | +512  (new — server, handlers, schemas, resources)
tests/test_mcp_server.py                     | +258  (new)
```

## Test plan

- [x] `pytest tests/test_mcp_server.py` — covers:
  - v0 tool surface lock-in (exact set of 5 tool names)
  - every tool has a description + JSON-Schema input
  - unknown tool raises `ValueError`
  - `list_templates` / `get_onboarding_template` against real packaged files
  - `bundle_init` quickstart writes a config + calls `bundle_init`
  - `bundle_init` non-quickstart requires `config_file`
  - `bundle_validate` forwards args and propagates non-zero return codes
  - `bundle_add_flow` builds `FlowSpec` from dicts; rejects empty `flows`
  - resources: list + read template, reject unknown scheme + missing template
  - `build_server()` wires the named MCP `Server`
  - CLI wiring: `mcp` is in `MAPPING` and `labs.yml`, raises a useful
    `ImportError` when the extra is missing
- [x] `databricks labs sdp-meta mcp` from a terminal launches and waits on
      stdio (sanity check; expected behaviour)
- [ ] Wired into Claude Desktop (`claude_desktop_config.json`) and verified:
  - `tools/list` returns the 5 tools
  - `resources/list` returns packaged templates
  - `sdp_meta_bundle_init` with `quickstart=true` scaffolds a working DAB
  - `sdp_meta_bundle_validate` returns rc=0 on the scaffolded DAB
  - `sdp_meta_bundle_add_flow` appends a flow that subsequently validates

## Backwards compatibility

The `mcp` subcommand and `mcp` extra are purely additive. Existing CLI flows
(`onboard`, `deploy`, `bundle-*`) are untouched. Users who don't install the
extra never load `mcp`-related code.
