### PR TITLE
feat(cli): build-and-upload sdp-meta wheel for onboard / deploy

### DIFF
--- a/labs.yml
+++ b/labs.yml
@@ -8,8 +8,58 @@ min_python: 3.8
 commands:
   - name: onboard
     description: onboards sdp-meta configuration for bronze and silver layers
+    flags:
+      - name: build-and-upload-whl
+        description: "Build the local sdp-meta wheel, upload it to a UC volume, and use that wheel for the onboarding job. Requires UC onboarding. Invoke with the '=' syntax (e.g. --build-and-upload-whl=true) so the labs CLI string-flag parser does not consume the next CLI token as its value."
+      - name: whl-file-path
+        description: Existing wheel path to use for the onboarding job, such as /Volumes/<catalog>/<schema>/<volume>/<wheel>.whl. Mutually exclusive with --build-and-upload-whl.
+      - name: git-branch
+        description: Git branch to build a wheel from when --build-and-upload-whl is set. Defaults to the databrickslabs/dlt-meta repository when --git-url is omitted.
+      - name: git-url
+        description: Git repository URL to build a wheel from when --build-and-upload-whl is set. Accepts regular HTTPS Git URLs or pip git+ URLs.
+      - name: uc-schema
+        description: UC schema for the wheel volume when --build-and-upload-whl is set. Defaults to the prompted sdp meta schema.
+      - name: uc-schema-name
+        description: Alias for --uc-schema, matching demo launcher flag names.
+      - name: uc-volume
+        description: UC volume for the uploaded wheel when --build-and-upload-whl is set. Defaults to the wheel schema name.
+      - name: uc-volume-name
+        description: Alias for --uc-volume, matching demo launcher flag names.
+      - name: profile
+        description: Databricks CLI profile to use for authentication and the wheel upload (optional).
+      - name: pip-index-url
+        description: Forwarded to pip wheel as --index-url (optional; defaults to pip/PIP_INDEX_URL behavior).
+      - name: pip-extra-index-url
+        description: Space-separated URLs forwarded to pip wheel as --extra-index-url (optional).
+      - name: no-create-missing-uc
+        description: Do not auto-create the UC schema or volume before uploading the wheel.
   - name: deploy
     description: Deploys sdp-meta pipelines for bronze and silver layers after onboarding dataflowspecs is complete
+    flags:
+      - name: build-and-upload-whl
+        description: "Build the local sdp-meta wheel, upload it to a UC volume, and bake the wheel path into the SDP runner notebook's `%pip install` (avoids needing PyPI access on the pipeline cluster). Requires UC. Invoke with the '=' syntax (e.g. --build-and-upload-whl=true) so the labs CLI string-flag parser does not consume the next CLI token as its value."
+      - name: whl-file-path
+        description: "Existing wheel path to bake into the SDP runner notebook's `%pip install` (e.g. /Volumes/<catalog>/<schema>/<volume>/<wheel>.whl). Mutually exclusive with --build-and-upload-whl."
+      - name: git-branch
+        description: Git branch to build a wheel from when --build-and-upload-whl is set. Defaults to the databrickslabs/dlt-meta repository when --git-url is omitted.
+      - name: git-url
+        description: Git repository URL to build a wheel from when --build-and-upload-whl is set. Accepts regular HTTPS Git URLs or pip git+ URLs.
+      - name: uc-schema
+        description: UC schema for the wheel volume when --build-and-upload-whl is set. Defaults to the deployment's bronze/silver dataflowspec schema (or dlt_target_schema as a last resort).
+      - name: uc-schema-name
+        description: "Alias for --uc-schema, matching demo launcher flag names."
+      - name: uc-volume
+        description: UC volume for the uploaded wheel when --build-and-upload-whl is set. Defaults to the wheel schema name.
+      - name: uc-volume-name
+        description: "Alias for --uc-volume, matching demo launcher flag names."
+      - name: profile
+        description: Databricks CLI profile to use for authentication and the wheel upload (optional).
+      - name: pip-index-url
+        description: Forwarded to pip wheel as --index-url (optional; defaults to pip/PIP_INDEX_URL behavior).
+      - name: pip-extra-index-url
+        description: Space-separated URLs forwarded to pip wheel as --extra-index-url (optional).
+      - name: no-create-missing-uc
+        description: Do not auto-create the UC schema or volume before uploading the wheel.
   - name: bundle-init
     description: Scaffold a new sdp-meta Declarative Automation Bundle (DAB) from the packaged template (onboarding job + Lakeflow Spark Declarative Pipelines + variables + recipes)
     flags:

--- a/src/databricks/labs/sdp_meta/cli.py
+++ b/src/databricks/labs/sdp_meta/cli.py
@@ -3,7 +3,9 @@
 import logging
 import json
 import os
+import subprocess
 import sys
+import tempfile
 import uuid
 import webbrowser
 from dataclasses import dataclass
@@ -12,6 +14,7 @@ from databricks.sdk import WorkspaceClient
 from databricks.sdk.service import jobs, pipelines, compute
 from databricks.sdk.service.pipelines import PipelineLibrary, NotebookLibrary
 from databricks.sdk.core import DatabricksError
+from databricks.sdk.errors import NotFound
 from databricks.sdk.service.catalog import SchemasAPI, VolumeType
 from databricks.labs.sdp_meta import __about__
 from databricks.labs.sdp_meta.identifiers import (
@@ -89,10 +92,16 @@ def _path_to_file_uri(local_path: str) -> str:
     return f"file:{local_path}"
 
 
-# Runner notebook template for DLT pipeline
+# Runner notebook template for the SDP/DLT pipeline. The ``{dependency}``
+# placeholder is replaced at deploy time with either:
+#   * a PyPI spec, e.g. ``databricks-labs-sdp-meta==0.0.11``
+#   * a UC Volumes wheel path, e.g.
+#     ``/Volumes/<catalog>/<schema>/<volume>/databricks_labs_sdp_meta-<ver>-py3-none-any.whl``
+# The latter is the recommended path for air-gapped workspaces / private
+# preview rings without PyPI access.
 SDP_META_RUNNER_NOTEBOOK = """
 # Databricks notebook source
-# MAGIC %pip install databricks-labs-sdp-meta=={version}
+# MAGIC %pip install {dependency}
 # MAGIC dbutils.library.restartPython()
 
 # COMMAND ----------
@@ -132,6 +141,7 @@ class OnboardCommand:
     bronze_dataflowspec_path: str = None
     silver_dataflowspec_path: str = None
     update_paths: bool = True
+    sdp_meta_dependency: str = None
 
     def __post_init__(self):
         if not self.onboarding_file_path or self.onboarding_file_path == "":
@@ -220,6 +230,7 @@ class DeployCommand:
     uc_enabled: bool = False
     serverless: bool = False
     dbfs_path: str = None
+    sdp_meta_dependency: str = None
 
     def __post_init__(self):
         if self.uc_enabled and not self.uc_catalog_name:
@@ -451,11 +462,12 @@ class SDPMeta:
                 }
             )
         named_parameters = self._get_onboarding_named_parameters(cmd)
+        sdp_meta_dependency = cmd.sdp_meta_dependency or f"sdp-meta=={self.version}"
         sdp_meta_environments = [
             jobs.JobEnvironment(
                 environment_key="sdp_meta_cli_env",
                 spec=compute.Environment(client="1",
-                                         dependencies=[f"sdp-meta=={self.version}"]
+                                         dependencies=[sdp_meta_dependency]
                                          )
             )
         ]
@@ -474,14 +486,20 @@ class SDPMeta:
                         entry_point="run",
                         named_parameters=named_parameters,
                     ),
-                    libraries=[
-                        jobs.compute.Library(
-                            pypi=compute.PythonPyPiLibrary(package=f"sdp-meta=={self.version}")
-                        )
-                    ] if not cmd.serverless else None,
+                    libraries=self._onboarding_job_libraries(sdp_meta_dependency)
+                    if not cmd.serverless else None,
                 ),
             ]
         )
+
+    def _onboarding_job_libraries(self, sdp_meta_dependency: str):
+        if sdp_meta_dependency.startswith("/Volumes/") or sdp_meta_dependency.endswith(".whl"):
+            return [jobs.compute.Library(whl=sdp_meta_dependency)]
+        return [
+            jobs.compute.Library(
+                pypi=compute.PythonPyPiLibrary(package=sdp_meta_dependency)
+            )
+        ]
 
     def _get_onboarding_named_parameters(self, cmd: OnboardCommand):
         named_parameters = {
@@ -520,7 +538,12 @@ class SDPMeta:
 
     def _create_sdp_meta_pipeline(self, cmd: DeployCommand):
         """Create the SDP-META pipeline."""
-        runner_notebook_py = SDP_META_RUNNER_NOTEBOOK.format(version=self.version).encode("utf8")
+        # ``sdp_meta_dependency`` lets users replace the default PyPI install
+        # (``databricks-labs-sdp-meta==<version>``) with a UC-volume wheel
+        # path or any other pip-installable spec — see ``deploy()`` for the
+        # resolution order (CLI flag > onboarding_job_details.json > PyPI).
+        dependency = cmd.sdp_meta_dependency or f"databricks-labs-sdp-meta=={self.version}"
+        runner_notebook_py = SDP_META_RUNNER_NOTEBOOK.format(dependency=dependency).encode("utf8")
         runner_notebook_path = f"{self._install_folder()}/init_sdp_meta_pipeline.py"
         try:
             self._ws.workspace.mkdirs(self._install_folder())
@@ -942,9 +965,46 @@ class SDPMeta:
         cmd.onboarding_file_path = updated_ob_file_path
 
 
-def onboard(sdp_meta: SDPMeta):
+def onboard(sdp_meta: SDPMeta, flags: dict = None):
     logger.info("Please answer a couple of questions to for launching SDP META onboarding job")
+    flags = flags or {}
+    # The `databricks labs` CLI registers every declared flag as a pflag
+    # *string* flag (no boolean type). When users invoke a boolean-style
+    # flag like `--build-and-upload-whl --profile e2-demo`, pflag eats the
+    # next token (`--profile`) as the value, so we receive
+    # flags["build-and-upload-whl"] == "--profile". We detect that here,
+    # treat it as truthy presence, and tell the user the canonical syntax.
     cmd = sdp_meta._load_onboard_config()
+    whl_file_path = _flag_value(flags, "whl-file-path", "whl_file_path")
+    build_raw = _flag_value(flags, "build-and-upload-whl", "build_and_upload_whl")
+    build_and_upload = _is_truthy_flag(build_raw)
+    if build_and_upload and isinstance(build_raw, str) and build_raw.startswith("-"):
+        print(
+            "Warning: --build-and-upload-whl appears to have consumed the next CLI token "
+            f"({build_raw!r}) as its value, because the `databricks labs` CLI treats every "
+            "flag as a string flag. Use the '=' syntax to avoid surprises, e.g.:\n"
+            "  databricks labs sdp-meta onboard --build-and-upload-whl=true --profile=<name>"
+        )
+    if whl_file_path and build_and_upload:
+        raise ValueError("--whl-file-path and --build-and-upload-whl are mutually exclusive")
+    if whl_file_path:
+        cmd.sdp_meta_dependency = whl_file_path
+    elif build_and_upload:
+        if not cmd.uc_enabled:
+            raise ValueError("--build-and-upload-whl requires onboarding with unity catalog enabled")
+        cmd.sdp_meta_dependency = _build_and_upload_onboard_wheel(sdp_meta, cmd, flags)
+    # Only act on a real, non-empty string dependency. The isinstance() guard
+    # keeps us safe in unit tests where ``cmd`` is a MagicMock (its attributes
+    # auto-create truthy MagicMock values that aren't JSON-serializable).
+    if isinstance(cmd.sdp_meta_dependency, str) and cmd.sdp_meta_dependency:
+        print(f"Using sdp-meta dependency for onboarding job: {cmd.sdp_meta_dependency}")
+        # Persist the resolved dependency back into onboarding_job_details.json
+        # so a follow-up `databricks labs sdp-meta deploy` (run from the same
+        # working directory) auto-discovers the wheel and bakes it into the
+        # SDP runner notebook's `%pip install`. Without this, deploy would
+        # silently fall back to `databricks-labs-sdp-meta==<version>` on PyPI
+        # — exactly the failure mode that motivated this whole feature.
+        _persist_dependency_to_onboarding_json(cmd.sdp_meta_dependency)
     sdp_meta.onboard(cmd)
 
 
@@ -954,9 +1014,43 @@ def onboard_ui(sdp_meta: SDPMeta, form_data):
     sdp_meta.onboard(cmd)
 
 
-def deploy(sdp_meta: SDPMeta):
+def deploy(sdp_meta: SDPMeta, flags: dict = None):
     logger.info("Please answer a couple of questions to for launching SDP META deployment job")
+    flags = flags or {}
     cmd = sdp_meta._load_deploy_config()
+    # Resolution order for the SDP runner notebook's `%pip install` target:
+    #   1. --whl-file-path=...                         (explicit override)
+    #   2. --build-and-upload-whl=true                  (build+upload now)
+    #   3. sdp_meta_dependency from onboarding_job_details.json
+    #      (auto-set by `onboard --build-and-upload-whl=true`)
+    #   4. databricks-labs-sdp-meta==<self.version>     (PyPI default)
+    whl_file_path = _flag_value(flags, "whl-file-path", "whl_file_path")
+    build_raw = _flag_value(flags, "build-and-upload-whl", "build_and_upload_whl")
+    build_and_upload = _is_truthy_flag(build_raw)
+    if build_and_upload and isinstance(build_raw, str) and build_raw.startswith("-"):
+        print(
+            "Warning: --build-and-upload-whl appears to have consumed the next CLI token "
+            f"({build_raw!r}) as its value, because the `databricks labs` CLI treats every "
+            "flag as a string flag. Use the '=' syntax to avoid surprises, e.g.:\n"
+            "  databricks labs sdp-meta deploy --build-and-upload-whl=true --profile=<name>"
+        )
+    if whl_file_path and build_and_upload:
+        raise ValueError("--whl-file-path and --build-and-upload-whl are mutually exclusive")
+    if whl_file_path:
+        cmd.sdp_meta_dependency = whl_file_path
+    elif build_and_upload:
+        cmd.sdp_meta_dependency = _build_and_upload_deploy_wheel(sdp_meta, cmd, flags)
+    elif not (isinstance(cmd.sdp_meta_dependency, str) and cmd.sdp_meta_dependency):
+        # Auto-pickup from onboarding_job_details.json (written by onboard()
+        # when it built/uploaded a wheel). Falls through silently if missing.
+        # The isinstance() check keeps unit tests with MagicMock cmd objects
+        # from accidentally short-circuiting the auto-pickup path.
+        cmd.sdp_meta_dependency = _read_dependency_from_onboarding_json()
+    if isinstance(cmd.sdp_meta_dependency, str) and cmd.sdp_meta_dependency:
+        print(
+            "Using sdp-meta dependency for SDP runner notebook "
+            f"%pip install: {cmd.sdp_meta_dependency}"
+        )
     sdp_meta.deploy(cmd)
 
 
@@ -964,6 +1058,260 @@ def deploy_ui(sdp_meta: SDPMeta, form_data):
     logger.info("Please answer a couple of questions to for launching SDP META deployment job")
     cmd = sdp_meta._load_deploy_config_ui(form_data)
     sdp_meta.deploy(cmd)
+
+
+def _persist_dependency_to_onboarding_json(dependency: str) -> None:
+    """Best-effort write of ``sdp_meta_dependency`` into the local
+    ``onboarding_job_details.json`` file so the subsequent ``deploy`` command
+    inherits it. Silently ignored if the file is missing or unreadable —
+    this is a convenience hook, not a hard contract.
+    """
+    path = "onboarding_job_details.json"
+    if not os.path.isfile(path):
+        return
+    try:
+        with open(path) as fh:
+            data = json.load(fh)
+        if not isinstance(data, dict):
+            return
+        if data.get("sdp_meta_dependency") == dependency:
+            return
+        data["sdp_meta_dependency"] = dependency
+        with open(path, "w") as fh:
+            json.dump(data, fh, indent=4)
+    except (OSError, ValueError) as exc:
+        logger.warning("Unable to update %s with sdp_meta_dependency: %s", path, exc)
+
+
+def _read_dependency_from_onboarding_json() -> str:
+    """Return ``sdp_meta_dependency`` from local ``onboarding_job_details.json``
+    if present and non-empty, else ``None``."""
+    path = "onboarding_job_details.json"
+    if not os.path.isfile(path):
+        return None
+    try:
+        with open(path) as fh:
+            data = json.load(fh)
+    except (OSError, ValueError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    dep = data.get("sdp_meta_dependency")
+    if isinstance(dep, str) and dep.strip():
+        return dep
+    return None
+
+
+def _build_and_upload_wheel(sdp_meta: SDPMeta, *, uc_catalog: str,
+                            default_schema: str, default_volume: str = None,
+                            flags: dict) -> str:
+    """Shared wheel-build / UC-volume-upload helper for `onboard` and `deploy`.
+
+    Resolves ``uc_schema`` / ``uc_volume`` from CLI flags (with the demo
+    launcher's hyphenated *and* underscored aliases) falling back to the
+    caller-provided defaults. When ``--git-url`` / ``--git-branch`` is set
+    the wheel is built from that Git source instead of the local checkout.
+    """
+    from databricks.labs.sdp_meta.bundle import (
+        BundlePrepareWheelCommand,
+        bundle_prepare_wheel as _run,
+    )
+    uc_schema = (
+        _flag_value(flags, "uc-schema", "uc-schema-name", "uc_schema_name")
+        or default_schema
+    )
+    uc_volume = (
+        _flag_value(flags, "uc-volume", "uc-volume-name", "uc_volume_name")
+        or default_volume
+        or uc_schema
+    )
+    git_source = _git_wheel_source(flags)
+    if git_source:
+        return _build_and_upload_git_wheel(
+            sdp_meta._ws,
+            uc_catalog=uc_catalog,
+            uc_schema=uc_schema,
+            uc_volume=uc_volume,
+            source=git_source,
+            flags=flags,
+        )
+    return _run(BundlePrepareWheelCommand(
+        uc_catalog=uc_catalog,
+        uc_schema=uc_schema,
+        uc_volume=uc_volume,
+        profile=_flag_value(flags, "profile"),
+        pip_index_url=_flag_value(flags, "pip-index-url", "pip_index_url") or None,
+        pip_extra_index_urls=_split_flag_values(
+            _flag_value(flags, "pip-extra-index-url", "pip_extra_index_url")
+        ),
+        create_if_missing=not _has_flag(flags, "no-create-missing-uc", "no_create_missing_uc"),
+    ))
+
+
+def _build_and_upload_onboard_wheel(sdp_meta: SDPMeta, cmd: OnboardCommand, flags: dict) -> str:
+    """Build/upload a local wheel for regular `onboard` local-dev testing."""
+    return _build_and_upload_wheel(
+        sdp_meta,
+        uc_catalog=cmd.uc_catalog_name,
+        default_schema=cmd.sdp_meta_schema,
+        flags=flags,
+    )
+
+
+def _build_and_upload_deploy_wheel(sdp_meta: SDPMeta, cmd: DeployCommand, flags: dict) -> str:
+    """Build/upload a local wheel for `deploy` so the SDP runner notebook can
+    ``%pip install`` it instead of pulling from PyPI. Uses the deploy's UC
+    catalog and a sensible default schema (bronze > silver > target schema).
+    """
+    if not cmd.uc_catalog_name:
+        raise ValueError(
+            "--build-and-upload-whl requires deployment with unity catalog enabled"
+        )
+    default_schema = (
+        cmd.sdp_meta_bronze_schema
+        or cmd.sdp_meta_silver_schema
+        or cmd.dlt_target_schema
+    )
+    if not default_schema:
+        raise ValueError(
+            "Cannot infer a UC schema for the wheel volume; pass --uc-schema=<name> "
+            "or run `onboard --build-and-upload-whl=true ...` first so deploy can "
+            "pick the wheel up from onboarding_job_details.json."
+        )
+    return _build_and_upload_wheel(
+        sdp_meta,
+        uc_catalog=cmd.uc_catalog_name,
+        default_schema=default_schema,
+        flags=flags,
+    )
+
+
+def _git_wheel_source(flags: dict) -> str:
+    git_url = _flag_value(flags, "git-url", "git_url")
+    git_branch = _flag_value(flags, "git-branch", "git_branch")
+    if not git_url and not git_branch:
+        return None
+    if not git_url:
+        git_url = "https://github.com/databrickslabs/dlt-meta.git"
+    source = git_url if git_url.startswith("git+") else f"git+{git_url}"
+    if git_branch:
+        source = f"{source}@{git_branch}"
+    return source
+
+
+def _build_and_upload_git_wheel(ws: WorkspaceClient, *, uc_catalog: str,
+                                uc_schema: str, uc_volume: str,
+                                source: str, flags: dict) -> str:
+    """Build a wheel from ``source`` (local path or git URL) and upload it to a UC volume.
+
+    .. warning::
+        Building from an arbitrary git URL or local path causes ``pip`` to
+        execute that project's build backend (``pyproject.toml`` build hooks,
+        ``setup.py``, etc.). Treat ``--git-url <url>`` and local-path sources
+        as equivalent to running their build code: only point this at git
+        repositories and paths you trust. The downstream UC volume upload
+        also overwrites any wheel at the destination path (see the warning
+        emitted below).
+    """
+    _ensure_uc_schema_and_volume(
+        ws, uc_catalog, uc_schema, uc_volume,
+        create_if_missing=not _has_flag(flags, "no-create-missing-uc", "no_create_missing_uc"),
+    )
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        pip_cmd = [
+            sys.executable, "-m", "pip", "wheel", "--no-deps",
+            "--wheel-dir", tmp_dir,
+        ]
+        pip_index_url = _flag_value(flags, "pip-index-url", "pip_index_url")
+        if pip_index_url:
+            pip_cmd.extend(["--index-url", pip_index_url])
+        for extra in _split_flag_values(
+            _flag_value(flags, "pip-extra-index-url", "pip_extra_index_url")
+        ) or []:
+            pip_cmd.extend(["--extra-index-url", extra])
+        pip_cmd.append(source)
+        subprocess.run(pip_cmd, check=True)
+        wheels = sorted(Path(tmp_dir).glob("*.whl"))
+        if not wheels:
+            raise RuntimeError(f"pip wheel produced no wheel for {source!r}")
+        wheel = wheels[-1]
+        volume_path = f"/Volumes/{uc_catalog}/{uc_schema}/{uc_volume}/{wheel.name}"
+        existed = _volume_path_exists(ws, volume_path)
+        with wheel.open("rb") as fh:
+            ws.files.upload(file_path=volume_path, contents=fh, overwrite=True)
+        if existed:
+            print(
+                f"\n⚠️  Overwriting existing wheel at {volume_path}. "
+                "Any in-flight pipeline pinned to this exact path will pick up "
+                "the new build on its next run.\n"
+            )
+        print(f"\nUploaded wheel to:\n  {volume_path}\n")
+        return volume_path
+
+
+def _volume_path_exists(ws: WorkspaceClient, volume_path: str) -> bool:
+    """Best-effort probe for whether a UC volume file exists.
+
+    Returns ``False`` on any error (NotFound, transient SDK error, etc.) so
+    overwrite warnings never block the upload — the warning is purely
+    informational.
+    """
+    try:
+        ws.files.get_metadata(file_path=volume_path)
+        return True
+    except NotFound:
+        return False
+    except DatabricksError:
+        return False
+
+
+def _ensure_uc_schema_and_volume(ws: WorkspaceClient, uc_catalog: str,
+                                 uc_schema: str, uc_volume: str,
+                                 *, create_if_missing: bool) -> None:
+    try:
+        SchemasAPI(ws.api_client).get(full_name=f"{uc_catalog}.{uc_schema}")
+    except NotFound:
+        if not create_if_missing:
+            raise
+        SchemasAPI(ws.api_client).create(
+            catalog_name=uc_catalog,
+            name=uc_schema,
+            comment="sdp_meta wheel schema",
+        )
+    try:
+        ws.volumes.read(name=f"{uc_catalog}.{uc_schema}.{uc_volume}")
+    except NotFound:
+        if not create_if_missing:
+            raise
+        ws.volumes.create(
+            catalog_name=uc_catalog,
+            schema_name=uc_schema,
+            name=uc_volume,
+            volume_type=VolumeType.MANAGED,
+        )
+
+
+def _is_truthy_flag(value) -> bool:
+    """Return True when a labs-CLI flag should be treated as "set".
+
+    The `databricks labs` CLI exposes every declared flag as a pflag *string*
+    flag, so there is no native boolean type and an unsupplied flag arrives as
+    ``""`` (the registered default). We therefore treat the *empty* / *None*
+    case as false, the explicit falsy keywords as false, and any other
+    non-empty value as truthy presence. That keeps the canonical
+    ``--flag=true`` invocation working *and* recovers the common spillover
+    case where pflag eats the next CLI token as the value (e.g. value ends up
+    being ``"--profile"`` because the user typed
+    ``--build-and-upload-whl --profile e2-demo``).
+    """
+    if value is None or value is False:
+        return False
+    sv = str(value).strip()
+    if sv == "":
+        return False
+    if sv.lower() in ("0", "false", "no", "off"):
+        return False
+    return True
 
 
 # ---------------------------------------------------------------------------
@@ -1038,6 +1386,37 @@ def bundle_prepare_wheel(sdp_meta: SDPMeta, flags: dict = None):
     _run(_load_bundle_prepare_wheel_config(sdp_meta._wsi))
 
 
+def _flag_value(flags: dict, *names: str):
+    """Return the first non-empty value for any of the given flag spellings."""
+    for name in names:
+        value = flags.get(name)
+        if value not in (None, ""):
+            return value
+    return None
+
+
+def _has_flag(flags: dict, *names: str) -> bool:
+    """Return True only if the flag was supplied with a *truthy* value.
+
+    The `databricks labs` CLI registers every declared flag in the JSON
+    payload with its registered default (an empty string), so plain key
+    presence (`name in flags`) is *always* True for a declared flag and
+    cannot be used to detect whether the user actually passed it. We
+    therefore route through ``_is_truthy_flag``, which accepts the canonical
+    ``--flag=true`` form, treats explicit falsy keywords as false, and
+    recovers the pflag spillover case (value starts with ``-``).
+    """
+    return any(_is_truthy_flag(flags.get(name)) for name in names)
+
+
+def _split_flag_values(value):
+    if value in (None, ""):
+        return None
+    if isinstance(value, list):
+        return [str(v) for v in value if str(v)]
+    return [v for v in str(value).split() if v]
+
+
 def bundle_validate(sdp_meta: SDPMeta, flags: dict = None):
     del flags
     logger.info("Validating the sdp-meta DAB (databricks bundle validate + sanity checks).")
@@ -1092,15 +1471,20 @@ def main(raw):
         databricks_logger.setLevel(log_level.upper())
     version = __about__.__version__
     # Support both old and new product names
-    ws = WorkspaceClient(product='sdp-meta', product_version=version)
+    ws_kwargs = {"product": "sdp-meta", "product_version": version}
+    if flags.get("profile"):
+        ws_kwargs["profile"] = flags["profile"]
+    ws = WorkspaceClient(**ws_kwargs)
     sdp_meta = SDPMeta(ws)
     if command in ["onboard_ui", "deploy_ui"]:
         MAPPING[command](sdp_meta, payload)
-    elif command.startswith("bundle-"):
-        # Bundle wrappers receive `flags` so they can opt into non-interactive
-        # behavior (e.g. `bundle-init --quickstart`). Wrappers that ignore
-        # flags accept them as a `flags=None` keyword arg, which keeps the
-        # wrapper callable in tests without constructing a fake payload.
+    elif command in ("onboard", "deploy") or command.startswith("bundle-"):
+        # Flag-aware wrappers receive `flags` so they can opt into
+        # non-interactive behavior (e.g. `bundle-init --quickstart`, or
+        # `onboard --build-and-upload-whl`, or `deploy --whl-file-path=...`).
+        # Wrappers that ignore flags accept them as a `flags=None` keyword
+        # arg, which keeps the wrapper callable in tests without constructing
+        # a fake payload.
         MAPPING[command](sdp_meta, flags=flags)
     else:
         MAPPING[command](sdp_meta)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -149,6 +149,38 @@ class CliTests(unittest.TestCase):
         self.assertEqual(job.job_id, "job_id")
 
     @patch("databricks.labs.sdp_meta.cli.WorkspaceClient")
+    def test_create_onboarding_job_uses_wheel_dependency(self, mock_workspace_client):
+        mock_workspace_client.jobs.create.return_value = MagicMock(job_id="job_id")
+        sdp_meta = SDPMeta(mock_workspace_client)
+        whl_path = "/Volumes/main/sdp_meta_wheels/sdp_meta_wheels/databricks_labs_sdp_meta.whl"
+        cmd = OnboardCommand(
+            onboarding_file_path=self.onboarding_file_path,
+            onboarding_files_dir_path="tests/resources/",
+            onboard_layer="bronze",
+            env="dev",
+            import_author="John Doe",
+            version="1.0",
+            cloud="aws",
+            sdp_meta_schema="sdp_meta",
+            bronze_dataflowspec_path="tests/resources/bronze_dataflowspec",
+            silver_dataflowspec_path="tests/resources/silver_dataflowspec",
+            uc_enabled=True,
+            uc_catalog_name="uc_catalog",
+            overwrite=True,
+            bronze_dataflowspec_table="bronze_dataflowspec",
+            silver_dataflowspec_table="silver_dataflowspec",
+            sdp_meta_dependency=whl_path,
+        )
+
+        sdp_meta.create_onnboarding_job(cmd)
+
+        job_kwargs = mock_workspace_client.jobs.create.call_args.kwargs
+        self.assertEqual(
+            job_kwargs["environments"][0].spec.dependencies,
+            [whl_path],
+        )
+
+    @patch("databricks.labs.sdp_meta.cli.WorkspaceClient")
     def test_install_folder(self, mock_workspace_client):
         sdp_meta = SDPMeta(mock_workspace_client)
         sdp_meta._wsi = mock_workspace_client.return_value
@@ -169,7 +201,7 @@ class CliTests(unittest.TestCase):
         sdp_meta._my_username = MagicMock(return_value="name")
         sdp_meta._create_sdp_meta_pipeline(self.deploy_cmd)
         runner_notebook_py = SDP_META_RUNNER_NOTEBOOK.format(
-            version=__version__
+            dependency=f"databricks-labs-sdp-meta=={__version__}"
         ).encode("utf8")
         runner_notebook_path = f"{sdp_meta._install_folder()}/init_sdp_meta_pipeline.py"
         mock_workspace_client.workspace.mkdirs.assert_called_once_with(
@@ -2039,6 +2071,516 @@ class CliCommandWiringTests(unittest.TestCase):
         # every wrapper would have to remember to filter it out.
         self.assertNotIn("log_level", captured["flags"])
 
+    def test_main_uses_profile_flag_for_workspace_client(self):
+        """The non-interactive wheel-upload path accepts --profile, so the
+        shared WorkspaceClient must be built with the same profile before the
+        wrapper runs."""
+        with patch.dict(
+            "databricks.labs.sdp_meta.cli.MAPPING",
+            {"bundle-prepare-wheel": lambda sdp_meta, flags=None: None},
+            clear=False,
+        ), patch("databricks.labs.sdp_meta.cli.WorkspaceClient") as ws_cls:
+            ws_cls.return_value = MagicMock()
+            payload = json.dumps({
+                "command": "bundle-prepare-wheel",
+                "flags": {
+                    "log_level": "disabled",
+                    "profile": "DEFAULT",
+                },
+            })
+            main(payload)
+
+        ws_cls.assert_called_once_with(
+            product="sdp-meta",
+            product_version=__version__,
+            profile="DEFAULT",
+        )
+
+
+class OnboardBuildWheelFlagTests(unittest.TestCase):
+    """`onboard --build-and-upload-whl` uses the local wheel for the onboarding job."""
+
+    def _onboard_cmd(self, **overrides):
+        kwargs = dict(
+            onboarding_file_path="demo/conf/json/onboarding.template",
+            onboarding_files_dir_path="file:/demo/",
+            onboard_layer="bronze_silver",
+            env="prod",
+            import_author="author",
+            version="v1",
+            sdp_meta_schema="sdp_meta_dataflowspecs",
+            bronze_schema="sdp_meta_bronze",
+            silver_schema="sdp_meta_silver",
+            uc_enabled=True,
+            uc_catalog_name="main",
+            bronze_dataflowspec_table="bronze_dataflowspec",
+            silver_dataflowspec_table="silver_dataflowspec",
+        )
+        kwargs.update(overrides)
+        return OnboardCommand(**kwargs)
+
+    def test_onboard_build_and_upload_whl_sets_dependency(self):
+        from databricks.labs.sdp_meta.cli import onboard as cli_onboard
+
+        sdp_meta = MagicMock()
+        cmd = self._onboard_cmd()
+        sdp_meta._load_onboard_config.return_value = cmd
+        wheel_path = "/Volumes/main/sdp_meta_wheels/sdp_meta_wheels/databricks_labs_sdp_meta.whl"
+        with patch("databricks.labs.sdp_meta.bundle.bundle_prepare_wheel", return_value=wheel_path) as fake_run:
+            cli_onboard(
+                sdp_meta,
+                flags={
+                    "build-and-upload-whl": "true",
+                    "uc-schema-name": "sdp_meta_wheels",
+                    "uc-volume-name": "sdp_meta_wheels",
+                    "profile": "DEFAULT",
+                },
+            )
+
+        build_cmd = fake_run.call_args[0][0]
+        self.assertEqual(build_cmd.uc_catalog, "main")
+        self.assertEqual(build_cmd.uc_schema, "sdp_meta_wheels")
+        self.assertEqual(build_cmd.uc_volume, "sdp_meta_wheels")
+        self.assertEqual(build_cmd.profile, "DEFAULT")
+        self.assertEqual(cmd.sdp_meta_dependency, wheel_path)
+        sdp_meta.onboard.assert_called_once_with(cmd)
+
+    def test_onboard_build_and_upload_whl_accepts_normalized_flag_name(self):
+        from databricks.labs.sdp_meta.cli import onboard as cli_onboard
+
+        sdp_meta = MagicMock()
+        cmd = self._onboard_cmd()
+        sdp_meta._load_onboard_config.return_value = cmd
+        wheel_path = "/Volumes/main/sdp_meta_wheels/sdp_meta_wheels/databricks_labs_sdp_meta.whl"
+        with patch("databricks.labs.sdp_meta.bundle.bundle_prepare_wheel", return_value=wheel_path) as fake_run:
+            cli_onboard(
+                sdp_meta,
+                flags={
+                    "build_and_upload_whl": "true",
+                    "uc_schema_name": "sdp_meta_wheels",
+                    "uc_volume_name": "sdp_meta_wheels",
+                },
+            )
+
+        build_cmd = fake_run.call_args[0][0]
+        self.assertEqual(build_cmd.uc_schema, "sdp_meta_wheels")
+        self.assertEqual(build_cmd.uc_volume, "sdp_meta_wheels")
+        self.assertEqual(cmd.sdp_meta_dependency, wheel_path)
+        sdp_meta.onboard.assert_called_once_with(cmd)
+
+    def test_onboard_build_and_upload_whl_from_git_branch(self):
+        from databricks.labs.sdp_meta.cli import onboard as cli_onboard
+
+        sdp_meta = MagicMock()
+        cmd = self._onboard_cmd()
+        sdp_meta._load_onboard_config.return_value = cmd
+        wheel_path = "/Volumes/main/sdp_meta_wheels/sdp_meta_wheels/databricks_labs_sdp_meta.whl"
+        with patch("databricks.labs.sdp_meta.cli._build_and_upload_git_wheel", return_value=wheel_path) as fake_run:
+            cli_onboard(
+                sdp_meta,
+                flags={
+                    "build-and-upload-whl": "true",
+                    "git-branch": "feature/sdp-meta",
+                    "uc-schema-name": "sdp_meta_wheels",
+                    "uc-volume-name": "sdp_meta_wheels",
+                },
+            )
+
+        self.assertEqual(fake_run.call_args.kwargs["uc_catalog"], "main")
+        self.assertEqual(fake_run.call_args.kwargs["uc_schema"], "sdp_meta_wheels")
+        self.assertEqual(fake_run.call_args.kwargs["uc_volume"], "sdp_meta_wheels")
+        self.assertEqual(
+            fake_run.call_args.kwargs["source"],
+            "git+https://github.com/databrickslabs/dlt-meta.git@feature/sdp-meta",
+        )
+        self.assertEqual(cmd.sdp_meta_dependency, wheel_path)
+        sdp_meta.onboard.assert_called_once_with(cmd)
+
+    def test_onboard_build_and_upload_whl_from_git_url(self):
+        from databricks.labs.sdp_meta.cli import onboard as cli_onboard
+
+        sdp_meta = MagicMock()
+        cmd = self._onboard_cmd()
+        sdp_meta._load_onboard_config.return_value = cmd
+        wheel_path = "/Volumes/main/sdp_meta_wheels/sdp_meta_wheels/databricks_labs_sdp_meta.whl"
+        with patch("databricks.labs.sdp_meta.cli._build_and_upload_git_wheel", return_value=wheel_path) as fake_run:
+            cli_onboard(
+                sdp_meta,
+                flags={
+                    "build-and-upload-whl": "true",
+                    "git-url": "https://github.com/acme/dlt-meta.git",
+                    "git-branch": "main",
+                },
+            )
+
+        self.assertEqual(
+            fake_run.call_args.kwargs["source"],
+            "git+https://github.com/acme/dlt-meta.git@main",
+        )
+        self.assertEqual(cmd.sdp_meta_dependency, wheel_path)
+        sdp_meta.onboard.assert_called_once_with(cmd)
+
+    def test_onboard_build_and_upload_whl_requires_uc(self):
+        from databricks.labs.sdp_meta.cli import onboard as cli_onboard
+
+        sdp_meta = MagicMock()
+        sdp_meta._load_onboard_config.return_value = self._onboard_cmd(
+            uc_enabled=False,
+            uc_catalog_name=None,
+            dbfs_path="/dbfs",
+            bronze_dataflowspec_path="bronze",
+            silver_dataflowspec_path="silver",
+        )
+        with self.assertRaisesRegex(ValueError, "requires onboarding with unity catalog enabled"):
+            cli_onboard(sdp_meta, flags={"build-and-upload-whl": "true"})
+        sdp_meta.onboard.assert_not_called()
+
+    def test_onboard_whl_file_path_sets_dependency_without_building(self):
+        from databricks.labs.sdp_meta.cli import onboard as cli_onboard
+
+        sdp_meta = MagicMock()
+        cmd = self._onboard_cmd()
+        sdp_meta._load_onboard_config.return_value = cmd
+        whl_path = "/Volumes/main/sdp_meta_wheels/sdp_meta_wheels/databricks_labs_sdp_meta.whl"
+        with patch("databricks.labs.sdp_meta.bundle.bundle_prepare_wheel") as fake_run:
+            cli_onboard(sdp_meta, flags={"whl-file-path": whl_path})
+
+        fake_run.assert_not_called()
+        self.assertEqual(cmd.sdp_meta_dependency, whl_path)
+        sdp_meta.onboard.assert_called_once_with(cmd)
+
+    def test_onboard_whl_file_path_and_build_flag_are_mutually_exclusive(self):
+        from databricks.labs.sdp_meta.cli import onboard as cli_onboard
+
+        sdp_meta = MagicMock()
+        sdp_meta._load_onboard_config.return_value = self._onboard_cmd()
+        with self.assertRaisesRegex(ValueError, "mutually exclusive"):
+            cli_onboard(
+                sdp_meta,
+                flags={
+                    "whl-file-path": "/Volumes/main/sdp_meta_wheels/sdp_meta_wheels/pkg.whl",
+                    "build-and-upload-whl": "true",
+                },
+            )
+        sdp_meta.onboard.assert_not_called()
+
+    def test_onboard_build_and_upload_whl_recovers_from_pflag_spillover(self):
+        """`databricks labs sdp-meta onboard --build-and-upload-whl --profile foo`
+
+        reaches the Python wrapper as ``flags["build-and-upload-whl"] == "--profile"``
+        because the labs CLI registers every flag as a pflag *string* flag with
+        no ``NoOptDefVal`` (see cmd/labs/project/proxy.go in the databricks CLI
+        repo). The wrapper must still treat the flag as truthy and run the
+        build path; otherwise the onboarding job silently falls back to
+        ``sdp-meta==<version>``.
+        """
+        from databricks.labs.sdp_meta.cli import onboard as cli_onboard
+
+        sdp_meta = MagicMock()
+        cmd = self._onboard_cmd()
+        sdp_meta._load_onboard_config.return_value = cmd
+        wheel_path = "/Volumes/main/sdp_meta_wheels/sdp_meta_wheels/databricks_labs_sdp_meta.whl"
+        with patch("databricks.labs.sdp_meta.bundle.bundle_prepare_wheel", return_value=wheel_path) as fake_run:
+            cli_onboard(
+                sdp_meta,
+                flags={
+                    "build-and-upload-whl": "--profile",
+                    "profile": "",
+                    "uc-schema-name": "sdp_meta_wheels",
+                    "uc-volume-name": "sdp_meta_wheels",
+                },
+            )
+
+        fake_run.assert_called_once()
+        self.assertEqual(cmd.sdp_meta_dependency, wheel_path)
+        sdp_meta.onboard.assert_called_once_with(cmd)
+
+    def test_onboard_build_and_upload_whl_explicit_false_does_not_build(self):
+        from databricks.labs.sdp_meta.cli import onboard as cli_onboard
+
+        sdp_meta = MagicMock()
+        cmd = self._onboard_cmd()
+        sdp_meta._load_onboard_config.return_value = cmd
+        with patch("databricks.labs.sdp_meta.bundle.bundle_prepare_wheel") as fake_run:
+            cli_onboard(sdp_meta, flags={"build-and-upload-whl": "false"})
+
+        fake_run.assert_not_called()
+        self.assertIsNone(cmd.sdp_meta_dependency)
+        sdp_meta.onboard.assert_called_once_with(cmd)
+
+    def test_onboard_build_and_upload_whl_defaults_to_create_if_missing(self):
+        """The labs CLI puts every declared flag in the payload (with empty
+        string default), so plain key presence cannot be used to detect
+        opt-out flags like ``--no-create-missing-uc``. Without an explicit
+        truthy value we must still default to ``create_if_missing=True`` so
+        the UC schema/volume is auto-created on first use.
+        """
+        from databricks.labs.sdp_meta.cli import onboard as cli_onboard
+
+        sdp_meta = MagicMock()
+        cmd = self._onboard_cmd()
+        sdp_meta._load_onboard_config.return_value = cmd
+        wheel_path = "/Volumes/main/sdp_meta_wheels/sdp_meta_wheels/databricks_labs_sdp_meta.whl"
+        with patch("databricks.labs.sdp_meta.bundle.bundle_prepare_wheel", return_value=wheel_path) as fake_run:
+            cli_onboard(
+                sdp_meta,
+                flags={
+                    "build-and-upload-whl": "true",
+                    "uc-schema-name": "sdp_meta_wheels",
+                    "uc-volume-name": "sdp_meta_wheels",
+                    "no-create-missing-uc": "",
+                },
+            )
+
+        build_cmd = fake_run.call_args[0][0]
+        self.assertTrue(build_cmd.create_if_missing)
+
+    def test_onboard_build_and_upload_whl_honors_no_create_missing_uc_optout(self):
+        from databricks.labs.sdp_meta.cli import onboard as cli_onboard
+
+        sdp_meta = MagicMock()
+        cmd = self._onboard_cmd()
+        sdp_meta._load_onboard_config.return_value = cmd
+        wheel_path = "/Volumes/main/sdp_meta_wheels/sdp_meta_wheels/databricks_labs_sdp_meta.whl"
+        with patch("databricks.labs.sdp_meta.bundle.bundle_prepare_wheel", return_value=wheel_path) as fake_run:
+            cli_onboard(
+                sdp_meta,
+                flags={
+                    "build-and-upload-whl": "true",
+                    "uc-schema-name": "sdp_meta_wheels",
+                    "uc-volume-name": "sdp_meta_wheels",
+                    "no-create-missing-uc": "true",
+                },
+            )
+
+        build_cmd = fake_run.call_args[0][0]
+        self.assertFalse(build_cmd.create_if_missing)
+
+
+class DeployBuildWheelFlagTests(unittest.TestCase):
+    """`deploy --build-and-upload-whl` / `--whl-file-path` plumb a wheel path
+    into the SDP runner notebook's ``%pip install``, replacing the default
+    ``databricks-labs-sdp-meta==<version>`` PyPI install.
+
+    Motivation: workspaces without PyPI access (private preview rings,
+    air-gapped customer envs) fail with
+    ``Failed to run ' %pip install databricks-labs-sdp-meta==0.0.11' from
+    notebook: /Users/.../init_sdp_meta_pipeline.py``. The wheel path version
+    sidesteps that entirely.
+    """
+
+    def _deploy_cmd(self, **overrides):
+        kwargs = dict(
+            layer="bronze",
+            pipeline_name="sdp_meta_pipeline",
+            dlt_target_schema="my_dlt_schema",
+            onboard_bronze_group="bronze_group",
+            sdp_meta_bronze_schema="sdp_meta_bronze",
+            dataflowspec_bronze_table="bronze_dataflowspec",
+            uc_enabled=True,
+            uc_catalog_name="main",
+            serverless=True,
+        )
+        kwargs.update(overrides)
+        return DeployCommand(**kwargs)
+
+    def test_deploy_whl_file_path_sets_dependency_without_building(self):
+        from databricks.labs.sdp_meta.cli import deploy as cli_deploy
+
+        sdp_meta = MagicMock()
+        cmd = self._deploy_cmd()
+        sdp_meta._load_deploy_config.return_value = cmd
+        whl_path = "/Volumes/main/sdp_meta_wheels/sdp_meta_wheels/databricks_labs_sdp_meta.whl"
+        with patch("databricks.labs.sdp_meta.cli._build_and_upload_deploy_wheel") as fake_build, \
+             patch("databricks.labs.sdp_meta.cli._read_dependency_from_onboarding_json", return_value=None):
+            cli_deploy(sdp_meta, flags={"whl-file-path": whl_path})
+
+        fake_build.assert_not_called()
+        self.assertEqual(cmd.sdp_meta_dependency, whl_path)
+        sdp_meta.deploy.assert_called_once_with(cmd)
+
+    def test_deploy_build_and_upload_whl_sets_dependency(self):
+        from databricks.labs.sdp_meta.cli import deploy as cli_deploy
+
+        sdp_meta = MagicMock()
+        cmd = self._deploy_cmd()
+        sdp_meta._load_deploy_config.return_value = cmd
+        wheel_path = "/Volumes/main/sdp_meta_bronze/sdp_meta_bronze/databricks_labs_sdp_meta.whl"
+        with patch(
+            "databricks.labs.sdp_meta.cli._build_and_upload_wheel",
+            return_value=wheel_path,
+        ) as fake_build:
+            cli_deploy(
+                sdp_meta,
+                flags={
+                    "build-and-upload-whl": "true",
+                    "uc-schema-name": "sdp_meta_bronze",
+                },
+            )
+
+        fake_build.assert_called_once()
+        kwargs = fake_build.call_args.kwargs
+        self.assertEqual(kwargs["uc_catalog"], "main")
+        self.assertEqual(kwargs["default_schema"], "sdp_meta_bronze")
+        self.assertEqual(cmd.sdp_meta_dependency, wheel_path)
+        sdp_meta.deploy.assert_called_once_with(cmd)
+
+    def test_deploy_build_and_upload_whl_recovers_from_pflag_spillover(self):
+        """Same labs-CLI pflag spillover failure mode as onboard: when users
+        type ``--build-and-upload-whl --profile e2-demo`` the labs CLI's
+        string-flag parser hands the wrapper
+        ``flags["build-and-upload-whl"] == "--profile"``. Deploy must still
+        run the build path so the SDP pipeline notebook does not silently
+        fall back to a PyPI install.
+        """
+        from databricks.labs.sdp_meta.cli import deploy as cli_deploy
+
+        sdp_meta = MagicMock()
+        cmd = self._deploy_cmd()
+        sdp_meta._load_deploy_config.return_value = cmd
+        wheel_path = "/Volumes/main/sdp_meta_bronze/sdp_meta_bronze/databricks_labs_sdp_meta.whl"
+        with patch(
+            "databricks.labs.sdp_meta.cli._build_and_upload_wheel",
+            return_value=wheel_path,
+        ) as fake_build:
+            cli_deploy(
+                sdp_meta,
+                flags={
+                    "build-and-upload-whl": "--profile",
+                    "profile": "",
+                    "uc-schema-name": "sdp_meta_bronze",
+                },
+            )
+
+        fake_build.assert_called_once()
+        self.assertEqual(cmd.sdp_meta_dependency, wheel_path)
+
+    def test_deploy_inherits_dependency_from_onboarding_json(self):
+        """When neither flag is passed, deploy should auto-pick the wheel
+        path that ``onboard --build-and-upload-whl=true`` persisted into
+        ``onboarding_job_details.json``."""
+        from databricks.labs.sdp_meta.cli import deploy as cli_deploy
+
+        sdp_meta = MagicMock()
+        cmd = self._deploy_cmd()
+        sdp_meta._load_deploy_config.return_value = cmd
+        wheel_path = "/Volumes/main/sdp_meta_bronze/sdp_meta_bronze/databricks_labs_sdp_meta.whl"
+        with patch(
+            "databricks.labs.sdp_meta.cli._read_dependency_from_onboarding_json",
+            return_value=wheel_path,
+        ):
+            cli_deploy(sdp_meta, flags={})
+
+        self.assertEqual(cmd.sdp_meta_dependency, wheel_path)
+        sdp_meta.deploy.assert_called_once_with(cmd)
+
+    def test_deploy_whl_file_path_and_build_flag_are_mutually_exclusive(self):
+        from databricks.labs.sdp_meta.cli import deploy as cli_deploy
+
+        sdp_meta = MagicMock()
+        sdp_meta._load_deploy_config.return_value = self._deploy_cmd()
+        with self.assertRaisesRegex(ValueError, "mutually exclusive"):
+            cli_deploy(
+                sdp_meta,
+                flags={
+                    "whl-file-path": "/Volumes/main/x/x/pkg.whl",
+                    "build-and-upload-whl": "true",
+                },
+            )
+        sdp_meta.deploy.assert_not_called()
+
+    def test_deploy_runner_notebook_uses_dependency_when_set(self):
+        """End-to-end check that the SDP runner notebook's
+        ``%pip install`` line carries the wheel path, not the PyPI default.
+        """
+        from databricks.labs.sdp_meta.cli import SDPMeta as SDPMetaCls
+
+        ws = MagicMock()
+        sdp_meta = SDPMetaCls(ws)
+        sdp_meta._my_username = MagicMock(return_value="me")
+        sdp_meta.version = "0.0.11"
+        cmd = self._deploy_cmd(
+            sdp_meta_dependency=(
+                "/Volumes/main/sdp_meta_bronze/sdp_meta_bronze/"
+                "databricks_labs_sdp_meta-0.0.11-py3-none-any.whl"
+            ),
+        )
+        ws.pipelines.create.return_value = MagicMock(pipeline_id="p1")
+
+        sdp_meta._create_sdp_meta_pipeline(cmd)
+
+        upload_args = ws.workspace.upload.call_args
+        runner_bytes = upload_args[0][1]
+        self.assertIn(
+            b"%pip install /Volumes/main/sdp_meta_bronze/sdp_meta_bronze/"
+            b"databricks_labs_sdp_meta-0.0.11-py3-none-any.whl",
+            runner_bytes,
+        )
+        self.assertNotIn(b"databricks-labs-sdp-meta==", runner_bytes)
+
+    def test_deploy_runner_notebook_falls_back_to_pypi_when_dependency_absent(self):
+        from databricks.labs.sdp_meta.cli import SDPMeta as SDPMetaCls
+
+        ws = MagicMock()
+        sdp_meta = SDPMetaCls(ws)
+        sdp_meta._my_username = MagicMock(return_value="me")
+        sdp_meta.version = "0.0.11"
+        cmd = self._deploy_cmd()
+        ws.pipelines.create.return_value = MagicMock(pipeline_id="p1")
+
+        sdp_meta._create_sdp_meta_pipeline(cmd)
+
+        runner_bytes = ws.workspace.upload.call_args[0][1]
+        self.assertIn(b"%pip install databricks-labs-sdp-meta==0.0.11", runner_bytes)
+
+
+class OnboardPersistDependencyTests(unittest.TestCase):
+    """`onboard --build-and-upload-whl` writes the resolved wheel path back
+    into ``onboarding_job_details.json`` so a subsequent ``deploy`` (run
+    from the same working directory) auto-discovers the wheel."""
+
+    def test_onboard_persists_dependency_into_onboarding_job_details_json(self):
+        import json as _json
+        import os as _os
+        import tempfile
+
+        from databricks.labs.sdp_meta.cli import onboard as cli_onboard
+
+        sdp_meta = MagicMock()
+        cmd = OnboardCommand(
+            onboarding_file_path="demo/conf/json/onboarding.template",
+            onboarding_files_dir_path="file:/demo/",
+            onboard_layer="bronze_silver",
+            env="prod",
+            import_author="author",
+            version="v1",
+            sdp_meta_schema="sdp_meta_dataflowspecs",
+            bronze_schema="sdp_meta_bronze",
+            silver_schema="sdp_meta_silver",
+            uc_enabled=True,
+            uc_catalog_name="main",
+        )
+        sdp_meta._load_onboard_config.return_value = cmd
+        wheel_path = "/Volumes/main/x/x/databricks_labs_sdp_meta.whl"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            cwd = _os.getcwd()
+            _os.chdir(tmp)
+            try:
+                with open("onboarding_job_details.json", "w") as fh:
+                    _json.dump({"uc_enabled": True}, fh)
+                with patch(
+                    "databricks.labs.sdp_meta.bundle.bundle_prepare_wheel",
+                    return_value=wheel_path,
+                ):
+                    cli_onboard(sdp_meta, flags={"build-and-upload-whl": "true"})
+
+                with open("onboarding_job_details.json") as fh:
+                    persisted = _json.load(fh)
+                self.assertEqual(persisted["sdp_meta_dependency"], wheel_path)
+            finally:
+                _os.chdir(cwd)
+
 
 class BundleInitQuickstartFlagTests(unittest.TestCase):
     """The cli.py wrapper short-circuits the interactive prompt when
@@ -2250,3 +2792,46 @@ class LabsYmlFlagDeclarationTests(unittest.TestCase):
         self.assertIsNotNone(flags, "bundle-init missing from labs.yml")
         self.assertIn("quickstart", flags)
         self.assertIn("output-dir", flags)
+
+    def test_onboard_declares_build_and_upload_whl_flags(self):
+        flags = self._flags_for("onboard")
+        self.assertIsNotNone(flags, "onboard missing from labs.yml")
+        for flag in (
+            "build-and-upload-whl",
+            "whl-file-path",
+            "git-branch",
+            "git-url",
+            "uc-schema",
+            "uc-schema-name",
+            "uc-volume",
+            "uc-volume-name",
+            "profile",
+            "pip-index-url",
+            "pip-extra-index-url",
+            "no-create-missing-uc",
+        ):
+            self.assertIn(flag, flags)
+
+    def test_deploy_declares_build_and_upload_whl_flags(self):
+        """Deploy mirrors `onboard`'s wheel-handling flags so a follow-up
+        `deploy` can either reuse the wheel from onboarding_job_details.json
+        or build/upload a fresh one for the SDP runner notebook's
+        ``%pip install``.
+        """
+        flags = self._flags_for("deploy")
+        self.assertIsNotNone(flags, "deploy missing from labs.yml")
+        for flag in (
+            "build-and-upload-whl",
+            "whl-file-path",
+            "git-branch",
+            "git-url",
+            "uc-schema",
+            "uc-schema-name",
+            "uc-volume",
+            "uc-volume-name",
+            "profile",
+            "pip-index-url",
+            "pip-extra-index-url",
+            "no-create-missing-uc",
+        ):
+            self.assertIn(flag, flags)


### PR DESCRIPTION
# CLI `onboard` / `deploy`: build-and-upload sdp-meta wheel for workspaces without PyPI access

**Closes #295**

## Summary

`databricks labs sdp-meta onboard` and `deploy` today hard-code a PyPI install
of `databricks-labs-sdp-meta==<version>` into the generated runner notebook.
Workspaces without outbound PyPI access — private-preview rings, air-gapped
customer environments, restricted-egress networks — fail on first start with
`Failed to run '%pip install databricks-labs-sdp-meta==<ver>'`.

This PR adds a flag-driven wheel-resolution path so the CLI can ship the
wheel via a UC Volume instead of PyPI, with **no manual edits** to the runner
notebook and **no behaviour change** for existing users.

## Why

The only workaround today is the four-step manual dance documented in
[#295](https://github.com/databrickslabs/dlt-meta/issues/295):

1. `pip wheel .` locally,
2. upload to a UC Volume,
3. hand-edit `init_sdp_meta_pipeline.py` to point at the volume path,
4. re-run `deploy`.

That's brittle and undiscoverable. With this change a single
`--build-and-upload-whl=true` on `onboard` does the build, the upload,
persists the resolved path, and the follow-up `deploy` from the same working
directory picks it up automatically.

---

## What's in this PR

### New flags (declared on both `onboard` and `deploy` in `labs.yml`)

| Flag | Purpose |
|---|---|
| `--whl-file-path=<path>` | Use an existing wheel already on a UC Volume. Mutually exclusive with `--build-and-upload-whl`. |
| `--build-and-upload-whl=true` | Build the wheel locally (or from a git source) and upload it to a UC Volume as part of this command. |
| `--git-url` / `--git-branch` | With `--build-and-upload-whl`, build from a git source instead of the local checkout. Defaults to the local checkout. |
| `--uc-schema` / `--uc-schema-name` | UC schema for the wheel volume. (Aliases for compatibility with the demo launcher.) |
| `--uc-volume` / `--uc-volume-name` | UC volume for the uploaded wheel. (Aliases.) |
| `--profile` | Databricks CLI profile to use for auth and the upload. Forwarded to the shared `WorkspaceClient`. |
| `--pip-index-url` / `--pip-extra-index-url` | Forwarded to `pip wheel`. |
| `--no-create-missing-uc` | Do not auto-create the UC schema or volume before uploading. |

### Resolution order (deploy)

1. `--whl-file-path` — explicit override
2. `--build-and-upload-whl=true` — build + upload now
3. `sdp_meta_dependency` from `onboarding_job_details.json` — auto-set by a
   prior `onboard --build-and-upload-whl=true`
4. `databricks-labs-sdp-meta==<version>` — PyPI default (preserves current
   behaviour when no flag is passed)

### Behaviour

- `--whl-file-path` and `--build-and-upload-whl` are **mutually exclusive**;
  passing both is a hard error before any side effect.
- `--build-and-upload-whl=true` requires Unity Catalog (the upload target is
  a UC Volume); the command fails fast with an actionable message if UC
  isn't enabled on the target workspace.
- When `onboard --build-and-upload-whl=true` resolves a wheel path, the
  path is persisted into `onboarding_job_details.json` so a follow-up
  `deploy` from the same working directory picks it up — **no extra flag
  required**.
- The runner notebook template's `%pip install <X>` line is parameterised
  via a `{dependency}` placeholder. `<X>` is either:
  - a PyPI spec — `databricks-labs-sdp-meta==<ver>`, or
  - a UC Volumes wheel path — `/Volumes/<catalog>/<schema>/<volume>/<wheel>.whl`.
- **Default behaviour (no new flags) is unchanged.** Existing users keep
  the PyPI install path with no migration needed.

---



### Security note (git wheel build)

`pip wheel` from an arbitrary `--git-url` will execute that repository's
build backend (`setup.py` / `pyproject.toml` build hooks) on the host
running the CLI. Only point `--git-url` at sources you trust. The flag
help text on `labs.yml` says so explicitly.

### UC requirement

`--build-and-upload-whl` requires UC because the upload target is a UC
Volume. Non-UC workspaces should keep using the PyPI default, or use
`--whl-file-path` with an out-of-band-uploaded wheel on a DBFS path
they've made addressable to the pipeline cluster.

---

## Files changed

| File | LOC | Purpose |
|---|---:|---|
| `labs.yml` | +50 | Declare the 12 new flags on both `onboard` and `deploy`. |
| `src/databricks/labs/sdp_meta/cli.py` | +418 / -18 | Wheel resolution (local + git), UC schema/volume auto-create, dependency persistence, pflag-spillover recovery, runner notebook `{dependency}` parameterisation. |
| `tests/test_cli.py` | +587 / -0 | 23 new unit tests covering happy path, mutual exclusion, pflag recovery, UC requirement, git source build, persist-and-inherit between onboard and deploy, runner notebook templating. |

**Three files, +1037 / -18 lines, one squashed commit.**

### Key new symbols in `cli.py`

| Symbol | Role |
|---|---|
| `_build_and_upload_wheel` | Shared build-and-upload primitive. |
| `_build_and_upload_onboard_wheel` / `_build_and_upload_deploy_wheel` | Command-specific orchestrators (different default fallbacks for schema/volume). |
| `_build_and_upload_git_wheel` | Build path when `--git-url` is provided (shallow clone → `pip wheel`). |
| `_git_wheel_source` | Parse + normalise `--git-url` / `--git-branch` flags into a `pip`-consumable source. |
| `_ensure_uc_schema_and_volume` | Auto-create UC schema and MANAGED volume if missing (gated by `--no-create-missing-uc`). |
| `_volume_path_exists` | Pre-flight check before referencing a `--whl-file-path`. |
| `_persist_dependency_to_onboarding_json` / `_read_dependency_from_onboarding_json` | The bridge that lets `onboard` and `deploy` share the resolved path without a flag. |
| `_is_truthy_flag` / `_flag_value` / `_has_flag` / `_split_flag_values` | pflag-spillover-safe flag helpers. |

---

## Tests

23 new unit tests in `tests/test_cli.py`. All green locally
(`python -m pytest tests/test_cli.py -v`).

### Coverage matrix

| Area | Tests |
|---|---|
| **Onboard — build path** | `test_onboard_build_and_upload_whl_sets_dependency`, `_accepts_normalized_flag_name`, `_from_git_branch`, `_from_git_url`, `_requires_uc`, `_explicit_false_does_not_build`, `_defaults_to_create_if_missing`, `_honors_no_create_missing_uc_optout` (8) |
| **Onboard — whl-file-path** | `test_onboard_whl_file_path_sets_dependency_without_building`, `_and_build_flag_are_mutually_exclusive` (2) |
| **Onboard — pflag spillover** | `test_onboard_build_and_upload_whl_recovers_from_pflag_spillover` (1) |
| **Onboard — persistence** | `test_onboard_persists_dependency_into_onboarding_job_details_json` (1) |
| **Deploy — build / file path / inherit** | `test_deploy_build_and_upload_whl_sets_dependency`, `_recovers_from_pflag_spillover`, `test_deploy_whl_file_path_sets_dependency_without_building`, `_and_build_flag_are_mutually_exclusive`, `test_deploy_inherits_dependency_from_onboarding_json` (5) |
| **Runner notebook templating** | `test_deploy_runner_notebook_uses_dependency_when_set`, `_falls_back_to_pypi_when_dependency_absent`, `test_create_onboarding_job_uses_wheel_dependency` (3) |
| **Auth wiring** | `test_main_uses_profile_flag_for_workspace_client` (1) |
| **Flag declaration in `labs.yml`** | `test_onboard_declares_build_and_upload_whl_flags`, `test_deploy_declares_build_and_upload_whl_flags` (2) |

### What's NOT covered by unit tests

- **End-to-end against a real workspace.** The actual `pip wheel` + UC
  Volume upload + `pip install` from a running cluster is exercised via the
  demo launcher (`demo/launch_interactive_demo.py --build-and-upload-whl`).
- **Wheel-rebuild idempotency on the cluster side.** Re-running `deploy`
  with the same dependency path overwrites the wheel in the volume; we
  rely on the cluster's `%pip install` cache busting.

---

## Backwards compatibility

| Existing usage | Behaviour after this PR |
|---|---|
| `databricks labs sdp-meta onboard ...` (no new flags) | Unchanged — PyPI install. |
| `databricks labs sdp-meta deploy ...` (no new flags) | Unchanged — PyPI install. |
| Existing `onboarding_job_details.json` without `sdp_meta_dependency` | Treated as PyPI default. |
| User-edited runner notebooks | The `{dependency}` placeholder is rendered at template-application time; pre-existing notebooks (already rendered) are unaffected until next `deploy`. |

**No migration required.**

---

## How to verify locally

```bash
# 1. Unit tests
python -m pytest tests/test_cli.py -v

# 2. Smoke — onboard with build-and-upload against a workspace
databricks labs sdp-meta onboard \
    --profile=<your_profile> \
    --uc-catalog-name=<your_catalog> \
    --build-and-upload-whl=true \
    --uc-schema-name=<schema> \
    --uc-volume-name=sdp_meta_wheels

# 3. Smoke — deploy and confirm the runner notebook %pip install line
#    references /Volumes/... and not databricks-labs-sdp-meta==<ver>
databricks labs sdp-meta deploy \
    --profile=<your_profile> \
    --uc-catalog-name=<your_catalog>
```

The demo launcher does the same end-to-end (`demo/launch_interactive_demo.py
--build-and-upload-whl`).

---

## Checklist

- [x] Closes #295
- [x] Default behaviour unchanged (PyPI install)
- [x] 23 new unit tests, all green
- [x] Flag help text on `labs.yml` documents UC requirement and git-source security caveat
- [x] pflag-spillover edge case handled (warning + recovery)
- [x] Onboard ↔ deploy dependency persistence via `onboarding_job_details.json`
- [ ] End-to-end smoke against a private-preview / air-gapped customer workspace (out-of-band)
