### PR TITLE
Test + demo coverage for row_filter on multi-source CDC flows

### DIFF
--- a/demo/conf/json/multi-source-cdc-onboarding.template
+++ b/demo/conf/json/multi-source-cdc-onboarding.template
@@ -73,6 +73,7 @@
       "silver_table_properties": {
          "pipelines.reset.allowed": "false"
       },
+      "silver_row_filter": "ROW FILTER {uc_catalog_name}.{silver_schema}.region_filter ON (region)",
       "silver_cdc_apply_changes_flows": {
          "keys": ["customer_id"],
          "sequence_by": "operation_date",

--- a/demo/conf/yml/multi-source-cdc-onboarding.template.yml
+++ b/demo/conf/yml/multi-source-cdc-onboarding.template.yml
@@ -59,6 +59,7 @@
   silver_table: customers
   silver_table_properties:
     pipelines.reset.allowed: 'false'
+  silver_row_filter: 'ROW FILTER {uc_catalog_name}.{silver_schema}.region_filter ON (region)'
   silver_cdc_apply_changes_flows:
     keys:
     - customer_id

--- a/demo/launch_multi_source_cdc_demo.py
+++ b/demo/launch_multi_source_cdc_demo.py
@@ -198,7 +198,14 @@ class SDPMETAMultiSourceCDCDemo(SDPMETARunner):
         self.open_job_url(runner_conf, created_job)
 
     def create_msc_workflow_spec(self, runner_conf: SDPMetaRunnerConf):
-        """3-task workflow: onboarding -> sdp-meta-pipeline -> validate.
+        """4-task workflow: setup_row_filter_udf -> onboarding ->
+        sdp-meta-pipeline -> validate.
+
+        The ``setup_row_filter_udf`` task runs FIRST and creates the
+        ``region_filter`` UDF in the silver schema. UC requires the
+        filter function to exist BEFORE the pipeline mints the merged
+        streaming target table inside ``cdc_apply_changes_flows``,
+        otherwise CREATE TABLE … WITH ROW FILTER fails at table-mint.
 
         The single ``sdp-meta-pipeline`` task runs the combined
         Lakeflow Spark Declarative Pipeline that processes BOTH bronze
@@ -217,11 +224,37 @@ class SDPMETAMultiSourceCDCDemo(SDPMETARunner):
         ]
         tasks = [
             jobs.Task(
+                # Mints the row-filter UDF in the silver schema BEFORE
+                # any DLT table is created. Required because the silver
+                # target carries `silver_row_filter` and UC CREATE TABLE
+                # validates the referenced function at mint time.
+                task_key="setup_row_filter_udf",
+                description=(
+                    "Create the silver_schema.region_filter UDF that "
+                    "the merged silver customers table attaches via "
+                    "silver_row_filter"
+                ),
+                timeout_seconds=0,
+                notebook_task=jobs.NotebookTask(
+                    notebook_path=(
+                        f"{runner_conf.runners_nb_path}/runners/"
+                        "setup_row_filter_udf.py"
+                    ),
+                    base_parameters={
+                        "uc_catalog_name": runner_conf.uc_catalog_name,
+                        "silver_schema": runner_conf.silver_schema,
+                    },
+                ),
+            ),
+            jobs.Task(
                 task_key="onboarding_job",
                 description=(
                     "Onboard bronze + silver dataflow specs from the "
                     "multi-source CDC template"
                 ),
+                depends_on=[
+                    jobs.TaskDependency(task_key="setup_row_filter_udf")
+                ],
                 environment_key="sdp_meta_msc_demo_env",
                 timeout_seconds=0,
                 python_wheel_task=jobs.PythonWheelTask(

--- a/demo/notebooks/multi_source_cdc_runners/setup_row_filter_udf.py
+++ b/demo/notebooks/multi_source_cdc_runners/setup_row_filter_udf.py
@@ -1,0 +1,52 @@
+# Databricks notebook source
+# MAGIC %md
+# MAGIC # Row-filter UDF setup for the multi-source CDC demo
+# MAGIC
+# MAGIC The silver `customers` table is the merged target of three regional
+# MAGIC CDC bronze flows (US / EU / APAC). Every per-flow `select_exp`
+# MAGIC tags its rows with a constant `region` literal — so a row filter
+# MAGIC on `region` is the natural privacy boundary for the merged table.
+# MAGIC
+# MAGIC The onboarding row references this UDF via `silver_row_filter`,
+# MAGIC and DLT requires the function to exist BEFORE the pipeline first
+# MAGIC creates the target table — otherwise CREATE TABLE … WITH ROW
+# MAGIC FILTER fails. This notebook is the very first task in the demo
+# MAGIC workflow and creates the UDF so the pipeline can attach the
+# MAGIC filter when it mints the merged streaming table inside
+# MAGIC `cdc_apply_changes_flows`.
+# MAGIC
+# MAGIC Predicate: members of the `admins` account group see every row;
+# MAGIC everyone else sees only rows where `region IN ('US', 'EU')`.
+# MAGIC The APAC rows from `customers_apac_silver` therefore land in the
+# MAGIC merged silver table but are invisible to non-admin readers — a
+# MAGIC straightforward demonstration that one row filter governs ALL N
+# MAGIC flows feeding the same DLT streaming table (per the DLT mandate
+# MAGIC that row filters bind at table-creation, not at write time).
+
+# COMMAND ----------
+
+dbutils.widgets.text("uc_catalog_name", "")
+dbutils.widgets.text("silver_schema", "")
+uc_catalog_name = dbutils.widgets.get("uc_catalog_name")
+silver_schema = dbutils.widgets.get("silver_schema")
+print(f"uc_catalog_name : {uc_catalog_name}")
+print(f"silver_schema   : {silver_schema}")
+
+# COMMAND ----------
+
+spark.sql(f"CREATE SCHEMA IF NOT EXISTS {uc_catalog_name}.{silver_schema}")
+
+spark.sql(f"""
+    CREATE OR REPLACE FUNCTION
+        {uc_catalog_name}.{silver_schema}.region_filter(region STRING)
+    RETURNS BOOLEAN
+    RETURN
+        is_account_group_member('admins')
+        OR region IS NULL
+        OR region IN ('US', 'EU')
+""")
+
+print(
+    f"Created row-filter UDF: "
+    f"{uc_catalog_name}.{silver_schema}.region_filter"
+)

--- a/demo/notebooks/multi_source_cdc_runners/validate.py
+++ b/demo/notebooks/multi_source_cdc_runners/validate.py
@@ -105,5 +105,57 @@ except AssertionError:
         f"Expected: {sorted(expected_ids)} Actual: {sorted(actual_ids)}. Failed!"
     )
 
+# Row-filter attachment check: confirm the merged silver `customers`
+# table has the `region_filter` UDF attached via `silver_row_filter`.
+# We use `information_schema.row_filters` (UC system view) which
+# exposes `filter_name` (UDF FQN) and `target_columns` for every
+# filter currently bound to a table.
+#
+# This is the multi-source-CDC analogue of the cloudfiles validate
+# step at integration_tests/notebooks/cloudfile_runners/validate.py.
+# It proves the row filter survives the full path:
+#   onboarding spec (silver_row_filter)
+#     -> populate_dataflow_spec
+#     -> DataflowPipeline.cdc_apply_changes_flows
+#     -> create_streaming_table(row_filter=...)
+#     -> dp.create_streaming_table
+#     -> UC table-creation
+# breaking the chain at any step will surface here as a missing or
+# wrong filter_name.
+log_list.append(
+    "Validating silver row_filter attachment on merged customers table..."
+)
+expected_filter = f"{uc_catalog_name}.{silver_schema}.region_filter"
+expected_target_columns = ["region"]
+filters_df = spark.sql(f"""
+    SELECT filter_name, target_columns
+    FROM {uc_catalog_name}.information_schema.row_filters
+    WHERE table_catalog = '{uc_catalog_name}'
+      AND table_schema  = '{silver_schema}'
+      AND table_name    = 'customers'
+""")
+filter_rows = filters_df.collect()
+try:
+    assert len(filter_rows) == 1, (
+        f"expected exactly 1 row_filter on {silver_customers}, got "
+        f"{len(filter_rows)}"
+    )
+    actual_filter = filter_rows[0]["filter_name"]
+    actual_target = list(filter_rows[0]["target_columns"])
+    assert actual_filter == expected_filter, (
+        f"filter_name mismatch. Expected: {expected_filter} "
+        f"Actual: {actual_filter}"
+    )
+    assert actual_target == expected_target_columns, (
+        f"target_columns mismatch. Expected: {expected_target_columns} "
+        f"Actual: {actual_target}"
+    )
+    log_list.append(
+        f"row_filter attached. filter={actual_filter} "
+        f"target_columns={actual_target}. Passed!"
+    )
+except AssertionError as e:
+    log_list.append(f"row_filter attachment check FAILED: {e}")
+
 pd_df = pd.DataFrame(log_list)
 pd_df.to_csv(output_file_path)

--- a/src/databricks/labs/sdp_meta/dataflow_pipeline.py
+++ b/src/databricks/labs/sdp_meta/dataflow_pipeline.py
@@ -862,6 +862,16 @@ class DataflowPipeline:
 
         Source views are produced by :meth:`read_cdc_flows` at read-time
         and consumed here by name (``{flow.name}_cdc_view``).
+
+        Row filters: UC row filters bind at table-creation time, not at
+        write time. ``dp.create_auto_cdc_flow`` therefore has no
+        ``row_filter`` knob — every flow targeting the same streaming
+        table inherits the table-level filter. The spec-level
+        ``rowFilter`` is wired through :meth:`create_streaming_table`
+        below, so all N flows respect a single consistent policy on the
+        merged target. This is the correct shape: row filters express
+        WHO can read WHICH rows of the merged dataset, not how each
+        upstream flow should filter on write.
         """
         group = self.cdcApplyChangesFlows
         if group is None:

--- a/tests/test_dataflow_pipeline.py
+++ b/tests/test_dataflow_pipeline.py
@@ -3003,3 +3003,108 @@ class DataflowPipelineTests(SDPFrameworkTestCase):
         self.assertEqual(mock_dp.create_streaming_table.call_count, 1)
         self.assertEqual(mock_dp.create_auto_cdc_flow.call_count, 2)
         mock_dp.table.assert_not_called()
+
+    # ------------------------------------------------------------------
+    # row_filter coverage on multi-source CDC + snapshot CDC paths
+    #
+    # The ``cdc_apply_changes_flows`` and ``apply_changes_from_snapshot``
+    # methods don't carry a ``row_filter`` kwarg of their own — they
+    # delegate target-table creation to ``create_streaming_table``,
+    # which already pins ``row_filter=self._get_row_filter()``. These
+    # tests guard the inheritance: future changes that route either CDC
+    # path AROUND ``create_streaming_table`` (e.g. by inlining
+    # ``dp.create_streaming_table`` directly) would break this contract
+    # silently otherwise.
+    # ------------------------------------------------------------------
+
+    @patch("databricks.labs.sdp_meta.dataflow_pipeline.dp")
+    def test_cdc_apply_changes_flows_passes_row_filter_to_streaming_table(self, mock_dp):
+        """Multi-source CDC target table inherits the spec-level rowFilter via create_streaming_table."""
+        mock_dp.create_streaming_table = MagicMock()
+        mock_dp.create_auto_cdc_flow = MagicMock()
+        mock_dp.temporary_view = MagicMock(return_value=None)
+
+        bmap = copy.deepcopy(self.bronze_dataflow_spec_map)
+        bmap["cdcApplyChanges"] = None
+        bmap["dataQualityExpectations"] = None
+        bmap["cdcApplyChangesFlows"] = self._bronze_cdc_flows_payload()
+        bmap["rowFilter"] = self.ROW_FILTER_REGION
+        spec = BronzeDataflowSpec(**bmap)
+
+        self.spark.conf.set("spark.databricks.unityCatalog.enabled", "True")
+        self.addCleanup(self.spark.conf.unset, "spark.databricks.unityCatalog.enabled")
+        pipeline = DataflowPipeline(
+            self.spark, spec,
+            f"{spec.targetDetails['table']}_inputview", None,
+        )
+        pipeline.cdc_apply_changes_flows()
+
+        # Exactly one streaming table is created (single target — DLT
+        # mandate) and it carries the row_filter.
+        self.assertEqual(mock_dp.create_streaming_table.call_count, 1)
+        _, kwargs = mock_dp.create_streaming_table.call_args
+        self.assertEqual(kwargs["row_filter"], self.ROW_FILTER_REGION)
+
+    @patch("databricks.labs.sdp_meta.dataflow_pipeline.dp")
+    def test_cdc_apply_changes_flows_row_filter_suppressed_without_uc(self, mock_dp):
+        """With UC disabled, multi-source CDC target table receives row_filter=None even if spec.rowFilter is set."""
+        mock_dp.create_streaming_table = MagicMock()
+        mock_dp.create_auto_cdc_flow = MagicMock()
+        mock_dp.temporary_view = MagicMock(return_value=None)
+
+        bmap = copy.deepcopy(self.bronze_dataflow_spec_map)
+        bmap["cdcApplyChanges"] = None
+        bmap["dataQualityExpectations"] = None
+        bmap["cdcApplyChangesFlows"] = self._bronze_cdc_flows_payload()
+        bmap["rowFilter"] = self.ROW_FILTER_REGION
+        spec = BronzeDataflowSpec(**bmap)
+
+        self.spark.conf.set("spark.databricks.unityCatalog.enabled", "False")
+        self.addCleanup(self.spark.conf.unset, "spark.databricks.unityCatalog.enabled")
+        pipeline = DataflowPipeline(
+            self.spark, spec,
+            f"{spec.targetDetails['table']}_inputview", None,
+        )
+        pipeline.cdc_apply_changes_flows()
+
+        _, kwargs = mock_dp.create_streaming_table.call_args
+        self.assertIsNone(kwargs["row_filter"])
+
+    @patch("databricks.labs.sdp_meta.dataflow_pipeline.dp")
+    def test_apply_changes_from_snapshot_passes_row_filter_to_streaming_table(self, mock_dp):
+        """Snapshot-CDC target table inherits the spec-level rowFilter via create_streaming_table.
+
+        Parity with the multi-source CDC test above: both paths funnel
+        through ``create_streaming_table`` for the actual table mint,
+        so both must respect ``rowFilter``.
+        """
+        mock_dp.create_streaming_table = MagicMock()
+        mock_dp.create_auto_cdc_from_snapshot_flow = MagicMock()
+
+        bmap = copy.deepcopy(self.bronze_dataflow_spec_map)
+        bmap["cdcApplyChanges"] = None
+        bmap["cdcApplyChangesFlows"] = None
+        bmap["dataQualityExpectations"] = None
+        # applyChangesFromSnapshot drives the apply_changes_from_snapshot
+        # branch; the values mirror the single-source CDC shape.
+        bmap["applyChangesFromSnapshot"] = json.dumps({
+            "keys": ["customer_id"],
+            "scd_type": "1",
+        })
+        bmap["rowFilter"] = self.ROW_FILTER_DEPT
+        spec = BronzeDataflowSpec(**bmap)
+
+        self.spark.conf.set("spark.databricks.unityCatalog.enabled", "True")
+        self.addCleanup(self.spark.conf.unset, "spark.databricks.unityCatalog.enabled")
+        # apply_changes_from_snapshot needs a snapshot-version callback
+        # but doesn't care what it returns for this assertion path.
+        pipeline = DataflowPipeline(
+            self.spark, spec,
+            f"{spec.targetDetails['table']}_inputview", None,
+            next_snapshot_and_version=lambda *_a, **_k: None,
+        )
+        pipeline.apply_changes_from_snapshot()
+
+        self.assertEqual(mock_dp.create_streaming_table.call_count, 1)
+        _, kwargs = mock_dp.create_streaming_table.call_args
+        self.assertEqual(kwargs["row_filter"], self.ROW_FILTER_DEPT)


### PR DESCRIPTION
Multi-source CDC inherits row_filter via create_streaming_table (PR #305); no functional source code changes. Adds: docstring on cdc_apply_changes_flows, 3 regression tests, silver_row_filter in demo template, UDF setup task, and information_schema.row_filters assertion in validate.