### PR TITLE
v0.0.10 → v0.0.11 backward compatibility (#289)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,13 @@ test-dab/
 demo_runs/
 demo_runs_*/
 
+# Backward-compat integration test artifacts. The git-ref-based wheel
+# builder (integration_tests/wheel_builder.py) checks worktrees out
+# under .bc_wheels/worktrees/ and copies built wheels into
+# .bc_wheels/dist/ for the Phase 1 / Phase 2 wheel swap. Per-developer
+# artifacts; never checked in.
+.bc_wheels/
+
 # Distribution / packaging
 .Python
 build/

--- a/compat/README.md
+++ b/compat/README.md
@@ -4,8 +4,17 @@
 
 ## Overview
 
-This package (`dlt-meta`) is maintained for backwards compatibility with existing installations.
-All functionality has been moved to the `databricks-labs-sdp-meta` package.
+This package (`dlt-meta`) is maintained for backwards compatibility with existing v0.0.10 installations. All functionality has been moved to the `databricks-labs-sdp-meta` package.
+
+It supports three independent customer surfaces from v0.0.10:
+
+| Surface | What it covers |
+|---|---|
+| `from dlt_meta import …` | Flat re-exports of every v0.0.10 public symbol |
+| `from dlt_meta.cli import DLTMeta` | Renamed-class compatibility (DLTMeta → SDPMeta) |
+| `from src.<module> import …` | Legacy `src.*` import paths used by every v0.0.10 demo notebook |
+
+All three emit a one-time `DeprecationWarning` on first use and are scheduled for removal in v0.1.0.
 
 ## Migration Guide
 
@@ -37,27 +46,64 @@ databricks labs sdp-meta deploy
 
 ### Python Imports
 
-The old imports will continue to work with deprecation warnings:
+The old imports continue to work with deprecation warnings:
 
 ```python
 # Old (deprecated, but still works)
 from dlt_meta.cli import DLTMeta
+from dlt_meta import DataflowPipeline
+
+# Legacy v0.0.10 src.* imports (still work via .pth shim, removed in v0.1.0)
+from src.dataflow_pipeline import DataflowPipeline
+from src.cli import DLTMeta
 
 # New (recommended)
 from databricks.labs.sdp_meta.cli import SDPMeta
-from databricks.labs.sdp_meta import DataflowPipeline
+from databricks.labs.sdp_meta.dataflow_pipeline import DataflowPipeline
 ```
 
 ### Configuration Files
 
-Your existing configuration files (JSON/YAML) will continue to work without changes.
-Field names like `dlt_meta_schema`, `dlt_meta_bronze_schema`, etc. are still supported.
+Your existing configuration files (JSON/YAML) will continue to work without changes. Field names like `dlt_meta_schema`, `dlt_meta_bronze_schema`, etc. are still supported.
 
-## Deprecation Timeline
+## How the `src.*` shim works
 
-- **Current**: Both packages work, `dlt-meta` shows deprecation warnings
-- **Future**: `dlt-meta` package will be removed (announcement will be made)
+v0.0.10 published the framework as a top-level Python package literally named `src` (via `find_packages(include=["src", ...])` in `setup.py`). v0.0.11 dropped that layout in favour of `databricks.labs.sdp_meta.*`. To keep v0.0.10 customer notebooks running unchanged, this compat package:
+
+1. Ships a `dlt_meta.pth` file at the wheel's `site-packages` root. CPython's `site.py` runs every line beginning with `import` in `*.pth` files at interpreter startup, so the line `import os; os.environ.get('SDP_META_DISABLE_SRC_ALIAS') == '1' or __import__('dlt_meta')` triggers `dlt_meta`'s package init **before** any user code, including before notebook cell 1.
+2. `dlt_meta.__init__` registers `src` in `sys.modules` as an alias for itself, and each `src.<sub>` (e.g. `src.dataflow_pipeline`) as a `_LazyAliasModule` proxy for the corresponding `databricks.labs.sdp_meta.<sub>`.
+3. The proxy emits a `DeprecationWarning` once per process on first attribute access — `stacklevel` is tuned so the warning surfaces at the customer's notebook line, not somewhere inside this package.
+
+If `pyspark.pipelines` (the Lakeflow SDP runtime) isn't available — e.g. on a legacy DBR runtime — the registration falls back to a stub module whose `__getattr__` raises a clear `Lakeflow SDP runtime` error. This replaces the silent-swallow `ImportError: cannot import name 'DataflowPipeline'` that the old shim produced and points the customer at the actual cause (wrong DBR).
+
+## Disabling the shim
+
+Set `SDP_META_DISABLE_SRC_ALIAS=1` before any `dlt_meta` import to skip the `src.*` aliasing **and** suppress the package-level deprecation warning:
+
+```bash
+export SDP_META_DISABLE_SRC_ALIAS=1
+```
+
+Use this when you have your own `src/` package on `sys.path` that would conflict with the alias.
+
+## Editable-install caveat for maintainers
+
+`pip install -e ./compat` does **not** install the `.pth` file — `data_files` in setuptools is honoured for wheel installs only. Maintainers running editable installs need to either:
+
+- explicitly `import dlt_meta` in their notebook before any `from src.* import …` line, or
+- build and install the wheel: `python -m pip wheel ./compat -w dist/ && pip install dist/dlt_meta-*.whl`.
+
+CI verifies the wheel path; the editable-install path is a dev-loop convenience only.
+
+## Removal Timeline
+
+| Version | Behaviour |
+|---|---|
+| v0.0.11 | All compat surfaces work; emit `DeprecationWarning`s. |
+| v0.0.12 → v0.0.x | Same. No behaviour change. |
+| v0.1.0 | `src.*` shim removed. `compat/dlt_meta.pth` removed. `from src.* import …` returns to raising `ModuleNotFoundError`. |
+| Future | `dlt-meta` package removed entirely. Advance notice will be provided. |
 
 ## Support
 
-For issues, please file them at: https://github.com/databrickslabs/sdp-meta/issues
+For issues, please file them at: https://github.com/databrickslabs/dlt-meta/issues

--- a/compat/dlt_meta.pth
+++ b/compat/dlt_meta.pth
@@ -1,0 +1,1 @@
+import os; os.environ.get('SDP_META_DISABLE_SRC_ALIAS') == '1' or __import__('dlt_meta')

--- a/compat/dlt_meta/__init__.py
+++ b/compat/dlt_meta/__init__.py
@@ -1,53 +1,453 @@
 """DLT-META Compatibility Package.
 
-DEPRECATED: This package is a compatibility wrapper for databricks-labs-sdp-meta.
-Please migrate to using databricks.labs.sdp_meta directly.
+DEPRECATED: This package is a compatibility wrapper for
+``databricks-labs-sdp-meta``. Please migrate to
+``databricks.labs.sdp_meta`` directly.
 
-All imports from this package are re-exported from databricks.labs.sdp_meta with deprecation warnings.
+This module wires three independent compatibility surfaces:
+
+1. **Flat re-exports** under the ``dlt_meta.<name>`` namespace
+   (``from dlt_meta import DataflowPipeline`` etc.). Names with v0.0.10
+   spellings are aliased to their v0.0.11 counterparts (``DLTMeta`` →
+   ``SDPMeta``, ``DLT_META_RUNNER_NOTEBOOK`` → ``SDP_META_RUNNER_NOTEBOOK``).
+2. **``src.*`` aliasing** for v0.0.10 customer notebooks that still type
+   ``from src.dataflow_pipeline import DataflowPipeline``. Module objects
+   are registered in :data:`sys.modules` so the legacy import path
+   resolves without a `ModuleNotFoundError`. See
+   :func:`_register_src_aliases`.
+3. **Actionable runtime errors** when the underlying SDP runtime
+   (``pyspark.pipelines``) is unavailable: instead of silently swallowing
+   the import failure (which leaves callers staring at confusing
+   ``ImportError: cannot import name 'DataflowPipeline'`` messages), each
+   submodule that fails on the optional-runtime predicate is replaced by
+   a stub that raises a clear ``Lakeflow SDP runtime`` error on any
+   attribute access.
+
+Removal timeline: every alias here is scheduled for removal in v0.1.0.
 """
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import types
 import warnings
 
-# Issue deprecation warning on import
-warnings.warn(
-    "The 'dlt_meta' package is deprecated and will be removed in a future version. "
-    "Please migrate to 'databricks.labs.sdp_meta' (pip install databricks-labs-sdp-meta). "
-    "See https://databrickslabs.github.io/sdp-meta/ for migration guide.",
-    DeprecationWarning,
-    stacklevel=2
+
+# ---------------------------------------------------------------------------
+# Opt-out env var
+#
+# Customers with their own ``src/`` package on ``sys.path`` (rare but real
+# for monorepo-style notebook layouts) can disable the ``src.*`` aliasing
+# AND the package-level deprecation warning by exporting
+# ``SDP_META_DISABLE_SRC_ALIAS=1`` before any import. The ``.pth`` shipped
+# alongside this package also honours the same env var so opting out of
+# the aliasing also opts out of the auto-load.
+# ---------------------------------------------------------------------------
+_OPT_OUT_ENV = "SDP_META_DISABLE_SRC_ALIAS"
+_DISABLED = os.environ.get(_OPT_OUT_ENV) == "1"
+
+
+# ---------------------------------------------------------------------------
+# Submodule alias map
+#
+# Pinned to the v0.0.10 ``src/*.py`` set
+# (``git ls-tree v0.0.10 -- 'src/*.py'``). Tests in
+# ``tests/test_compat_src_aliases.py`` assert this list matches the
+# v0.0.10 publication so future edits don't drift.
+# ---------------------------------------------------------------------------
+_SRC_SUBMODULES = (
+    "dataflow_pipeline",
+    "dataflow_spec",
+    "onboard_dataflowspec",
+    "pipeline_readers",
+    "pipeline_writers",
+    "install",
+    "cli",
+    "config",
+    "metastore_ops",
+    "uninstall",
+    "__main__",
+    "__about__",
 )
 
-# Re-export everything from databricks.labs.sdp_meta
-# This maintains full backwards compatibility
-try:
-    from databricks.labs.sdp_meta import *  # noqa: F401, F403
-    from databricks.labs.sdp_meta.cli import (  # noqa: F401
-        SDPMeta as DLTMeta,  # Alias for backwards compatibility
-        OnboardCommand,
-        DeployCommand,
-        SDP_META_RUNNER_NOTEBOOK as DLT_META_RUNNER_NOTEBOOK,
-        onboard,
-        deploy,
-        main,
+
+# ---------------------------------------------------------------------------
+# Optional-runtime stub: actionable error when pyspark.pipelines is missing
+# ---------------------------------------------------------------------------
+def _optional_runtime_import_error(exc: BaseException) -> bool:
+    """Return ``True`` if *exc* is the SDP-runtime-missing failure mode.
+
+    ``databricks.labs.sdp_meta.dataflow_pipeline`` does
+    ``from pyspark import pipelines as dp`` at module load. On a runtime
+    that doesn't ship Lakeflow SDP yet, that line surfaces in three
+    distinct shapes depending on what's wrong with the platform's
+    ``pyspark.pipelines`` package:
+
+    - **No pyspark at all** → ``ModuleNotFoundError`` with
+      ``exc.name == 'pyspark.pipelines'`` (or ``'pipelines'`` on some
+      runtimes).
+    - **pyspark exists, no Lakeflow SDP** → bare ``ImportError`` with
+      message ``cannot import name 'pipelines' from 'pyspark'`` and
+      ``name`` unset.
+    - **Buggy PySpark on a runtime that has the package but lacks
+      ``dlt``** → ``TypeError`` from inside
+      ``pyspark.errors.utils.get_error_message`` while PySpark is
+      raising its own ``PIPELINES_NOT_SUPPORTED`` exception. The
+      runtime's ``pyspark/pipelines/__init__.py`` first tries
+      ``from dlt import *``; when that ``ModuleNotFoundError`` falls
+      through, the next line is
+      ``raise PySparkException(errorClass="PIPELINES_NOT_SUPPORTED")``,
+      and the exception constructor crashes on
+      ``set(messageParameters)`` because ``messageParameters`` is
+      ``None``. This is technically a PySpark bug -- the
+      ``PIPELINES_NOT_SUPPORTED`` errorClass entry on that runtime
+      requires substitutions PySpark didn't supply. We can't fix
+      that, but we can recognize the failure SHAPE: any exception
+      whose traceback passes through ``pyspark/pipelines/`` is the
+      Lakeflow-SDP-missing case from our point of view, regardless
+      of which specific ``Exception`` subclass got raised.
+
+    All three are treated as recoverable (register a stub that raises
+    a clear error on access) and everything else is re-raised.
+    """
+    if isinstance(exc, ModuleNotFoundError) and exc.name in {
+        "pyspark.pipelines",
+        "pipelines",
+    }:
+        return True
+    if isinstance(exc, ImportError):
+        msg = str(exc)
+        if "pipelines" in msg and "pyspark" in msg:
+            return True
+    # Walk the traceback chain (current + __cause__ + __context__).
+    # If any frame is inside ``pyspark/pipelines/``, this is the
+    # buggy-error-formatter / PIPELINES_NOT_SUPPORTED case described
+    # above. ``os.sep`` keeps the check working on Windows file
+    # separators too, though serverless DLT is always Linux.
+    needle = f"pyspark{os.sep}pipelines{os.sep}"
+    seen: set[int] = set()
+    cursor: BaseException | None = exc
+    while cursor is not None and id(cursor) not in seen:
+        seen.add(id(cursor))
+        tb = cursor.__traceback__
+        while tb is not None:
+            filename = tb.tb_frame.f_code.co_filename
+            if needle in filename or "pyspark/pipelines/" in filename:
+                return True
+            tb = tb.tb_next
+        cursor = cursor.__cause__ or cursor.__context__
+    return False
+
+
+def _make_stub_module(qualified_name: str, original_error: str) -> types.ModuleType:
+    """Build a sentinel module that raises a clear error on any access.
+
+    The error message tells the customer exactly what's wrong (Lakeflow
+    SDP runtime is missing) and includes the original exception message
+    so they can self-diagnose runtime mismatches.
+
+    Dunder-introspection contract
+    -----------------------------
+    Tools that walk ``sys.modules`` (IPython's autoreload reliability
+    hook, ``inspect.getmodule``, importlib metadata scanners, etc.)
+    routinely do ``getattr(mod, "__file__", "")`` and similar dunder
+    probes on every loaded module. If our ``__getattr__`` raises
+    ``ImportError`` for those probes, the introspecting tool's own
+    error-formatting path may also probe a dunder, and the same
+    ``ImportError`` re-fires inside the traceback formatter -- which
+    is exactly what produced the multi-page "Unexpected exception
+    formatting exception. Falling back to standard exception" cascade
+    after every cell of ``validate_phase2.py`` on serverless DLT.
+
+    Two-part fix:
+    1. Set ``mod.__file__`` to a self-describing sentinel string so
+       the most common probe (``getattr(mod, "__file__", default)``)
+       returns the sentinel directly without ever calling
+       ``__getattr__``.
+    2. Make ``__getattr__`` raise ``AttributeError`` (PEP 562
+       compliant) for any dunder name. Introspection tools handle
+       ``AttributeError`` correctly and fall back to their defaults.
+       Real attribute access like ``src.dataflow_pipeline.DataflowPipeline``
+       still gets the actionable ``ImportError`` it needs.
+    """
+    mod = types.ModuleType(qualified_name)
+    mod.__doc__ = (
+        f"Stub for {qualified_name}: the Lakeflow SDP runtime "
+        f"(pyspark.pipelines) is not available in this Python environment."
     )
-    from databricks.labs.sdp_meta.dataflow_pipeline import DataflowPipeline  # noqa: F401
-    from databricks.labs.sdp_meta.dataflow_spec import BronzeDataflowSpec, SilverDataflowSpec  # noqa: F401
-    from databricks.labs.sdp_meta.onboard_dataflowspec import OnboardDataflowspec  # noqa: F401
-    from databricks.labs.sdp_meta.pipeline_readers import PipelineReaders  # noqa: F401
-    from databricks.labs.sdp_meta.pipeline_writers import AppendFlowWriter, DLTSinkWriter  # noqa: F401
-    from databricks.labs.sdp_meta.install import WorkspaceInstaller  # noqa: F401
-    from databricks.labs.sdp_meta.config import WorkspaceConfig  # noqa: F401
-except ImportError:
-    # If databricks.labs.sdp_meta module not available, this is being run standalone
-    pass
+    # Self-describing sentinel: shows up if anything logs the path.
+    mod.__file__ = f"<sdp-meta compat stub for {qualified_name}>"
+
+    def _raise() -> None:
+        raise ImportError(
+            f"{qualified_name} requires the Lakeflow SDP runtime "
+            f"(pyspark.pipelines) which is not installed. Run on a "
+            f"Databricks Runtime that ships Lakeflow SDP, or use the "
+            f"v0.0.10 dlt-meta wheel if you must stay on legacy DLT. "
+            f"Original error: {original_error}"
+        )
+
+    def __getattr__(name: str):  # noqa: N807 (module-level dunder)
+        # PEP 562: raising ``AttributeError`` (not ``ImportError``)
+        # for dunders lets ``getattr(mod, dunder, default)`` in
+        # introspection paths return the default cleanly.
+        if name.startswith("__") and name.endswith("__"):
+            raise AttributeError(name)
+        _raise()
+
+    mod.__getattr__ = __getattr__  # type: ignore[attr-defined]
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Lazy alias module: emits DeprecationWarning per-attribute, with the
+# warning's stack pointing at the customer's code line (stacklevel=2),
+# not at this module's registration walk.
+# ---------------------------------------------------------------------------
+_WARNED_ALIASES: set[str] = set()
+
+
+def _warn_src_alias_once(alias: str) -> None:
+    if alias in _WARNED_ALIASES:
+        return
+    _WARNED_ALIASES.add(alias)
+    submodule = alias.split(".", 1)[1] if "." in alias else ""
+    canonical = (
+        f"databricks.labs.sdp_meta.{submodule}"
+        if submodule
+        else "databricks.labs.sdp_meta"
+    )
+    warnings.warn(
+        f"'{alias}' is a v0.0.10 compatibility alias and will be removed "
+        f"in v0.1.0. Migrate to 'from {canonical} import …' or "
+        f"'from dlt_meta import …'. See "
+        f"docs/content/getting_started/sdp_meta_renaming.md.",
+        DeprecationWarning,
+        stacklevel=4,
+    )
+
+
+class _LazyAliasModule(types.ModuleType):
+    """Module proxy: forwards attribute access to *target*, warns once per alias.
+
+    Why a proxy instead of plain ``sys.modules[alias] = target``? Two
+    reasons:
+
+    - **Correct ``stacklevel``** — emitting the deprecation warning lazily
+      from ``__getattr__`` lets us set ``stacklevel=4`` so the warning
+      surfaces at the customer's notebook line, not somewhere inside this
+      package's eager-registration walk.
+    - **No-op when not used** — a v0.0.10 customer who happened to upgrade
+      and rewrite their imports doesn't get spammed by warnings just
+      because the ``.pth`` ran ``import dlt_meta`` at interpreter startup.
+    """
+
+    def __init__(self, alias: str, target: types.ModuleType) -> None:
+        super().__init__(alias)
+        self._alias = alias
+        self._target = target
+        # Mirror the target's package metadata so isinstance / __path__ /
+        # __file__ checks behave like the real module.
+        self.__doc__ = getattr(target, "__doc__", None)
+        self.__file__ = getattr(target, "__file__", None)
+        self.__loader__ = getattr(target, "__loader__", None)
+        self.__spec__ = getattr(target, "__spec__", None)
+        if hasattr(target, "__path__"):
+            self.__path__ = target.__path__  # type: ignore[attr-defined]
+
+    def __getattr__(self, name: str):  # only called when not found on self
+        _warn_src_alias_once(self._alias)
+        return getattr(self._target, name)
+
+    def __dir__(self):
+        return dir(self._target)
+
+
+# ---------------------------------------------------------------------------
+# 1. Flat re-exports under dlt_meta.<name>
+#
+# Routed through the same _make_stub_module mechanism so that on a
+# non-SDP runtime, ``from dlt_meta import DataflowPipeline`` raises a
+# clear ``Lakeflow SDP runtime`` error instead of the silent-swallow
+# behaviour the previous shim had (``except ImportError: pass`` left
+# every symbol unbound and produced ``ImportError: cannot import name
+# 'DataflowPipeline' from 'dlt_meta'``, which masks the real cause).
+# ---------------------------------------------------------------------------
+# Tuple of (target_qualname, [(source_attr, alias_or_none)...]).
+# ``alias_or_none`` is the v0.0.10 name (``DLTMeta``); when ``None``,
+# the source attr is bound under its own name. Driven by a data
+# structure rather than a literal block of imports so the corresponding
+# stub-binding loop in ``_flat_reexport_or_stub`` can re-use the same
+# name set without duplication.
+_FLAT_REEXPORTS: tuple[tuple[str, tuple[tuple[str, str | None], ...]], ...] = (
+    ("databricks.labs.sdp_meta.cli", (
+        ("SDPMeta", "DLTMeta"),
+        ("OnboardCommand", None),
+        ("DeployCommand", None),
+        ("SDP_META_RUNNER_NOTEBOOK", "DLT_META_RUNNER_NOTEBOOK"),
+        ("onboard", None),
+        ("deploy", None),
+        ("main", None),
+    )),
+    ("databricks.labs.sdp_meta.dataflow_pipeline", (
+        ("DataflowPipeline", None),
+    )),
+    ("databricks.labs.sdp_meta.dataflow_spec", (
+        ("BronzeDataflowSpec", None),
+        ("SilverDataflowSpec", None),
+        ("DataflowSpecUtils", None),
+        ("DLTSink", None),
+    )),
+    ("databricks.labs.sdp_meta.onboard_dataflowspec", (
+        ("OnboardDataflowspec", None),
+    )),
+    ("databricks.labs.sdp_meta.pipeline_readers", (
+        ("PipelineReaders", None),
+    )),
+    ("databricks.labs.sdp_meta.pipeline_writers", (
+        ("AppendFlowWriter", None),
+        ("DLTSinkWriter", None),
+    )),
+    ("databricks.labs.sdp_meta.install", (
+        ("WorkspaceInstaller", None),
+    )),
+    ("databricks.labs.sdp_meta.config", (
+        ("WorkspaceConfig", None),
+    )),
+    ("databricks.labs.sdp_meta.metastore_ops", (
+        ("DeltaPipelinesMetaStoreOps", None),
+        ("DeltaPipelinesInternalTableOps", None),
+    )),
+)
+
+
+def _flat_reexport_or_stub() -> None:
+    """Bind v0.0.10 names on this package, with stub fallback."""
+    module_globals = sys.modules[__name__].__dict__
+    try:
+        for target_qualname, names in _FLAT_REEXPORTS:
+            target_module = importlib.import_module(target_qualname)
+            for source_name, alias in names:
+                bound_name = alias or source_name
+                module_globals[bound_name] = getattr(target_module, source_name)
+    except Exception as exc:  # noqa: BLE001 (broad-except is intentional)
+        # Catching ``Exception`` rather than just ``ImportError`` is
+        # deliberate. Some Databricks runtimes raise non-Import
+        # exception types out of ``pyspark.pipelines/__init__.py`` --
+        # most notably a ``TypeError`` from inside PySpark's own
+        # error formatter when raising ``PIPELINES_NOT_SUPPORTED`` on
+        # a runtime that lacks ``dlt`` (see
+        # :func:`_optional_runtime_import_error` for the full
+        # traceback shape). The predicate inspects the traceback
+        # chain to decide which exceptions are the legitimate
+        # Lakeflow-SDP-missing case; anything that doesn't match is
+        # re-raised so a real bug in our own modules still fails
+        # loudly at import time.
+        if not _optional_runtime_import_error(exc):
+            raise
+        # Bind a single descriptor that raises the actionable error on
+        # ANY public attribute access. Implemented via module
+        # ``__getattr__`` (PEP 562) -- set on this module's globals so
+        # ``from dlt_meta import DataflowPipeline`` raises with the
+        # SDP-runtime-missing message rather than the historical silent
+        # ``cannot import name 'DataflowPipeline' from 'dlt_meta'``.
+        #
+        # Dunders raise ``AttributeError`` instead of ``ImportError``
+        # for the same reason ``_make_stub_module`` does: tools like
+        # IPython's autoreload reliability hook walk ``sys.modules``
+        # probing ``__file__``, ``__path__``, etc., and a raised
+        # ``ImportError`` poisons their traceback formatter (which
+        # itself probes dunders). See ``_make_stub_module`` for the
+        # full rationale.
+        _err_msg = str(exc)
+
+        def __getattr__(name: str):  # noqa: N807
+            if name.startswith("__") and name.endswith("__"):
+                raise AttributeError(name)
+            raise ImportError(
+                f"dlt_meta.{name} requires the Lakeflow SDP runtime "
+                f"(pyspark.pipelines) which is not installed. Run on a "
+                f"Databricks Runtime that ships Lakeflow SDP. "
+                f"Original error: {_err_msg}"
+            )
+
+        sys.modules[__name__].__getattr__ = __getattr__  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# 2. src.* aliasing
+# ---------------------------------------------------------------------------
+def _register_src_aliases() -> None:
+    """Register ``src`` and ``src.<sub>`` in :data:`sys.modules`.
+
+    Idempotent and opt-out-aware. Callable from a ``.pth`` file at
+    interpreter startup or directly via ``import dlt_meta``.
+    """
+    if _DISABLED:
+        return
+
+    # Top-level ``src`` package alias. Use ``setdefault`` so a customer
+    # who happens to have their own ``src`` package on ``sys.path``
+    # doesn't get clobbered (their import will have already populated
+    # ``sys.modules['src']`` before this runs, and our ``setdefault``
+    # is a no-op).
+    sys.modules.setdefault("src", sys.modules[__name__])
+
+    for sub in _SRC_SUBMODULES:
+        alias = f"src.{sub}"
+        if alias in sys.modules:
+            continue
+
+        target_qualname = f"databricks.labs.sdp_meta.{sub}"
+        try:
+            target = importlib.import_module(target_qualname)
+        except Exception as exc:  # noqa: BLE001 (broad-except is intentional)
+            # See ``_flat_reexport_or_stub`` for why we catch the
+            # broad ``Exception`` rather than just ``ImportError``:
+            # serverless DLT raises a TypeError (not an ImportError)
+            # out of ``pyspark.pipelines/__init__.py`` on certain
+            # runtimes that lack ``dlt`` but whose PySpark error
+            # formatter expects substitutions for the
+            # ``PIPELINES_NOT_SUPPORTED`` errorClass.
+            if not _optional_runtime_import_error(exc):
+                raise
+            sys.modules[alias] = _make_stub_module(alias, str(exc))
+            continue
+
+        # Wrap in a lazy proxy so DeprecationWarning fires at the
+        # customer's import line (stacklevel resolved per attribute
+        # access), not on the eager registration walk.
+        sys.modules[alias] = _LazyAliasModule(alias, target)
+
+
+# ---------------------------------------------------------------------------
+# Package-level deprecation warning — suppressed under opt-out
+# ---------------------------------------------------------------------------
+if not _DISABLED:
+    warnings.warn(
+        "The 'dlt_meta' package is deprecated and will be removed in a "
+        "future version. Please migrate to 'databricks.labs.sdp_meta' "
+        "(pip install databricks-labs-sdp-meta). See "
+        "https://databrickslabs.github.io/sdp-meta/ for migration guide.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
+# Wire up the surfaces. Order matters: do flat re-exports first so the
+# stub-module __getattr__ on this package (set when the runtime is
+# missing) takes effect BEFORE any src.* alias resolves to a stub.
+_flat_reexport_or_stub()
+_register_src_aliases()
 
 
 def _deprecated_wrapper(func, old_name, new_name):
-    """Wrapper that adds deprecation warning to functions."""
+    """Wrapper that adds a deprecation warning to *func* invocations."""
     def wrapper(*args, **kwargs):
         warnings.warn(
             f"'{old_name}' is deprecated, use '{new_name}' instead.",
             DeprecationWarning,
-            stacklevel=2
+            stacklevel=2,
         )
         return func(*args, **kwargs)
     return wrapper

--- a/compat/setup.py
+++ b/compat/setup.py
@@ -1,14 +1,87 @@
-"""Setup file for dlt-meta compatibility wrapper.
+"""Setup file for the ``dlt-meta`` compatibility wrapper.
 
-This package provides backwards compatibility for users migrating from dlt-meta to databricks-labs-sdp-meta.
-It re-exports all functionality from databricks-labs-sdp-meta and logs deprecation warnings.
+This distribution exists so ``pip install dlt-meta`` keeps resolving on
+PyPI for v0.0.10 customers. It is a thin **redirect**: it depends on the
+primary ``databricks-labs-sdp-meta`` package and ships none of the
+compat code itself.
+
+Why ship no packages
+--------------------
+The primary ``databricks-labs-sdp-meta`` wheel already bundles BOTH
+compat surfaces at its purelib root (see the top-level ``setup.py``):
+
+  * the ``dlt_meta`` flat re-export package (from ``compat/dlt_meta/``)
+  * the ``src`` v0.0.10 re-export package (from ``compat/src/``)
+
+If this wrapper ALSO shipped ``dlt_meta`` and ``src``, then
+``pip install dlt-meta`` (which pulls in ``databricks-labs-sdp-meta`` as
+a dependency) would install BOTH distributions, each writing the same
+``site-packages/dlt_meta/`` and ``site-packages/src/`` files. The two
+``RECORD`` manifests would both claim those files, so uninstalling
+either distribution would delete files the other still needs. Shipping
+them from exactly one distribution (the primary one) avoids the
+collision entirely; this wrapper relies on the dependency to provide
+them.
 """
-from setuptools import setup, find_packages
+import os
+
+from setuptools import setup
+
+try:  # setuptools >= 70.1 ships the integrated command
+    from setuptools.command.bdist_wheel import bdist_wheel as _bdist_wheel
+except ImportError:  # older setuptools delegates to the wheel package
+    from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
+
+
+_PTH_NAME = "dlt_meta.pth"
+
+
+class bdist_wheel_with_pth_file(_bdist_wheel):
+    """Ship ``dlt_meta.pth`` at the wheel's purelib root.
+
+    The usual ``build_py``-based trick (copy the ``.pth`` into
+    ``build_lib`` so it lands in the wheel root) does NOT work here:
+    this distribution declares ``packages=[]`` (see the module
+    docstring — the ``dlt_meta`` / ``src`` packages come from the
+    ``databricks-labs-sdp-meta`` dependency, not this wheel), and with
+    nothing to build modern setuptools skips ``build_py`` entirely, so
+    the override never fires.
+
+    Instead we hook ``bdist_wheel``, which always runs. ``write_wheelfile``
+    is invoked once ``self.bdist_dir`` is fully populated and just before
+    the archive is zipped from it, so dropping the ``.pth`` into
+    ``bdist_dir`` there gets it into both the wheel and its ``RECORD``.
+    The wheel stays pure-python (``Root-Is-Purelib: true``), so pip
+    extracts the root straight into site-packages and ``site.py`` picks
+    up the ``.pth`` at interpreter startup.
+
+    Note: this is a **best-effort** auto-load convenience, not the load-
+    bearing mechanism. The actual ``from src.* import …`` resolution on
+    serverless DLT is carried by the real ``src`` package shipped in the
+    ``databricks-labs-sdp-meta`` wheel — serverless ``%pip install`` does
+    not re-trigger ``site.py``'s ``.pth`` scan, so the ``.pth`` only
+    fires for a normal ``pip install`` followed by a fresh interpreter.
+    The ``.pth`` does NOT collide with the primary wheel (which ships no
+    ``.pth``), so it is safe to ship here.
+
+    See:
+      https://peps.python.org/pep-0491/  (Root-Is-Purelib semantics)
+    """
+
+    def write_wheelfile(self, *args, **kwargs):
+        src = os.path.join(os.path.dirname(__file__) or ".", _PTH_NAME)
+        dst = os.path.join(self.bdist_dir, _PTH_NAME)
+        self.copy_file(src, dst, preserve_mode=0)
+        super().write_wheelfile(*args, **kwargs)
 
 setup(
     name="dlt-meta",
     version="0.0.11",
-    python_requires=">=3.8",
+    # Match the primary package's Python floor and ceiling: pyspark
+    # 3.5.5 (a transitive runtime dep) is incompatible with Python
+    # 3.13's pickle changes, so cap at <3.13. Re-evaluate when pyspark
+    # ships a 3.13-compatible release.
+    python_requires=">=3.8, <3.13",
     install_requires=[
         "databricks-labs-sdp-meta>=0.0.11",  # Depends on the new primary package
     ],
@@ -37,7 +110,24 @@ All functionality is identical. This wrapper package will be maintained for back
 compatibility but new features will only be added to `sdp-meta`.
     """,
     long_description_content_type="text/markdown",
-    packages=find_packages(),
+    # Intentionally NO packages: ``dlt_meta`` and ``src`` are provided
+    # by the ``databricks-labs-sdp-meta`` dependency (see module
+    # docstring). Shipping them here too would make two distributions
+    # own the same site-packages files.
+    packages=[],
+    # ``dlt_meta.pth`` ships at the wheel's purelib root (see
+    # ``bdist_wheel_with_pth_file`` above). It is a best-effort startup
+    # auto-load of the ``dlt_meta`` package (which comes from the
+    # dependency); the real ``src`` package in the primary wheel is what
+    # actually carries ``from src.* import …`` on serverless DLT.
+    #
+    # NOTE: The .pth is only delivered for wheel installs — i.e.
+    # ``pip install ./compat`` (which builds a wheel under PEP 517)
+    # or ``pip install <built-wheel>``. ``pip install -e ./compat``
+    # (editable) does NOT re-run build_py, so the .pth is not
+    # installed. Maintainers running editable installs should
+    # explicitly ``import dlt_meta`` in their notebooks.
+    cmdclass={"bdist_wheel": bdist_wheel_with_pth_file},
     entry_points={"group_1": "run=dlt_meta:main"},
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/compat/src/__init__.py
+++ b/compat/src/__init__.py
@@ -1,0 +1,67 @@
+"""Backward-compatibility ``src.*`` re-export package for v0.0.10 customers.
+
+What this is for
+----------------
+v0.0.10 of dlt-meta shipped its source tree as a ``src/`` package
+(``src/dataflow_pipeline.py``, ``src/cli.py``, etc.). Customer runner
+notebooks therefore import as::
+
+    from src.dataflow_pipeline import DataflowPipeline
+
+The v0.0.11 package rename to ``databricks.labs.sdp_meta`` would
+normally break those notebooks. This package preserves them: it ships
+inside the v0.0.11 main wheel as a top-level ``src`` namespace so the
+legacy import keeps resolving to the same class objects.
+
+Why a real package, not a ``.pth`` trick
+----------------------------------------
+The earlier iteration of this surface relied on a ``dlt_meta.pth``
+file dropped at the wheel's purelib root, exec'd by CPython's
+``site.py`` at interpreter startup. That worked on a normal
+``pip install`` followed by a fresh ``python`` process, but NOT on
+serverless DLT: the platform's ``%pip install`` notebook magic lays
+the wheel's files into site-packages and runs the next cell in the
+SAME interpreter without re-firing ``site.py``'s ``.pth`` scan, so the
+freshly-installed ``.pth`` is silently ignored and ``src.*`` aliases
+are never registered. Resolving through a real Python package -- this
+file -- sidesteps the entire ``.pth`` lifecycle: ``from src.X import …``
+just walks the standard import machinery, which locates ``src/`` in
+site-packages and runs this ``__init__.py``.
+
+Single source of truth
+-----------------------
+This module deliberately contains **no** alias-registration logic of
+its own. All of it -- the canonical ``src.<sub>`` ->
+``databricks.labs.sdp_meta.<sub>`` submodule list, the per-alias
+``DeprecationWarning``, the ``SDP_META_DISABLE_SRC_ALIAS`` opt-out, and
+(critically) the actionable stub modules that raise a clear "requires
+the Lakeflow SDP runtime" error when ``pyspark.pipelines`` is missing
+-- lives in :mod:`dlt_meta`. Importing it below runs that registration
+as an import side effect.
+
+This used to be a second, independent implementation. The two drifted:
+``compat/src`` carried a shorter submodule list and silently *skipped*
+modules whose canonical target failed to import, so on a non-SDP
+runtime a customer's ``from src.dataflow_pipeline import …`` raised the
+confusing ``ModuleNotFoundError: No module named 'src.dataflow_pipeline'``
+-- exactly the failure mode the shim is supposed to eliminate.
+Delegating to :mod:`dlt_meta` keeps both surfaces in lockstep.
+
+Opt-out
+-------
+Set ``SDP_META_DISABLE_SRC_ALIAS=1`` in the environment to skip alias
+registration (and the deprecation warning). :mod:`dlt_meta` honours the
+same variable, so importing it below becomes a no-op for the ``src.*``
+surface. Useful if a project has its own (unrelated) ``src/`` directory
+it wants to import from.
+"""
+
+# Importing ``dlt_meta`` triggers its registration walk, which wires
+# ``src.<sub>`` into ``sys.modules`` (with actionable stub modules on a
+# non-SDP runtime), binds the renamed symbols, honours
+# ``SDP_META_DISABLE_SRC_ALIAS``, and emits the deprecation warning.
+# Its ``sys.modules.setdefault("src", …)`` is a no-op here because we
+# (the real ``src`` package) are already mid-import in ``sys.modules``,
+# so this package object stays the canonical ``src`` and merely gains
+# the ``src.<sub>`` entries dlt_meta registers.
+import dlt_meta  # noqa: F401  (imported for its registration side effects)

--- a/docs/content/getting_started/sdp_meta_renaming.md
+++ b/docs/content/getting_started/sdp_meta_renaming.md
@@ -109,6 +109,51 @@ from dlt_meta.cli import DLTMeta
 # DLTMeta is aliased to SDPMeta under the hood
 ```
 
+### Legacy `src.*` Imports (still work in v0.0.11, removed in v0.1.0)
+
+v0.0.10 published the framework as a top-level Python package literally named `src`. Customer notebooks following the v0.0.10 demo guide contain lines like:
+
+```python
+from src.dataflow_pipeline import DataflowPipeline
+from src.cli import DLTMeta
+from src.dataflow_spec import BronzeDataflowSpec, SilverDataflowSpec
+```
+
+After upgrading to `dlt-meta==0.0.11`, **these continue to work unchanged** — each `src.*` module is registered in `sys.modules` as an alias for the corresponding `databricks.labs.sdp_meta.*` module at interpreter startup (via a `.pth` file shipped in the wheel). On first attribute access, each alias emits a one-time `DeprecationWarning` per process pointing at the canonical replacement.
+
+```text
+DeprecationWarning: 'src.dataflow_pipeline' is a v0.0.10 compatibility
+alias and will be removed in v0.1.0. Migrate to 'from
+databricks.labs.sdp_meta.dataflow_pipeline import …' or 'from
+dlt_meta import …'.
+```
+
+#### Disabling the `src.*` shim
+
+If you have your own `src/` package on `sys.path` (rare but real for monorepo layouts), set `SDP_META_DISABLE_SRC_ALIAS=1` in the cluster environment **before** any `dlt_meta` import. This skips both the alias registration and the package-level deprecation warning.
+
+```bash
+export SDP_META_DISABLE_SRC_ALIAS=1
+```
+
+#### Removal in v0.1.0
+
+The `src.*` aliases will be removed in v0.1.0. Migrate before then by rewriting:
+
+```python
+# v0.0.10
+from src.dataflow_pipeline import DataflowPipeline
+from src.cli import DLTMeta
+
+# v0.0.11+ (canonical)
+from databricks.labs.sdp_meta.dataflow_pipeline import DataflowPipeline
+from databricks.labs.sdp_meta.cli import SDPMeta
+```
+
+#### What's NOT aliased: `integration_tests.*`
+
+v0.0.10's `setup.py` also published `integration_tests` as a top-level package, but this was an oversight — `integration_tests/` is not a stable API surface. It is **not** aliased in v0.0.11; if you have notebook code that does `from integration_tests.run_integration_tests import …`, inline the relevant code instead.
+
 ### Config Key Compatibility
 
 The framework reads both key formats automatically:
@@ -187,10 +232,12 @@ A `compat/` package provides the bridge between old and new:
 | --- | --- |
 | `dlt-meta` PyPI package | v0.0.11 depends on `databricks-labs-sdp-meta>=0.0.11` |
 | `from dlt_meta import ...` | Re-exports all symbols from `databricks.labs.sdp_meta` with deprecation warnings |
-| `DLTMeta` class | Aliased to `SDPMeta` |
+| `from src.* import ...` | `src.*` modules are registered in `sys.modules` as aliases for `databricks.labs.sdp_meta.*` at interpreter startup via a `.pth` file. Removed in v0.1.0. |
+| `DLTMeta` class | Aliased to `SDPMeta` (rebound in `cli.py` so `from src.cli import DLTMeta` resolves through the module alias) |
 | `DLT_META_RUNNER_NOTEBOOK` | Aliased to `SDP_META_RUNNER_NOTEBOOK` |
 | `databricks labs dlt-meta` CLI | Forwards to `databricks labs sdp-meta` with deprecation banner |
 | `dlt_meta_schema` config key | Read with a logged warning suggesting `sdp_meta_schema` |
+| `SDP_META_DISABLE_SRC_ALIAS=1` env var | Disables the `src.*` shim and suppresses the package-level deprecation warning |
 
 ---
 
@@ -198,6 +245,7 @@ A `compat/` package provides the bridge between old and new:
 
 | Phase | Status | Details |
 | --- | --- | --- |
-| **v0.0.11** | Active | Both `dlt-meta` and `sdp-meta` packages work. Old package shows deprecation warnings. |
-| **Next Release** | Planned | `dlt-meta` compat package maintained but no new features added. |
+| **v0.0.11** | Active | Both `dlt-meta` and `sdp-meta` packages work. Old package shows deprecation warnings. `src.*` imports work via shim. |
+| **v0.0.12 → v0.0.x** | Planned | `dlt-meta` compat package maintained but no new features added. `src.*` shim still active. |
+| **v0.1.0** | Planned | `src.*` shim removed. `from src.X import …` returns to raising `ModuleNotFoundError`. |
 | **Future** | Planned | `dlt-meta` package removed. Advance notice will be provided. |

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -143,6 +143,115 @@
 
 ---
 
+## Backward-compatibility upgrade test (any source → any target)
+
+`integration_tests/run_backward_compat_tests.py` is a separate orchestrator that proves a customer's existing pipeline keeps working when the wheel is swapped from `--source_version` to `--target_version`. No notebook edits, no onboarding redo, no DLT checkpoint resets.
+
+The test runs in **two phases against the same DLT pipelines** (same pipeline IDs across both phases — only the wheel path attached to each pipeline's `configuration` changes between Phase 1 and Phase 2):
+
+| Phase | Wheel install spec | What runs |
+|---|---|---|
+| 1 | SOURCE main wheel only | onboard A1 → bronze A1 → silver → onboard A2 → bronze A2 → silver → validate Phase 1 row counts and persist them |
+| 2 | TARGET main wheel only (one config key, one `%pip install`, byte-for-byte the customer's source-version notebook) | drop a small new incremental seed batch → bronze → silver → validate row counts (data preserved + grew), and dataclass compatibility (SOURCE-persisted dataflowspec rows materialize through TARGET's dataclasses with new fields backfilled to defaults) |
+
+### Version profiles
+
+Two version-line profiles ship in [`integration_tests/version_profiles.py`](version_profiles.py):
+
+| Profile | Refs it owns | Distribution | Pipeline-config key | Runner notebook | Cross-namespace compatibility |
+|---|---|---|---|---|---|
+| `legacy` | `v0.0.1` … `v0.0.10`, `main` | `dlt_meta` | `dlt_meta_whl` (single) | imports `from src.*` | — |
+| `current` | `v0.0.11`+, `feature/sdp-meta` | `databricks_labs_sdp_meta` | `sdp_meta_whl` (single) | imports `from databricks.labs.sdp_meta.*` | When the TARGET wheel comes from this profile and the SOURCE was `legacy`, the wheel BUNDLES a legacy-namespace compat shim (the `dlt_meta` package + a `dlt_meta.pth` file at the wheel's purelib root, configured in the top-level `setup.py`). After `%pip install` lands the wheel, CPython's `site.py` execs the bundled `.pth` at the next interpreter startup — exactly when DLT runs the runner notebook (after `%pip install` and in a fresh interpreter) — so the shim's `src.*` aliases are registered before the source notebook's `from src.dataflow_pipeline import …` resolves. Same-namespace upgrades (`current → current`, e.g. `v0.0.11 → v0.0.12`) install one wheel and don't need any of this. |
+
+**Why one wheel + one `%pip install`, not two?** The first cut of this test installed two wheels (main + a separate compat shim) under two pipeline-config keys, which forced either a `%pip install $a $b` magic shape or two separate `%pip install` lines. Both failed on serverless DLT: `%pip install` magic substitution is fragile when composing multiple wheels in one line (variables quote as single args), and two install lines in one cell don't reliably compose (only the last seems to survive). Bundling the shim into the main wheel sidesteps both — one wheel install satisfies both the canonical namespace and the legacy-namespace import surface in one shot.
+
+Profiles are resolved from each git ref by prefix match; pass `--source_profile=<name>` / `--target_profile=<name>` to force resolution for custom branches the registry doesn't recognize.
+
+### Install modes
+
+`--install_mode` picks how each wheel reaches the cluster:
+
+- **`local` (default)** — build wheels via [`integration_tests/wheel_builder.py`](wheel_builder.py) (which uses `git worktree` + `python setup.py bdist_wheel` against the source/target refs), upload them to the per-run UC volume, and reference UC volume paths in both `JobEnvironment.dependencies` and the runner notebook's `%pip install`. This matches what real customers do (install a pre-built artifact); does NOT require workspace egress to GitHub.
+- **`git`** — skip the local build entirely. `JobEnvironment.dependencies` and `%pip install` resolve `git+https://github.com/databrickslabs/dlt-meta.git@<ref>` directly. Faster local iteration. The cluster MUST have egress to `--git_repo_url`.
+
+### Iterating on uncommitted target-side changes — `--build_target_from_worktree`
+
+While developing the bundled compat shim or post-rename CLI aliases on a feature branch, you'll want to test changes that aren't pushed to `--target_version` yet. Pass `--build_target_from_worktree` (requires `--install_mode=local`) to build the TARGET main wheel from your local working tree instead of from the git ref:
+
+```commandline
+python integration_tests/run_backward_compat_tests.py \
+    --uc_catalog_name=<<uc catalog name>> \
+    --build_target_from_worktree \
+    --profile=<<DEFAULT>>
+```
+
+The SOURCE wheel still comes from `--source_version` (e.g. `v0.0.10`) — that's the customer's already-released artifact and has nothing to do with local edits. Only the TARGET side honours the working tree, because that's where the unreleased bundled compat shim and CLI work live.
+
+Use ONLY for development. Production runs should pin a real git ref so the test artifact is reproducible from version control.
+
+### Common upgrade scenarios
+
+```commandline
+# Default (legacy → current): v0.0.10 → feature/sdp-meta. Local wheel build.
+python integration_tests/run_backward_compat_tests.py \
+    --uc_catalog_name=<<uc catalog name>> \
+    --profile=<<DEFAULT>>
+
+# Same scenario, but install wheels via git+https instead of local build:
+python integration_tests/run_backward_compat_tests.py \
+    --uc_catalog_name=<<uc catalog name>> \
+    --install_mode=git \
+    --profile=<<DEFAULT>>
+
+# Future release pair (current → current, e.g. v0.0.11 → v0.0.12).
+# Same one-wheel/one-key contract — the namespace does not change,
+# so no compat shim is needed in the wheel either way.
+python integration_tests/run_backward_compat_tests.py \
+    --uc_catalog_name=<<uc catalog name>> \
+    --source_version=v0.0.11 \
+    --target_version=v0.0.12 \
+    --profile=<<DEFAULT>>
+
+# Custom branches with explicit profile pins (used when the branch
+# name doesn't match a registered prefix):
+python integration_tests/run_backward_compat_tests.py \
+    --uc_catalog_name=<<uc catalog name>> \
+    --source_version=feature/legacy-bugfix --source_profile=legacy \
+    --target_version=feature/sdp-meta     --target_profile=current \
+    --profile=<<DEFAULT>>
+
+# Skip cleanup on success/failure so the run state is debuggable;
+# add --cleanup to wipe pipelines/jobs/schemas/volumes when done.
+python integration_tests/run_backward_compat_tests.py \
+    --uc_catalog_name=<<uc catalog name>> --cleanup --profile=<<DEFAULT>>
+```
+
+### What changes between phases (and what doesn't)
+
+**Stays identical across both phases:**
+- The three DLT pipeline IDs (created in Phase 1, reused in Phase 2 via `pipelines.update()`).
+- Per-pipeline DLT checkpoints — Auto Loader picks up Phase 2's incremental seed by checkpoint, not by re-listing.
+- The runner notebook contents — uploaded once from the SOURCE profile's runner. For legacy → current upgrades, the SOURCE's `from src.*` imports are kept verbatim and resolve in Phase 2 via the legacy-namespace compat shim BUNDLED into the target wheel (proving zero-code-change upgrade end-to-end).
+- The pipeline-config KEY the runner notebook reads (`dlt_meta_whl` for legacy source, `sdp_meta_whl` for current source).
+- The dataflowspec table — Phase 2 reads what Phase 1 persisted; new fields are backfilled to documented defaults by `populate_additional_df_cols`.
+
+**Changes between Phase 1 and Phase 2 (and only this):**
+- The value behind the SOURCE profile's pipeline-config key in each pipeline's `configuration` flips from the SOURCE main wheel path to the TARGET main wheel path. That's it — one key, one swap, per pipeline.
+- The runner notebook itself is not touched — the same single `%pip install $key` line that ran in Phase 1 runs again in Phase 2, with `$key` resolving to the new wheel path.
+
+### Output
+
+Two CSVs land locally on completion:
+
+```
+backward_compat_phase1_<run_id>.csv   # row-count assertions per table after Phase 1
+backward_compat_phase2_<run_id>.csv   # data preservation + growth + dataclass compat after Phase 2
+```
+
+Every line in either CSV ending in `Passed!` is a green assertion; any line ending in `Failed!` is a red one. The Phase 2 validator is the authoritative source for the "upgrade does not break the customer's pipeline" claim.
+
+---
+
 ## Onboarding file format (JSON or YAML)
 
 The integration test runner can drive every supported source (`cloudfiles`, `eventhub`, `kafka`, `snapshot`, `multi_source_cdc`) with either a JSON or a YAML onboarding spec. The format is selected per-run with a single CLI flag:

--- a/integration_tests/conf/json/backward_compat-cloudfiles-onboarding.template
+++ b/integration_tests/conf/json/backward_compat-cloudfiles-onboarding.template
@@ -1,0 +1,174 @@
+[
+{
+   "data_flow_id": "100",
+   "data_flow_group": "A1",
+   "source_system": "MYSQL",
+   "source_format": "cloudFiles",
+   "source_details": {
+      "source_database": "APP",
+      "source_table": "CUSTOMERS",
+      "source_path_it": "{uc_volume_path}/integration_tests/resources/data/customers",
+      "source_metadata": {
+            "include_autoloader_metadata_column": "True",
+            "autoloader_metadata_col_name": "source_metadata",
+            "select_metadata_cols": {
+               "input_file_name": "_metadata.file_name",
+               "input_file_path": "_metadata.file_path"
+            }
+      },
+      "source_schema_path": "{uc_volume_path}/integration_tests/resources/customers.ddl"
+   },
+   "bronze_catalog_it": "{uc_catalog_name}",
+   "bronze_database_it": "{bronze_schema}",
+   "bronze_table": "customers",
+   "bronze_table_comment": "bronze customer table",
+   "bronze_reader_options": {
+      "cloudFiles.format": "json",
+      "cloudFiles.inferColumnTypes": "true",
+      "cloudFiles.rescuedDataColumn": "_rescued_data"
+   },
+   "bronze_table_path_it": "{uc_volume_path}/data/bronze/customers",
+   "bronze_table_properties": {
+         "pipelines.autoOptimize.managed": "true"
+   },
+   "bronze_data_quality_expectations_json_it": "{uc_volume_path}/integration_tests/conf/json/dqe/customers/bronze_data_quality_expectations.json",
+   "bronze_catalog_quarantine_it": "{uc_catalog_name}",
+   "bronze_database_quarantine_it": "{bronze_schema}",
+   "bronze_quarantine_table": "customers_quarantine",
+   "bronze_quarantine_table_comment": "bronze customers quarantine table",
+   "bronze_quarantine_table_path_it": "{uc_volume_path}/data/bronze/customers_quarantine",
+   "bronze_quarantine_table_properties": {
+         "pipelines.reset.allowed": "false"
+   },
+   "bronze_quarantine_table_cluster_by":["id", "email"],
+   "bronze_append_flows": [
+      {
+            "name": "customer_bronze_flow",
+            "create_streaming_table": false,
+            "source_format": "cloudFiles",
+            "source_details": {
+               "source_path_it": "{uc_volume_path}/integration_tests/resources/data/customers_af",
+               "source_schema_path": "{uc_volume_path}/integration_tests/resources/customers.ddl"
+            },
+            "reader_options": {
+               "cloudFiles.format": "json",
+               "cloudFiles.inferColumnTypes": "true",
+               "cloudFiles.rescuedDataColumn": "_rescued_data"
+            },
+            "once": false
+      }
+   ],
+   "silver_catalog_it": "{uc_catalog_name}",
+   "silver_database_it": "{silver_schema}",
+   "silver_table": "customers",
+   "silver_table_comment": "customers silver table",
+   "silver_table_path_it": "{uc_volume_path}/data/silver/customers",
+   "silver_transformation_json_it": "{uc_volume_path}/integration_tests/conf/json/silver_transformations.json",
+   "silver_table_properties": {
+         "pipelines.reset.allowed": "false"
+   },
+   "silver_data_quality_expectations_json_it": "{uc_volume_path}/integration_tests/conf/json/dqe/customers/silver_data_quality_expectations.json",
+   "silver_catalog_quarantine_it":"{uc_catalog_name}",
+   "silver_database_quarantine_it":"{silver_schema}",
+   "silver_quarantine_table":"customers_quarantine",
+   "silver_quarantine_table_properties": {
+         "pipelines.reset.allowed": "false"
+   },
+   "silver_append_flows": [
+      {
+            "name": "customers_silver_flow",
+            "create_streaming_table": false,
+            "source_format": "delta",
+            "source_details": {
+               "source_database": "{uc_catalog_name}.{bronze_schema}", "source_table": "customers_delta"
+            },
+            "reader_options": {},
+            "once": false
+      }
+   ]
+},
+{
+   "data_flow_id": "102",
+   "data_flow_group": "A1",
+   "source_system": "MYSQL",
+   "source_format": "cloudFiles",
+   "source_details": {
+      "source_database": "APP",
+      "source_table": "TRANSACTIONS",
+      "source_path_it": "{uc_volume_path}/integration_tests/resources/data/transactions",
+      "source_metadata": {
+            "include_autoloader_metadata_column": "True",
+            "select_metadata_cols": {
+               "input_file_name": "_metadata.file_name",
+               "input_file_path": "_metadata.file_path"
+            }
+      },
+      "source_schema_path": "{uc_volume_path}/integration_tests/resources/transactions.ddl"
+   },
+   "bronze_catalog_it": "{uc_catalog_name}",
+   "bronze_database_it": "{bronze_schema}",
+   "bronze_table": "transactions",
+   "bronze_reader_options": {
+      "cloudFiles.format": "json",
+      "cloudFiles.inferColumnTypes": "true",
+      "cloudFiles.rescuedDataColumn": "_rescued_data"
+   },
+   "bronze_table_path_it": "{uc_volume_path}/data/bronze/transactions",
+   "bronze_table_properties": {
+         "pipelines.reset.allowed": "true"
+   },
+   "bronze_data_quality_expectations_json_it": "{uc_volume_path}/integration_tests/conf/json/dqe/transactions/bronze_data_quality_expectations.json",
+   "bronze_catalog_quarantine_it": "{uc_catalog_name}",
+   "bronze_database_quarantine_it": "{bronze_schema}",
+   "bronze_quarantine_table": "transactions_quarantine",
+   "bronze_quarantine_table_path_it": "{uc_volume_path}/data/bronze/transactions_quarantine",
+   "bronze_quarantine_table_properties": {
+         "pipelines.reset.allowed": "true",
+         "pipelines.autoOptimize.managed": "false"
+   },
+   "bronze_append_flows": [
+      {
+            "name": "transactions_bronze_flow",
+            "create_streaming_table": false,
+            "source_format": "cloudFiles",
+            "source_details": {
+               "source_path_it": "{uc_volume_path}/integration_tests/resources/data/transactions_af",
+               "source_schema_path": "{uc_volume_path}/integration_tests/resources/transactions.ddl"
+            },
+            "reader_options": {
+               "cloudFiles.format": "json",
+               "cloudFiles.inferColumnTypes": "true",
+               "cloudFiles.rescuedDataColumn": "_rescued_data"
+            },
+            "once": false
+      }
+   ],
+   "silver_catalog_it": "{uc_catalog_name}",
+   "silver_database_it": "{silver_schema}",
+   "silver_table": "transactions",
+   "silver_cdc_apply_changes": {
+      "keys": [
+         "id"
+      ],
+      "sequence_by": "operation_date",
+      "scd_type": "1",
+      "apply_as_deletes": "operation = 'DELETE'",
+      "except_column_list": [
+         "operation",
+         "operation_date",
+         "_rescued_data"
+      ],
+      "flow_name":"silver_transactions_cdc_applychanges_flow"
+   },
+   "silver_table_path_it": "{uc_volume_path}/data/silver/transactions",
+   "silver_transformation_json_it": "{uc_volume_path}/integration_tests/conf/json/silver_transformations.json",
+   "silver_data_quality_expectations_json_it": "{uc_volume_path}/integration_tests/conf/json/dqe/transactions/silver_data_quality_expectations.json",
+   "silver_table_properties": {
+         "pipelines.reset.allowed": "false"
+   },
+   "silver_catalog_quarantine_it":"{uc_catalog_name}",
+   "silver_database_quarantine_it":"{silver_schema}",
+   "silver_quarantine_table":"transactions_quarantine",
+   "silver_quarantine_table_cluster_by":["id","customer_id"]
+}
+]

--- a/integration_tests/conf/json/backward_compat-cloudfiles-onboarding_A2.template
+++ b/integration_tests/conf/json/backward_compat-cloudfiles-onboarding_A2.template
@@ -1,0 +1,42 @@
+[
+{
+   "data_flow_id": "103",
+   "data_flow_group": "A2",
+   "source_system": "MYSQL",
+   "source_format": "cloudFiles",
+   "source_details": {
+      "source_database": "APP",
+      "source_table": "CUSTOMERS",
+      "source_path_it": "{uc_volume_path}/integration_tests/resources/data/customers_delta",
+      "source_metadata": {
+            "select_metadata_cols": {
+               "input_file_name": "_metadata.file_name",
+               "input_file_path": "_metadata.file_path"
+            }
+      },
+      "source_schema_path": "{uc_volume_path}/integration_tests/resources/customers.ddl"
+   },
+   "bronze_catalog_it": "{uc_catalog_name}",
+   "bronze_database_it": "{bronze_schema}",
+   "bronze_table": "customers_delta",
+   "bronze_reader_options": {
+      "cloudFiles.format": "json",
+      "cloudFiles.inferColumnTypes": "true",
+      "cloudFiles.rescuedDataColumn": "_rescued_data"
+   },
+   "bronze_table_path_it": "{uc_volume_path}/data/bronze/customers_delta",
+   "bronze_table_properties": {
+         "pipelines.autoOptimize.managed": "true"
+   },
+   "bronze_cluster_by":["id", "email"],
+   "bronze_data_quality_expectations_json_it": "{uc_volume_path}/integration_tests/conf/json/dqe/customers/bronze_data_quality_expectations.json",
+   "bronze_catalog_quarantine_it": "{uc_catalog_name}",
+   "bronze_database_quarantine_it": "{bronze_schema}",
+   "bronze_quarantine_table": "customers_delta_quarantine",
+   "bronze_quarantine_table_path_it": "{uc_volume_path}/data/bronze/customers_quarantine_delta",
+   "bronze_quarantine_table_properties": {
+         "pipelines.reset.allowed": "false"
+   },
+   "bronze_quarantine_table_cluster_by":["id", "email"]
+}
+]

--- a/integration_tests/conf/json/backward_compat_onboarding_028bdbcc8db8.json
+++ b/integration_tests/conf/json/backward_compat_onboarding_028bdbcc8db8.json
@@ -1,0 +1,181 @@
+[
+    {
+        "data_flow_id": "100",
+        "data_flow_group": "A1",
+        "source_system": "MYSQL",
+        "source_format": "cloudFiles",
+        "source_details": {
+            "source_database": "APP",
+            "source_table": "CUSTOMERS",
+            "source_path_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_028bdbcc8db8/dlt_meta_files//integration_tests/resources/data/customers",
+            "source_metadata": {
+                "include_autoloader_metadata_column": "True",
+                "autoloader_metadata_col_name": "source_metadata",
+                "select_metadata_cols": {
+                    "input_file_name": "_metadata.file_name",
+                    "input_file_path": "_metadata.file_path"
+                }
+            },
+            "source_schema_path": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_028bdbcc8db8/dlt_meta_files//integration_tests/resources/customers.ddl"
+        },
+        "bronze_catalog_it": "ravi_dlt_meta_uc",
+        "bronze_database_it": "sdp_meta_bronze_bc_028bdbcc8db8",
+        "bronze_table": "customers",
+        "bronze_table_comment": "bronze customer table",
+        "bronze_reader_options": {
+            "cloudFiles.format": "json",
+            "cloudFiles.inferColumnTypes": "true",
+            "cloudFiles.rescuedDataColumn": "_rescued_data"
+        },
+        "bronze_table_path_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_028bdbcc8db8/dlt_meta_files//data/bronze/customers",
+        "bronze_table_properties": {
+            "pipelines.autoOptimize.managed": "true"
+        },
+        "bronze_data_quality_expectations_json_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_028bdbcc8db8/dlt_meta_files//integration_tests/conf/json/dqe/customers/bronze_data_quality_expectations.json",
+        "bronze_catalog_quarantine_it": "ravi_dlt_meta_uc",
+        "bronze_database_quarantine_it": "sdp_meta_bronze_bc_028bdbcc8db8",
+        "bronze_quarantine_table": "customers_quarantine",
+        "bronze_quarantine_table_comment": "bronze customers quarantine table",
+        "bronze_quarantine_table_path_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_028bdbcc8db8/dlt_meta_files//data/bronze/customers_quarantine",
+        "bronze_quarantine_table_properties": {
+            "pipelines.reset.allowed": "false"
+        },
+        "bronze_quarantine_table_cluster_by": [
+            "id",
+            "email"
+        ],
+        "bronze_append_flows": [
+            {
+                "name": "customer_bronze_flow",
+                "create_streaming_table": false,
+                "source_format": "cloudFiles",
+                "source_details": {
+                    "source_path_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_028bdbcc8db8/dlt_meta_files//integration_tests/resources/data/customers_af",
+                    "source_schema_path": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_028bdbcc8db8/dlt_meta_files//integration_tests/resources/customers.ddl"
+                },
+                "reader_options": {
+                    "cloudFiles.format": "json",
+                    "cloudFiles.inferColumnTypes": "true",
+                    "cloudFiles.rescuedDataColumn": "_rescued_data"
+                },
+                "once": false
+            }
+        ],
+        "silver_catalog_it": "ravi_dlt_meta_uc",
+        "silver_database_it": "sdp_meta_silver_bc_028bdbcc8db8",
+        "silver_table": "customers",
+        "silver_table_comment": "customers silver table",
+        "silver_table_path_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_028bdbcc8db8/dlt_meta_files//data/silver/customers",
+        "silver_transformation_json_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_028bdbcc8db8/dlt_meta_files//integration_tests/conf/json/silver_transformations.json",
+        "silver_table_properties": {
+            "pipelines.reset.allowed": "false"
+        },
+        "silver_data_quality_expectations_json_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_028bdbcc8db8/dlt_meta_files//integration_tests/conf/json/dqe/customers/silver_data_quality_expectations.json",
+        "silver_catalog_quarantine_it": "ravi_dlt_meta_uc",
+        "silver_database_quarantine_it": "sdp_meta_silver_bc_028bdbcc8db8",
+        "silver_quarantine_table": "customers_quarantine",
+        "silver_quarantine_table_properties": {
+            "pipelines.reset.allowed": "false"
+        },
+        "silver_append_flows": [
+            {
+                "name": "customers_silver_flow",
+                "create_streaming_table": false,
+                "source_format": "delta",
+                "source_details": {
+                    "source_database": "ravi_dlt_meta_uc.sdp_meta_bronze_bc_028bdbcc8db8",
+                    "source_table": "customers_delta"
+                },
+                "reader_options": {},
+                "once": false
+            }
+        ]
+    },
+    {
+        "data_flow_id": "102",
+        "data_flow_group": "A1",
+        "source_system": "MYSQL",
+        "source_format": "cloudFiles",
+        "source_details": {
+            "source_database": "APP",
+            "source_table": "TRANSACTIONS",
+            "source_path_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_028bdbcc8db8/dlt_meta_files//integration_tests/resources/data/transactions",
+            "source_metadata": {
+                "include_autoloader_metadata_column": "True",
+                "select_metadata_cols": {
+                    "input_file_name": "_metadata.file_name",
+                    "input_file_path": "_metadata.file_path"
+                }
+            },
+            "source_schema_path": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_028bdbcc8db8/dlt_meta_files//integration_tests/resources/transactions.ddl"
+        },
+        "bronze_catalog_it": "ravi_dlt_meta_uc",
+        "bronze_database_it": "sdp_meta_bronze_bc_028bdbcc8db8",
+        "bronze_table": "transactions",
+        "bronze_reader_options": {
+            "cloudFiles.format": "json",
+            "cloudFiles.inferColumnTypes": "true",
+            "cloudFiles.rescuedDataColumn": "_rescued_data"
+        },
+        "bronze_table_path_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_028bdbcc8db8/dlt_meta_files//data/bronze/transactions",
+        "bronze_table_properties": {
+            "pipelines.reset.allowed": "true"
+        },
+        "bronze_data_quality_expectations_json_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_028bdbcc8db8/dlt_meta_files//integration_tests/conf/json/dqe/transactions/bronze_data_quality_expectations.json",
+        "bronze_catalog_quarantine_it": "ravi_dlt_meta_uc",
+        "bronze_database_quarantine_it": "sdp_meta_bronze_bc_028bdbcc8db8",
+        "bronze_quarantine_table": "transactions_quarantine",
+        "bronze_quarantine_table_path_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_028bdbcc8db8/dlt_meta_files//data/bronze/transactions_quarantine",
+        "bronze_quarantine_table_properties": {
+            "pipelines.reset.allowed": "true",
+            "pipelines.autoOptimize.managed": "false"
+        },
+        "bronze_append_flows": [
+            {
+                "name": "transactions_bronze_flow",
+                "create_streaming_table": false,
+                "source_format": "cloudFiles",
+                "source_details": {
+                    "source_path_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_028bdbcc8db8/dlt_meta_files//integration_tests/resources/data/transactions_af",
+                    "source_schema_path": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_028bdbcc8db8/dlt_meta_files//integration_tests/resources/transactions.ddl"
+                },
+                "reader_options": {
+                    "cloudFiles.format": "json",
+                    "cloudFiles.inferColumnTypes": "true",
+                    "cloudFiles.rescuedDataColumn": "_rescued_data"
+                },
+                "once": false
+            }
+        ],
+        "silver_catalog_it": "ravi_dlt_meta_uc",
+        "silver_database_it": "sdp_meta_silver_bc_028bdbcc8db8",
+        "silver_table": "transactions",
+        "silver_cdc_apply_changes": {
+            "keys": [
+                "id"
+            ],
+            "sequence_by": "operation_date",
+            "scd_type": "1",
+            "apply_as_deletes": "operation = 'DELETE'",
+            "except_column_list": [
+                "operation",
+                "operation_date",
+                "_rescued_data"
+            ],
+            "flow_name": "silver_transactions_cdc_applychanges_flow"
+        },
+        "silver_table_path_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_028bdbcc8db8/dlt_meta_files//data/silver/transactions",
+        "silver_transformation_json_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_028bdbcc8db8/dlt_meta_files//integration_tests/conf/json/silver_transformations.json",
+        "silver_data_quality_expectations_json_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_028bdbcc8db8/dlt_meta_files//integration_tests/conf/json/dqe/transactions/silver_data_quality_expectations.json",
+        "silver_table_properties": {
+            "pipelines.reset.allowed": "false"
+        },
+        "silver_catalog_quarantine_it": "ravi_dlt_meta_uc",
+        "silver_database_quarantine_it": "sdp_meta_silver_bc_028bdbcc8db8",
+        "silver_quarantine_table": "transactions_quarantine",
+        "silver_quarantine_table_cluster_by": [
+            "id",
+            "customer_id"
+        ]
+    }
+]

--- a/integration_tests/conf/json/backward_compat_onboarding_905606092b4e.json
+++ b/integration_tests/conf/json/backward_compat_onboarding_905606092b4e.json
@@ -1,0 +1,181 @@
+[
+    {
+        "data_flow_id": "100",
+        "data_flow_group": "A1",
+        "source_system": "MYSQL",
+        "source_format": "cloudFiles",
+        "source_details": {
+            "source_database": "APP",
+            "source_table": "CUSTOMERS",
+            "source_path_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_905606092b4e/dlt_meta_files//integration_tests/resources/data/customers",
+            "source_metadata": {
+                "include_autoloader_metadata_column": "True",
+                "autoloader_metadata_col_name": "source_metadata",
+                "select_metadata_cols": {
+                    "input_file_name": "_metadata.file_name",
+                    "input_file_path": "_metadata.file_path"
+                }
+            },
+            "source_schema_path": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_905606092b4e/dlt_meta_files//integration_tests/resources/customers.ddl"
+        },
+        "bronze_catalog_it": "ravi_dlt_meta_uc",
+        "bronze_database_it": "sdp_meta_bronze_bc_905606092b4e",
+        "bronze_table": "customers",
+        "bronze_table_comment": "bronze customer table",
+        "bronze_reader_options": {
+            "cloudFiles.format": "json",
+            "cloudFiles.inferColumnTypes": "true",
+            "cloudFiles.rescuedDataColumn": "_rescued_data"
+        },
+        "bronze_table_path_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_905606092b4e/dlt_meta_files//data/bronze/customers",
+        "bronze_table_properties": {
+            "pipelines.autoOptimize.managed": "true"
+        },
+        "bronze_data_quality_expectations_json_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_905606092b4e/dlt_meta_files//integration_tests/conf/json/dqe/customers/bronze_data_quality_expectations.json",
+        "bronze_catalog_quarantine_it": "ravi_dlt_meta_uc",
+        "bronze_database_quarantine_it": "sdp_meta_bronze_bc_905606092b4e",
+        "bronze_quarantine_table": "customers_quarantine",
+        "bronze_quarantine_table_comment": "bronze customers quarantine table",
+        "bronze_quarantine_table_path_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_905606092b4e/dlt_meta_files//data/bronze/customers_quarantine",
+        "bronze_quarantine_table_properties": {
+            "pipelines.reset.allowed": "false"
+        },
+        "bronze_quarantine_table_cluster_by": [
+            "id",
+            "email"
+        ],
+        "bronze_append_flows": [
+            {
+                "name": "customer_bronze_flow",
+                "create_streaming_table": false,
+                "source_format": "cloudFiles",
+                "source_details": {
+                    "source_path_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_905606092b4e/dlt_meta_files//integration_tests/resources/data/customers_af",
+                    "source_schema_path": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_905606092b4e/dlt_meta_files//integration_tests/resources/customers.ddl"
+                },
+                "reader_options": {
+                    "cloudFiles.format": "json",
+                    "cloudFiles.inferColumnTypes": "true",
+                    "cloudFiles.rescuedDataColumn": "_rescued_data"
+                },
+                "once": false
+            }
+        ],
+        "silver_catalog_it": "ravi_dlt_meta_uc",
+        "silver_database_it": "sdp_meta_silver_bc_905606092b4e",
+        "silver_table": "customers",
+        "silver_table_comment": "customers silver table",
+        "silver_table_path_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_905606092b4e/dlt_meta_files//data/silver/customers",
+        "silver_transformation_json_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_905606092b4e/dlt_meta_files//integration_tests/conf/json/silver_transformations.json",
+        "silver_table_properties": {
+            "pipelines.reset.allowed": "false"
+        },
+        "silver_data_quality_expectations_json_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_905606092b4e/dlt_meta_files//integration_tests/conf/json/dqe/customers/silver_data_quality_expectations.json",
+        "silver_catalog_quarantine_it": "ravi_dlt_meta_uc",
+        "silver_database_quarantine_it": "sdp_meta_silver_bc_905606092b4e",
+        "silver_quarantine_table": "customers_quarantine",
+        "silver_quarantine_table_properties": {
+            "pipelines.reset.allowed": "false"
+        },
+        "silver_append_flows": [
+            {
+                "name": "customers_silver_flow",
+                "create_streaming_table": false,
+                "source_format": "delta",
+                "source_details": {
+                    "source_database": "ravi_dlt_meta_uc.sdp_meta_bronze_bc_905606092b4e",
+                    "source_table": "customers_delta"
+                },
+                "reader_options": {},
+                "once": false
+            }
+        ]
+    },
+    {
+        "data_flow_id": "102",
+        "data_flow_group": "A1",
+        "source_system": "MYSQL",
+        "source_format": "cloudFiles",
+        "source_details": {
+            "source_database": "APP",
+            "source_table": "TRANSACTIONS",
+            "source_path_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_905606092b4e/dlt_meta_files//integration_tests/resources/data/transactions",
+            "source_metadata": {
+                "include_autoloader_metadata_column": "True",
+                "select_metadata_cols": {
+                    "input_file_name": "_metadata.file_name",
+                    "input_file_path": "_metadata.file_path"
+                }
+            },
+            "source_schema_path": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_905606092b4e/dlt_meta_files//integration_tests/resources/transactions.ddl"
+        },
+        "bronze_catalog_it": "ravi_dlt_meta_uc",
+        "bronze_database_it": "sdp_meta_bronze_bc_905606092b4e",
+        "bronze_table": "transactions",
+        "bronze_reader_options": {
+            "cloudFiles.format": "json",
+            "cloudFiles.inferColumnTypes": "true",
+            "cloudFiles.rescuedDataColumn": "_rescued_data"
+        },
+        "bronze_table_path_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_905606092b4e/dlt_meta_files//data/bronze/transactions",
+        "bronze_table_properties": {
+            "pipelines.reset.allowed": "true"
+        },
+        "bronze_data_quality_expectations_json_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_905606092b4e/dlt_meta_files//integration_tests/conf/json/dqe/transactions/bronze_data_quality_expectations.json",
+        "bronze_catalog_quarantine_it": "ravi_dlt_meta_uc",
+        "bronze_database_quarantine_it": "sdp_meta_bronze_bc_905606092b4e",
+        "bronze_quarantine_table": "transactions_quarantine",
+        "bronze_quarantine_table_path_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_905606092b4e/dlt_meta_files//data/bronze/transactions_quarantine",
+        "bronze_quarantine_table_properties": {
+            "pipelines.reset.allowed": "true",
+            "pipelines.autoOptimize.managed": "false"
+        },
+        "bronze_append_flows": [
+            {
+                "name": "transactions_bronze_flow",
+                "create_streaming_table": false,
+                "source_format": "cloudFiles",
+                "source_details": {
+                    "source_path_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_905606092b4e/dlt_meta_files//integration_tests/resources/data/transactions_af",
+                    "source_schema_path": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_905606092b4e/dlt_meta_files//integration_tests/resources/transactions.ddl"
+                },
+                "reader_options": {
+                    "cloudFiles.format": "json",
+                    "cloudFiles.inferColumnTypes": "true",
+                    "cloudFiles.rescuedDataColumn": "_rescued_data"
+                },
+                "once": false
+            }
+        ],
+        "silver_catalog_it": "ravi_dlt_meta_uc",
+        "silver_database_it": "sdp_meta_silver_bc_905606092b4e",
+        "silver_table": "transactions",
+        "silver_cdc_apply_changes": {
+            "keys": [
+                "id"
+            ],
+            "sequence_by": "operation_date",
+            "scd_type": "1",
+            "apply_as_deletes": "operation = 'DELETE'",
+            "except_column_list": [
+                "operation",
+                "operation_date",
+                "_rescued_data"
+            ],
+            "flow_name": "silver_transactions_cdc_applychanges_flow"
+        },
+        "silver_table_path_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_905606092b4e/dlt_meta_files//data/silver/transactions",
+        "silver_transformation_json_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_905606092b4e/dlt_meta_files//integration_tests/conf/json/silver_transformations.json",
+        "silver_data_quality_expectations_json_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_905606092b4e/dlt_meta_files//integration_tests/conf/json/dqe/transactions/silver_data_quality_expectations.json",
+        "silver_table_properties": {
+            "pipelines.reset.allowed": "false"
+        },
+        "silver_catalog_quarantine_it": "ravi_dlt_meta_uc",
+        "silver_database_quarantine_it": "sdp_meta_silver_bc_905606092b4e",
+        "silver_quarantine_table": "transactions_quarantine",
+        "silver_quarantine_table_cluster_by": [
+            "id",
+            "customer_id"
+        ]
+    }
+]

--- a/integration_tests/conf/json/backward_compat_onboarding_A2_028bdbcc8db8.json
+++ b/integration_tests/conf/json/backward_compat_onboarding_A2_028bdbcc8db8.json
@@ -1,0 +1,48 @@
+[
+    {
+        "data_flow_id": "103",
+        "data_flow_group": "A2",
+        "source_system": "MYSQL",
+        "source_format": "cloudFiles",
+        "source_details": {
+            "source_database": "APP",
+            "source_table": "CUSTOMERS",
+            "source_path_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_028bdbcc8db8/dlt_meta_files//integration_tests/resources/data/customers_delta",
+            "source_metadata": {
+                "select_metadata_cols": {
+                    "input_file_name": "_metadata.file_name",
+                    "input_file_path": "_metadata.file_path"
+                }
+            },
+            "source_schema_path": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_028bdbcc8db8/dlt_meta_files//integration_tests/resources/customers.ddl"
+        },
+        "bronze_catalog_it": "ravi_dlt_meta_uc",
+        "bronze_database_it": "sdp_meta_bronze_bc_028bdbcc8db8",
+        "bronze_table": "customers_delta",
+        "bronze_reader_options": {
+            "cloudFiles.format": "json",
+            "cloudFiles.inferColumnTypes": "true",
+            "cloudFiles.rescuedDataColumn": "_rescued_data"
+        },
+        "bronze_table_path_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_028bdbcc8db8/dlt_meta_files//data/bronze/customers_delta",
+        "bronze_table_properties": {
+            "pipelines.autoOptimize.managed": "true"
+        },
+        "bronze_cluster_by": [
+            "id",
+            "email"
+        ],
+        "bronze_data_quality_expectations_json_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_028bdbcc8db8/dlt_meta_files//integration_tests/conf/json/dqe/customers/bronze_data_quality_expectations.json",
+        "bronze_catalog_quarantine_it": "ravi_dlt_meta_uc",
+        "bronze_database_quarantine_it": "sdp_meta_bronze_bc_028bdbcc8db8",
+        "bronze_quarantine_table": "customers_delta_quarantine",
+        "bronze_quarantine_table_path_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_028bdbcc8db8/dlt_meta_files//data/bronze/customers_quarantine_delta",
+        "bronze_quarantine_table_properties": {
+            "pipelines.reset.allowed": "false"
+        },
+        "bronze_quarantine_table_cluster_by": [
+            "id",
+            "email"
+        ]
+    }
+]

--- a/integration_tests/conf/json/backward_compat_onboarding_A2_905606092b4e.json
+++ b/integration_tests/conf/json/backward_compat_onboarding_A2_905606092b4e.json
@@ -1,0 +1,48 @@
+[
+    {
+        "data_flow_id": "103",
+        "data_flow_group": "A2",
+        "source_system": "MYSQL",
+        "source_format": "cloudFiles",
+        "source_details": {
+            "source_database": "APP",
+            "source_table": "CUSTOMERS",
+            "source_path_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_905606092b4e/dlt_meta_files//integration_tests/resources/data/customers_delta",
+            "source_metadata": {
+                "select_metadata_cols": {
+                    "input_file_name": "_metadata.file_name",
+                    "input_file_path": "_metadata.file_path"
+                }
+            },
+            "source_schema_path": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_905606092b4e/dlt_meta_files//integration_tests/resources/customers.ddl"
+        },
+        "bronze_catalog_it": "ravi_dlt_meta_uc",
+        "bronze_database_it": "sdp_meta_bronze_bc_905606092b4e",
+        "bronze_table": "customers_delta",
+        "bronze_reader_options": {
+            "cloudFiles.format": "json",
+            "cloudFiles.inferColumnTypes": "true",
+            "cloudFiles.rescuedDataColumn": "_rescued_data"
+        },
+        "bronze_table_path_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_905606092b4e/dlt_meta_files//data/bronze/customers_delta",
+        "bronze_table_properties": {
+            "pipelines.autoOptimize.managed": "true"
+        },
+        "bronze_cluster_by": [
+            "id",
+            "email"
+        ],
+        "bronze_data_quality_expectations_json_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_905606092b4e/dlt_meta_files//integration_tests/conf/json/dqe/customers/bronze_data_quality_expectations.json",
+        "bronze_catalog_quarantine_it": "ravi_dlt_meta_uc",
+        "bronze_database_quarantine_it": "sdp_meta_bronze_bc_905606092b4e",
+        "bronze_quarantine_table": "customers_delta_quarantine",
+        "bronze_quarantine_table_path_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_905606092b4e/dlt_meta_files//data/bronze/customers_quarantine_delta",
+        "bronze_quarantine_table_properties": {
+            "pipelines.reset.allowed": "false"
+        },
+        "bronze_quarantine_table_cluster_by": [
+            "id",
+            "email"
+        ]
+    }
+]

--- a/integration_tests/conf/json/backward_compat_onboarding_A2_a8e758c9f372.json
+++ b/integration_tests/conf/json/backward_compat_onboarding_A2_a8e758c9f372.json
@@ -1,0 +1,48 @@
+[
+    {
+        "data_flow_id": "103",
+        "data_flow_group": "A2",
+        "source_system": "MYSQL",
+        "source_format": "cloudFiles",
+        "source_details": {
+            "source_database": "APP",
+            "source_table": "CUSTOMERS",
+            "source_path_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_a8e758c9f372/dlt_meta_files//integration_tests/resources/data/customers_delta",
+            "source_metadata": {
+                "select_metadata_cols": {
+                    "input_file_name": "_metadata.file_name",
+                    "input_file_path": "_metadata.file_path"
+                }
+            },
+            "source_schema_path": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_a8e758c9f372/dlt_meta_files//integration_tests/resources/customers.ddl"
+        },
+        "bronze_catalog_it": "ravi_dlt_meta_uc",
+        "bronze_database_it": "sdp_meta_bronze_bc_a8e758c9f372",
+        "bronze_table": "customers_delta",
+        "bronze_reader_options": {
+            "cloudFiles.format": "json",
+            "cloudFiles.inferColumnTypes": "true",
+            "cloudFiles.rescuedDataColumn": "_rescued_data"
+        },
+        "bronze_table_path_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_a8e758c9f372/dlt_meta_files//data/bronze/customers_delta",
+        "bronze_table_properties": {
+            "pipelines.autoOptimize.managed": "true"
+        },
+        "bronze_cluster_by": [
+            "id",
+            "email"
+        ],
+        "bronze_data_quality_expectations_json_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_a8e758c9f372/dlt_meta_files//integration_tests/conf/json/dqe/customers/bronze_data_quality_expectations.json",
+        "bronze_catalog_quarantine_it": "ravi_dlt_meta_uc",
+        "bronze_database_quarantine_it": "sdp_meta_bronze_bc_a8e758c9f372",
+        "bronze_quarantine_table": "customers_delta_quarantine",
+        "bronze_quarantine_table_path_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_a8e758c9f372/dlt_meta_files//data/bronze/customers_quarantine_delta",
+        "bronze_quarantine_table_properties": {
+            "pipelines.reset.allowed": "false"
+        },
+        "bronze_quarantine_table_cluster_by": [
+            "id",
+            "email"
+        ]
+    }
+]

--- a/integration_tests/conf/json/backward_compat_onboarding_a8e758c9f372.json
+++ b/integration_tests/conf/json/backward_compat_onboarding_a8e758c9f372.json
@@ -1,0 +1,181 @@
+[
+    {
+        "data_flow_id": "100",
+        "data_flow_group": "A1",
+        "source_system": "MYSQL",
+        "source_format": "cloudFiles",
+        "source_details": {
+            "source_database": "APP",
+            "source_table": "CUSTOMERS",
+            "source_path_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_a8e758c9f372/dlt_meta_files//integration_tests/resources/data/customers",
+            "source_metadata": {
+                "include_autoloader_metadata_column": "True",
+                "autoloader_metadata_col_name": "source_metadata",
+                "select_metadata_cols": {
+                    "input_file_name": "_metadata.file_name",
+                    "input_file_path": "_metadata.file_path"
+                }
+            },
+            "source_schema_path": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_a8e758c9f372/dlt_meta_files//integration_tests/resources/customers.ddl"
+        },
+        "bronze_catalog_it": "ravi_dlt_meta_uc",
+        "bronze_database_it": "sdp_meta_bronze_bc_a8e758c9f372",
+        "bronze_table": "customers",
+        "bronze_table_comment": "bronze customer table",
+        "bronze_reader_options": {
+            "cloudFiles.format": "json",
+            "cloudFiles.inferColumnTypes": "true",
+            "cloudFiles.rescuedDataColumn": "_rescued_data"
+        },
+        "bronze_table_path_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_a8e758c9f372/dlt_meta_files//data/bronze/customers",
+        "bronze_table_properties": {
+            "pipelines.autoOptimize.managed": "true"
+        },
+        "bronze_data_quality_expectations_json_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_a8e758c9f372/dlt_meta_files//integration_tests/conf/json/dqe/customers/bronze_data_quality_expectations.json",
+        "bronze_catalog_quarantine_it": "ravi_dlt_meta_uc",
+        "bronze_database_quarantine_it": "sdp_meta_bronze_bc_a8e758c9f372",
+        "bronze_quarantine_table": "customers_quarantine",
+        "bronze_quarantine_table_comment": "bronze customers quarantine table",
+        "bronze_quarantine_table_path_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_a8e758c9f372/dlt_meta_files//data/bronze/customers_quarantine",
+        "bronze_quarantine_table_properties": {
+            "pipelines.reset.allowed": "false"
+        },
+        "bronze_quarantine_table_cluster_by": [
+            "id",
+            "email"
+        ],
+        "bronze_append_flows": [
+            {
+                "name": "customer_bronze_flow",
+                "create_streaming_table": false,
+                "source_format": "cloudFiles",
+                "source_details": {
+                    "source_path_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_a8e758c9f372/dlt_meta_files//integration_tests/resources/data/customers_af",
+                    "source_schema_path": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_a8e758c9f372/dlt_meta_files//integration_tests/resources/customers.ddl"
+                },
+                "reader_options": {
+                    "cloudFiles.format": "json",
+                    "cloudFiles.inferColumnTypes": "true",
+                    "cloudFiles.rescuedDataColumn": "_rescued_data"
+                },
+                "once": false
+            }
+        ],
+        "silver_catalog_it": "ravi_dlt_meta_uc",
+        "silver_database_it": "sdp_meta_silver_bc_a8e758c9f372",
+        "silver_table": "customers",
+        "silver_table_comment": "customers silver table",
+        "silver_table_path_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_a8e758c9f372/dlt_meta_files//data/silver/customers",
+        "silver_transformation_json_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_a8e758c9f372/dlt_meta_files//integration_tests/conf/json/silver_transformations.json",
+        "silver_table_properties": {
+            "pipelines.reset.allowed": "false"
+        },
+        "silver_data_quality_expectations_json_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_a8e758c9f372/dlt_meta_files//integration_tests/conf/json/dqe/customers/silver_data_quality_expectations.json",
+        "silver_catalog_quarantine_it": "ravi_dlt_meta_uc",
+        "silver_database_quarantine_it": "sdp_meta_silver_bc_a8e758c9f372",
+        "silver_quarantine_table": "customers_quarantine",
+        "silver_quarantine_table_properties": {
+            "pipelines.reset.allowed": "false"
+        },
+        "silver_append_flows": [
+            {
+                "name": "customers_silver_flow",
+                "create_streaming_table": false,
+                "source_format": "delta",
+                "source_details": {
+                    "source_database": "ravi_dlt_meta_uc.sdp_meta_bronze_bc_a8e758c9f372",
+                    "source_table": "customers_delta"
+                },
+                "reader_options": {},
+                "once": false
+            }
+        ]
+    },
+    {
+        "data_flow_id": "102",
+        "data_flow_group": "A1",
+        "source_system": "MYSQL",
+        "source_format": "cloudFiles",
+        "source_details": {
+            "source_database": "APP",
+            "source_table": "TRANSACTIONS",
+            "source_path_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_a8e758c9f372/dlt_meta_files//integration_tests/resources/data/transactions",
+            "source_metadata": {
+                "include_autoloader_metadata_column": "True",
+                "select_metadata_cols": {
+                    "input_file_name": "_metadata.file_name",
+                    "input_file_path": "_metadata.file_path"
+                }
+            },
+            "source_schema_path": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_a8e758c9f372/dlt_meta_files//integration_tests/resources/transactions.ddl"
+        },
+        "bronze_catalog_it": "ravi_dlt_meta_uc",
+        "bronze_database_it": "sdp_meta_bronze_bc_a8e758c9f372",
+        "bronze_table": "transactions",
+        "bronze_reader_options": {
+            "cloudFiles.format": "json",
+            "cloudFiles.inferColumnTypes": "true",
+            "cloudFiles.rescuedDataColumn": "_rescued_data"
+        },
+        "bronze_table_path_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_a8e758c9f372/dlt_meta_files//data/bronze/transactions",
+        "bronze_table_properties": {
+            "pipelines.reset.allowed": "true"
+        },
+        "bronze_data_quality_expectations_json_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_a8e758c9f372/dlt_meta_files//integration_tests/conf/json/dqe/transactions/bronze_data_quality_expectations.json",
+        "bronze_catalog_quarantine_it": "ravi_dlt_meta_uc",
+        "bronze_database_quarantine_it": "sdp_meta_bronze_bc_a8e758c9f372",
+        "bronze_quarantine_table": "transactions_quarantine",
+        "bronze_quarantine_table_path_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_a8e758c9f372/dlt_meta_files//data/bronze/transactions_quarantine",
+        "bronze_quarantine_table_properties": {
+            "pipelines.reset.allowed": "true",
+            "pipelines.autoOptimize.managed": "false"
+        },
+        "bronze_append_flows": [
+            {
+                "name": "transactions_bronze_flow",
+                "create_streaming_table": false,
+                "source_format": "cloudFiles",
+                "source_details": {
+                    "source_path_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_a8e758c9f372/dlt_meta_files//integration_tests/resources/data/transactions_af",
+                    "source_schema_path": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_a8e758c9f372/dlt_meta_files//integration_tests/resources/transactions.ddl"
+                },
+                "reader_options": {
+                    "cloudFiles.format": "json",
+                    "cloudFiles.inferColumnTypes": "true",
+                    "cloudFiles.rescuedDataColumn": "_rescued_data"
+                },
+                "once": false
+            }
+        ],
+        "silver_catalog_it": "ravi_dlt_meta_uc",
+        "silver_database_it": "sdp_meta_silver_bc_a8e758c9f372",
+        "silver_table": "transactions",
+        "silver_cdc_apply_changes": {
+            "keys": [
+                "id"
+            ],
+            "sequence_by": "operation_date",
+            "scd_type": "1",
+            "apply_as_deletes": "operation = 'DELETE'",
+            "except_column_list": [
+                "operation",
+                "operation_date",
+                "_rescued_data"
+            ],
+            "flow_name": "silver_transactions_cdc_applychanges_flow"
+        },
+        "silver_table_path_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_a8e758c9f372/dlt_meta_files//data/silver/transactions",
+        "silver_transformation_json_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_a8e758c9f372/dlt_meta_files//integration_tests/conf/json/silver_transformations.json",
+        "silver_data_quality_expectations_json_it": "/Volumes/ravi_dlt_meta_uc/sdp_meta_dataflowspecs_bc_a8e758c9f372/dlt_meta_files//integration_tests/conf/json/dqe/transactions/silver_data_quality_expectations.json",
+        "silver_table_properties": {
+            "pipelines.reset.allowed": "false"
+        },
+        "silver_catalog_quarantine_it": "ravi_dlt_meta_uc",
+        "silver_database_quarantine_it": "sdp_meta_silver_bc_a8e758c9f372",
+        "silver_quarantine_table": "transactions_quarantine",
+        "silver_quarantine_table_cluster_by": [
+            "id",
+            "customer_id"
+        ]
+    }
+]

--- a/integration_tests/notebooks/backward_compat_runners/add_phase2_incremental.py
+++ b/integration_tests/notebooks/backward_compat_runners/add_phase2_incremental.py
@@ -1,0 +1,43 @@
+# Databricks notebook source
+# Phase 2 incremental seed-data dropper.
+#
+# Runs at the start of the Phase 2 (v0.0.11 upgrade) workflow, BEFORE
+# the bronze pipeline. Copies fresh JSON files from the per-run
+# ``customers_phase2/`` and ``transactions_phase2/`` staging paths
+# (already on UC volume — uploaded by the orchestrator) into the
+# ORIGINAL source paths the dataflowspec points at
+# (``customers/`` and ``transactions/``).
+#
+# Auto Loader is deterministic on file path: a NEW file in an
+# already-watched directory is treated as new ingestion. So the very
+# next pipeline run inside Phase 2 picks up exactly the rows we
+# dropped here, on top of everything Phase 1 already wrote — proving
+# v0.0.11 can resume incremental ingestion against tables and
+# checkpoints first written by v0.0.10.
+import os
+
+uc_volume_path = dbutils.widgets.get("uc_volume_path").rstrip("/")
+int_tests_dir = dbutils.widgets.get("int_tests_dir").strip("/")
+
+PAIRS = (
+    ("customers_phase2",  "customers"),
+    ("transactions_phase2", "transactions"),
+)
+
+for staging, target in PAIRS:
+    src_dir = f"{uc_volume_path}/{int_tests_dir}/resources/data/{staging}"
+    dst_dir = f"{uc_volume_path}/{int_tests_dir}/resources/data/{target}"
+    src_files = dbutils.fs.ls(src_dir)
+    if not src_files:
+        raise RuntimeError(f"Phase 2 staging path {src_dir} is empty")
+    print(f"Copying {len(src_files)} file(s) from {src_dir} -> {dst_dir}")
+    for f in src_files:
+        # Force a unique destination filename so Auto Loader treats this
+        # as a brand-new file even if (somehow) a same-named file already
+        # landed in the watched directory.
+        new_name = f"phase2_{os.path.basename(f.name)}"
+        dst = f"{dst_dir}/{new_name}"
+        dbutils.fs.cp(f.path, dst)
+        print(f"  copied -> {dst}")
+
+print("Phase 2 incremental seed copy complete.")

--- a/integration_tests/notebooks/backward_compat_runners/init_dlt_meta_pipeline.py
+++ b/integration_tests/notebooks/backward_compat_runners/init_dlt_meta_pipeline.py
@@ -1,0 +1,46 @@
+# Databricks notebook source
+# Backward-compatibility integration test runner for LEGACY-shape
+# pipelines (dlt-meta v0.0.1 .. v0.0.10).
+#
+# This notebook is INTENTIONALLY a byte-for-byte clone of the v0.0.10
+# init notebook customers run in production. The whole point of the
+# backward-compat test is to prove that a v0.0.10 customer who flips
+# their ``dlt_meta_whl`` config from a v0.0.10 wheel to a v0.0.11
+# wheel -- without changing any other line in their pipeline or
+# notebook -- gets a working upgrade.
+#
+# Single-key, single-install contract
+# -----------------------------------
+# Phase 1 (SOURCE wheel = v0.0.10 dlt_meta):
+#   dlt_meta_whl -> /Volumes/.../dlt_meta-0.0.10.whl
+#
+# Phase 2 cross-namespace (legacy -> current):
+#   dlt_meta_whl -> /Volumes/.../databricks_labs_sdp_meta-0.0.11.whl
+#
+# How ``from src.* import …`` keeps resolving on Phase 2
+# ------------------------------------------------------
+# The v0.0.11 main wheel BUNDLES a real top-level ``src`` package (plus
+# a ``dlt_meta`` package), both re-exporting ``databricks.labs.sdp_meta.*``.
+# After ``%pip install`` lands the wheel in ``site-packages/``, the
+# legacy ``from src.dataflow_pipeline import …`` line below walks normal
+# import machinery: it finds ``src/`` in site-packages, runs its
+# ``__init__`` (which registers ``src.<sub>`` ->
+# ``databricks.labs.sdp_meta.<sub>`` aliases in ``sys.modules``), and
+# resolves to the canonical ``databricks.labs.sdp_meta.dataflow_pipeline``
+# symbols.
+#
+# This does NOT rely on a ``.pth`` startup hook. Serverless ``%pip
+# install`` does not re-trigger ``site.py``'s ``.pth`` scan, so the
+# v0.0.11 wheel deliberately resolves the legacy namespace through a
+# real package rather than a startup hook. No explicit ``import
+# dlt_meta`` is needed here. (See the top-level ``setup.py`` for the
+# bundling mechanism.)
+dlt_meta_whl = spark.conf.get("dlt_meta_whl")
+%pip install $dlt_meta_whl  # noqa : E999
+
+# COMMAND ----------
+
+layer = spark.conf.get("layer", None)
+
+from src.dataflow_pipeline import DataflowPipeline
+DataflowPipeline.invoke_dlt_pipeline(spark, layer)

--- a/integration_tests/notebooks/backward_compat_runners/init_sdp_meta_pipeline.py
+++ b/integration_tests/notebooks/backward_compat_runners/init_sdp_meta_pipeline.py
@@ -1,0 +1,24 @@
+# Databricks notebook source
+# Backward-compatibility integration test runner for CURRENT-shape
+# pipelines (sdp-meta v0.0.11+).
+#
+# Mirrors ``integration_tests/notebooks/cloudfile_runners/init_sdp_meta_pipeline.py``
+# but lives under ``backward_compat_runners/`` so the orchestrator
+# uploads it from a single, consistent directory regardless of which
+# profile (LEGACY or CURRENT) is the upgrade source. Used as the
+# runner notebook when the source profile of an upgrade is CURRENT
+# (e.g. v0.0.11 -> v0.0.12).
+#
+# Phase 1: ``sdp_meta_whl`` -> source-version sdp-meta wheel.
+# Phase 2: ``sdp_meta_whl`` swapped to the target-version sdp-meta
+# wheel via ``pipelines.update()``. No compat shim is needed here
+# because the namespace did not change.
+sdp_meta_whl = spark.conf.get("sdp_meta_whl")
+%pip install $sdp_meta_whl  # noqa : E999
+
+# COMMAND ----------
+
+layer = spark.conf.get("layer", None)
+
+from databricks.labs.sdp_meta.dataflow_pipeline import DataflowPipeline
+DataflowPipeline.invoke_dlt_pipeline(spark, layer)

--- a/integration_tests/notebooks/backward_compat_runners/validate_phase1.py
+++ b/integration_tests/notebooks/backward_compat_runners/validate_phase1.py
@@ -1,0 +1,54 @@
+# Databricks notebook source
+# Phase 1 validator -- runs AFTER the v0.0.10 wheel has finished both A1
+# (initial bronze + silver) and A2 (incremental bronze) workflows.
+#
+# Asserts the same row counts the existing cloudfiles integration test
+# already validates (see
+# ``integration_tests/notebooks/cloudfile_runners/validate.py``). We run
+# the SAME assertions here so the two suites stay in lockstep -- a
+# v0.0.10 customer landing on these counts is what "running in prod"
+# looks like, and Phase 2 has to grow these numbers, not lose them.
+import json
+
+import pandas as pd
+
+run_id = dbutils.widgets.get("run_id")
+uc_catalog_name = dbutils.widgets.get("uc_catalog_name")
+bronze_schema = dbutils.widgets.get("bronze_schema")
+silver_schema = dbutils.widgets.get("silver_schema")
+output_file_path = dbutils.widgets.get("output_file_path")
+log_list = []
+
+log_list.append("Backward-compat Phase 1 (v0.0.10 wheel) validation starting.")
+
+# Expected row counts after Phase 1 (A1 initial + A2 incremental). These
+# match ``cloudfile_runners/validate.py`` exactly: same seed data, same
+# DQE rules, same A1+A2 ordering.
+EXPECTED_COUNTS = {
+    f"{uc_catalog_name}.{bronze_schema}.customers": 51453,
+    f"{uc_catalog_name}.{bronze_schema}.customers_quarantine": 256,
+    f"{uc_catalog_name}.{bronze_schema}.transactions": 10002,
+    f"{uc_catalog_name}.{bronze_schema}.transactions_quarantine": 6,
+    f"{uc_catalog_name}.{silver_schema}.customers": 73212,
+    f"{uc_catalog_name}.{silver_schema}.transactions": 8759,
+}
+
+phase1_counts = {}
+for table, expected in EXPECTED_COUNTS.items():
+    actual = spark.sql(f"SELECT count(*) AS cnt FROM {table}").collect()[0].cnt
+    phase1_counts[table] = int(actual)
+    status = "Passed" if int(actual) == expected else "Failed"
+    log_list.append(
+        f"Phase1 count {table}: expected={expected} actual={actual}. {status}!"
+    )
+
+# Hand the per-table Phase 1 counts off to the Phase 2 validator. We
+# avoid persisting them to the dataflowspec table or any user-facing
+# catalog: a transient driver-local file under /Volumes/.../tmp/ keeps
+# the contract narrow and the cleanup script's job simple.
+uc_volume_path = dbutils.widgets.get("uc_volume_path").rstrip("/")
+phase1_counts_dump = f"{uc_volume_path}/tmp/backward_compat_phase1_counts_{run_id}.json"
+dbutils.fs.put(phase1_counts_dump, json.dumps(phase1_counts), overwrite=True)
+log_list.append(f"Phase1 counts persisted -> {phase1_counts_dump}")
+
+pd.DataFrame(log_list).to_csv(output_file_path)

--- a/integration_tests/notebooks/backward_compat_runners/validate_phase2.py
+++ b/integration_tests/notebooks/backward_compat_runners/validate_phase2.py
@@ -1,0 +1,275 @@
+# Databricks notebook source
+# Phase 2 validator -- runs AFTER the wheel has been swapped to v0.0.11
+# AND a fresh incremental cycle has consumed the Phase 2 seed batch.
+#
+# Three classes of assertions:
+#
+#   (1) Data preservation. Every row Phase 1 wrote must still be there.
+#       We compare against the per-table counts the Phase 1 validator
+#       persisted to a UC volume scratch file.
+#   (2) Incremental growth. Phase 2 fed N new customer rows and M new
+#       transaction rows into the watched source paths; bronze must
+#       grow by AT LEAST those row deltas (DQE may quarantine some, so
+#       we use >= rather than ==).
+#   (3) Schema compatibility. The dataflowspec persisted by v0.0.10
+#       must read cleanly through v0.0.11's ``BronzeDataflowSpec`` /
+#       ``SilverDataflowSpec`` dataclasses, with new v0.0.11 fields
+#       backfilled to their documented defaults
+#       (``rowFilter``/``quarantineRowFilter``/``cdcApplyChangesFlows``
+#       -> ``None``, ``cdcApplyChangesFlowsSchemas`` -> ``{}``,
+#       ``clusterByAuto`` -> ``False``).
+#
+# Together (1)+(2)+(3) prove the customer-pipeline-doesn't-break
+# contract end-to-end: same job, same notebook, same dataflowspec --
+# only the wheel changed, and v0.0.10's persisted state is fully
+# consumable by v0.0.11.
+#
+# This notebook is a regular jobs ``notebook_task`` -- not a DLT
+# runner -- so it doesn't get the wheel for free from the pipeline's
+# ``configuration.dlt_meta_whl``. We install the v0.0.11 main wheel
+# explicitly at the top of cell 1 so cell 2's
+# ``from src.dataflow_spec import …`` actually has the package on
+# sys.path. Every other path in the notebook lives below the install
+# in cell 2 so it sees the freshly-installed package.
+target_main_whl = dbutils.widgets.get("target_main_whl")
+%pip install $target_main_whl  # noqa: E999
+
+# COMMAND ----------
+
+import json
+
+import pandas as pd
+
+run_id = dbutils.widgets.get("run_id")
+uc_catalog_name = dbutils.widgets.get("uc_catalog_name")
+bronze_schema = dbutils.widgets.get("bronze_schema")
+silver_schema = dbutils.widgets.get("silver_schema")
+sdp_meta_schema = dbutils.widgets.get("sdp_meta_schema")
+output_file_path = dbutils.widgets.get("output_file_path")
+uc_volume_path = dbutils.widgets.get("uc_volume_path").rstrip("/")
+phase2_customer_delta = int(dbutils.widgets.get("phase2_customer_delta"))
+phase2_transaction_delta = int(dbutils.widgets.get("phase2_transaction_delta"))
+
+log_list = []
+log_list.append("Backward-compat Phase 2 (v0.0.11 upgrade) validation starting.")
+
+# (1) Read Phase 1 counts back.
+phase1_counts_path = f"{uc_volume_path}/tmp/backward_compat_phase1_counts_{run_id}.json"
+phase1_raw = dbutils.fs.head(phase1_counts_path, 1024 * 1024)
+phase1_counts = json.loads(phase1_raw)
+log_list.append(f"Loaded Phase 1 counts: {phase1_counts}")
+
+# (2) Delta budgets (incremental rows fed into the watched source paths
+# at the start of Phase 2). Bronze must grow by AT LEAST the delta;
+# silver follows bronze (CDC + dedup may shrink the silver delta below
+# the bronze delta, so we use >= for bronze and >0 for silver).
+budgets = {
+    f"{uc_catalog_name}.{bronze_schema}.customers": phase2_customer_delta,
+    f"{uc_catalog_name}.{bronze_schema}.transactions": phase2_transaction_delta,
+}
+for table, expected_delta in budgets.items():
+    actual = spark.sql(f"SELECT count(*) AS cnt FROM {table}").collect()[0].cnt
+    prior = phase1_counts.get(table, 0)
+    growth = int(actual) - int(prior)
+    if growth >= expected_delta:
+        log_list.append(
+            f"Phase2 bronze growth {table}: prior={prior} actual={actual} "
+            f"delta={growth} expected>={expected_delta}. Passed!"
+        )
+    else:
+        log_list.append(
+            f"Phase2 bronze growth {table}: prior={prior} actual={actual} "
+            f"delta={growth} expected>={expected_delta}. Failed!"
+        )
+
+# Silver tables must at least retain Phase 1 rows. CDC apply_changes can
+# both grow and shrink silver counts under fresh batches (dedup), so
+# the strict invariant is "row count must not regress to below Phase 1
+# baseline" -- not "must equal Phase 1 + delta".
+silver_tables = [
+    f"{uc_catalog_name}.{silver_schema}.customers",
+    f"{uc_catalog_name}.{silver_schema}.transactions",
+]
+for table in silver_tables:
+    actual = int(spark.sql(f"SELECT count(*) AS cnt FROM {table}").collect()[0].cnt)
+    prior = int(phase1_counts.get(table, 0))
+    # Silver `customers` is an append flow target -> count must grow.
+    # Silver `transactions` is CDC SCD-1 -> count may stay flat (dedup
+    # rewrote the same keys). In both cases, count must NOT drop.
+    if actual >= prior:
+        log_list.append(
+            f"Phase2 silver retention {table}: prior={prior} actual={actual}. Passed!"
+        )
+    else:
+        log_list.append(
+            f"Phase2 silver retention {table}: prior={prior} actual={actual}. "
+            "Failed!"
+        )
+
+# (3) Schema-compatibility check: load v0.0.10's persisted dataflowspec
+# rows through v0.0.11's dataclasses and confirm new fields backfilled
+# to documented defaults. We import via ``src.*`` to also exercise the
+# compat shim end-to-end.
+log_list.append(
+    "Verifying v0.0.10 persisted dataflowspec rows are consumable by v0.0.11..."
+)
+
+bronze_table = f"{uc_catalog_name}.{sdp_meta_schema}.bronze_dataflowspec"
+silver_table = f"{uc_catalog_name}.{sdp_meta_schema}.silver_dataflowspec"
+
+try:
+    from src.dataflow_spec import BronzeDataflowSpec, SilverDataflowSpec, DataflowSpecUtils
+    log_list.append("Imported BronzeDataflowSpec/SilverDataflowSpec via src.* shim. Passed!")
+except Exception as exc:
+    # Capture the full traceback so DLT-runtime-specific failures
+    # (e.g. a top-level statement in cli.py iterating over a config
+    # that's None on serverless) are debuggable from the persisted
+    # log without re-running the job to read driver stdout.
+    import traceback as _tb
+    tb_text = _tb.format_exc()
+    log_list.append(
+        f"Failed to import via src.* shim: {type(exc).__name__}: {exc}. Failed!"
+    )
+    log_list.append(f"  traceback: {tb_text}")
+    BronzeDataflowSpec = SilverDataflowSpec = DataflowSpecUtils = None
+
+if BronzeDataflowSpec is not None:
+    # Bronze: confirm every persisted row materializes into a
+    # dataclass without TypeError, with the new v0.0.11 fields
+    # backfilled to their documented defaults via
+    # DataflowSpecUtils.populate_additional_df_cols (the same helper
+    # the runtime path uses).
+    #
+    # populate_additional_df_cols expects a per-row dict (it calls
+    # ``onboarding_row_dict.keys()`` internally) -- not a Spark
+    # DataFrame. Spark Connect serverless rejects ``DataFrame.keys()``
+    # with PySparkAttributeError, so we MUST collect rows first and
+    # call the helper per-dict, mirroring how
+    # ``DataflowSpecUtils.get_bronze_dataflow_spec`` consumes it
+    # internally (see ``dataflow_spec.py:380-389``).
+    bronze_rows = [r.asDict() for r in spark.read.table(bronze_table).collect()]
+    bronze_rows = [
+        DataflowSpecUtils.populate_additional_df_cols(
+            r, DataflowSpecUtils.additional_bronze_df_columns
+        )
+        for r in bronze_rows
+    ]
+    rows = bronze_rows
+    bronze_ok = 0
+    for row in rows:
+        try:
+            spec = BronzeDataflowSpec(**row)
+        except Exception as exc:
+            log_list.append(
+                f"BronzeDataflowSpec from row dataFlowId={row.get('dataFlowId')} "
+                f"failed: {exc}. Failed!"
+            )
+            continue
+        # New v0.0.11 bronze fields must be present on the dataclass
+        # AND backfilled to whatever ``populate_additional_df_cols``
+        # (the read-time helper used by ``get_bronze_dataflow_spec``)
+        # writes when the column is absent from a v0.0.10-shape Delta
+        # row. That helper just sets missing columns to ``None``
+        # unconditionally (see ``dataflow_spec.py:391-396``), so the
+        # backward-compat invariant for THIS code path is "every new
+        # field is None on v0.0.10 rows".
+        #
+        # NOTE on divergence: the unit-test fixture
+        # ``EXPECTED_BRONZE_DEFAULTS_AT_ONBOARDING`` (in
+        # ``tests/test_backward_compat_v0_0_10.py``) expects
+        # ``clusterByAuto=False`` and ``cdcApplyChangesFlowsSchemas={}``
+        # because that test exercises a different code path:
+        # re-running v0.0.11 onboarding against a v0.0.10 JSON file,
+        # which goes through ``__get_cluster_by_auto`` (returns False)
+        # and ``get_cdc_apply_changes_flows_json`` (returns {}). Don't
+        # copy those expectations here -- they're for onboarding-side
+        # defaults, not read-side backfills.
+        new_v011_fields = (
+            "rowFilter",
+            "quarantineRowFilter",
+            "cdcApplyChangesFlows",
+            "cdcApplyChangesFlowsSchemas",
+            "clusterByAuto",
+        )
+        defaults_ok = all(
+            getattr(spec, fname, "MISSING") is None for fname in new_v011_fields
+        )
+        if defaults_ok:
+            bronze_ok += 1
+        else:
+            actuals = {
+                fname: getattr(spec, fname, "MISSING") for fname in new_v011_fields
+            }
+            log_list.append(
+                f"BronzeDataflowSpec dataFlowId={spec.dataFlowId} "
+                f"defaults wrong: {actuals}. Failed!"
+            )
+    if bronze_ok == len(rows):
+        log_list.append(
+            f"BronzeDataflowSpec backward-compat: {bronze_ok}/{len(rows)} rows "
+            "materialized with v0.0.11 defaults. Passed!"
+        )
+    else:
+        log_list.append(
+            f"BronzeDataflowSpec backward-compat: only {bronze_ok}/{len(rows)} OK. Failed!"
+        )
+
+    # Same per-row pattern as bronze above -- pass dicts, not the
+    # DataFrame, because Spark Connect serverless doesn't expose
+    # ``DataFrame.keys()`` and ``populate_additional_df_cols`` calls
+    # ``onboarding_row_dict.keys()`` internally.
+    silver_rows = [r.asDict() for r in spark.read.table(silver_table).collect()]
+    silver_rows = [
+        DataflowSpecUtils.populate_additional_df_cols(
+            r, DataflowSpecUtils.additional_silver_df_columns
+        )
+        for r in silver_rows
+    ]
+    rows = silver_rows
+    silver_ok = 0
+    for row in rows:
+        try:
+            spec = SilverDataflowSpec(**row)
+        except Exception as exc:
+            log_list.append(
+                f"SilverDataflowSpec from row dataFlowId={row.get('dataFlowId')} "
+                f"failed: {exc}. Failed!"
+            )
+            continue
+        # Silver has the same set of new v0.0.11 fields as bronze
+        # MINUS ``cdcApplyChangesFlowsSchemas`` (silver doesn't carry
+        # a per-flow schemas map -- see additional_silver_df_columns
+        # in dataflow_spec.py:307-324). Same read-side backfill
+        # invariant applies: every new field is None on v0.0.10 rows.
+        new_v011_silver_fields = (
+            "rowFilter",
+            "quarantineRowFilter",
+            "cdcApplyChangesFlows",
+            "clusterByAuto",
+        )
+        defaults_ok = all(
+            getattr(spec, fname, "MISSING") is None
+            for fname in new_v011_silver_fields
+        )
+        if defaults_ok:
+            silver_ok += 1
+        else:
+            actuals = {
+                fname: getattr(spec, fname, "MISSING")
+                for fname in new_v011_silver_fields
+            }
+            log_list.append(
+                f"SilverDataflowSpec dataFlowId={spec.dataFlowId} "
+                f"defaults wrong: {actuals}. Failed!"
+            )
+    if silver_ok == len(rows):
+        log_list.append(
+            f"SilverDataflowSpec backward-compat: {silver_ok}/{len(rows)} rows "
+            "materialized with v0.0.11 defaults. Passed!"
+        )
+    else:
+        log_list.append(
+            f"SilverDataflowSpec backward-compat: only {silver_ok}/{len(rows)} OK. Failed!"
+        )
+
+pd.DataFrame(log_list).to_csv(output_file_path)

--- a/integration_tests/resources/data/customers_phase2/customers.json
+++ b/integration_tests/resources/data/customers_phase2/customers.json
@@ -1,0 +1,5 @@
+{"address":"100 Phase2 Lane\nUpgradeville, CA 90210","email":"alice.phase2@example.com","firstname":"Alice","id":"bc0aa01a-1111-1111-1111-000000000001","lastname":"Upgrade","operation":"APPEND","operation_date":"06-08-2026 09:00:00"}
+{"address":"101 Phase2 Lane\nUpgradeville, CA 90210","email":"bob.phase2@example.com","firstname":"Bob","id":"bc0aa01a-2222-2222-2222-000000000002","lastname":"Migrate","operation":"APPEND","operation_date":"06-08-2026 09:01:00"}
+{"address":"102 Phase2 Lane\nUpgradeville, CA 90210","email":"carol.phase2@example.com","firstname":"Carol","id":"bc0aa01a-3333-3333-3333-000000000003","lastname":"Compatible","operation":"UPDATE","operation_date":"06-08-2026 09:02:00"}
+{"address":"103 Phase2 Lane\nUpgradeville, CA 90210","email":"dan.phase2@example.com","firstname":"Dan","id":"bc0aa01a-4444-4444-4444-000000000004","lastname":"Backward","operation":"APPEND","operation_date":"06-08-2026 09:03:00"}
+{"address":"104 Phase2 Lane\nUpgradeville, CA 90210","email":"eve.phase2@example.com","firstname":"Eve","id":"bc0aa01a-5555-5555-5555-000000000005","lastname":"Forward","operation":"APPEND","operation_date":"06-08-2026 09:04:00"}

--- a/integration_tests/resources/data/transactions_phase2/transactions.json
+++ b/integration_tests/resources/data/transactions_phase2/transactions.json
@@ -1,0 +1,5 @@
+{"amount":42.5,"customer_id":"bc0aa01a-1111-1111-1111-000000000001","id":"tx-bc0a-1111-1111-000000000001","item_count":2.0,"operation":"APPEND","operation_date":"06-08-2026 09:00:00","transaction_date":"06-08-2026 09:00:00"}
+{"amount":17.99,"customer_id":"bc0aa01a-2222-2222-2222-000000000002","id":"tx-bc0a-2222-2222-000000000002","item_count":1.0,"operation":"APPEND","operation_date":"06-08-2026 09:01:00","transaction_date":"06-08-2026 09:01:00"}
+{"amount":250.00,"customer_id":"bc0aa01a-3333-3333-3333-000000000003","id":"tx-bc0a-3333-3333-000000000003","item_count":5.0,"operation":"APPEND","operation_date":"06-08-2026 09:02:00","transaction_date":"06-08-2026 09:02:00"}
+{"amount":99.95,"customer_id":"bc0aa01a-4444-4444-4444-000000000004","id":"tx-bc0a-4444-4444-000000000004","item_count":3.0,"operation":"UPDATE","operation_date":"06-08-2026 09:03:00","transaction_date":"06-08-2026 09:03:00"}
+{"amount":7.49,"customer_id":"bc0aa01a-5555-5555-5555-000000000005","id":"tx-bc0a-5555-5555-000000000005","item_count":1.0,"operation":"APPEND","operation_date":"06-08-2026 09:04:00","transaction_date":"06-08-2026 09:04:00"}

--- a/integration_tests/run_backward_compat_tests.py
+++ b/integration_tests/run_backward_compat_tests.py
@@ -1,0 +1,1241 @@
+"""Backward-compatibility integration test: generic SOURCE -> TARGET upgrade.
+
+Goal
+----
+A customer's existing pipeline running on SOURCE_VERSION must keep working
+unchanged when the wheel is swapped to TARGET_VERSION. No notebook edits,
+no onboarding redo, no DLT checkpoint resets, no extra wheels.
+
+Two profiles ship out of the box -- see ``version_profiles.py``:
+
+  * ``LEGACY``   -- v0.0.1 through v0.0.10 (dlt_meta dist, ``from src.*``
+                    runner imports, ``dlt_meta_whl`` config key).
+  * ``CURRENT``  -- v0.0.11 and later (databricks_labs_sdp_meta dist,
+                    ``from databricks.labs.sdp_meta.*`` runner imports,
+                    ``sdp_meta_whl`` config key). The v0.0.11 main wheel
+                    BUNDLES a legacy-namespace compat surface: a real
+                    top-level ``src`` package (plus a ``dlt_meta``
+                    package), both re-exporting
+                    ``databricks.labs.sdp_meta.*``. So a LEGACY-source
+                    customer who flips their ``dlt_meta_whl`` config from
+                    a v0.0.10 wheel to a v0.0.11 wheel keeps working
+                    without any other change -- their
+                    ``from src.* import …`` resolves through the real
+                    ``src`` package via normal import machinery.
+
+Profile resolution is git-ref-prefix based. Pass ``--source_version`` and
+``--target_version`` (any git tag, branch, or SHA the wheel builder can
+check out). The orchestrator infers the profile for each ref; override
+via ``--source_profile`` / ``--target_profile`` if a custom branch needs
+explicit pinning.
+
+Two-phase contract
+------------------
+
+Phase 1 (SOURCE wheel):
+  1. Build SOURCE wheel from --source_version git ref.
+  2. Onboard A1 (initial) using SOURCE-shape onboarding template.
+  3. Run bronze A1 pipeline + silver pipeline.
+  4. Onboard A2 (incremental).
+  5. Run bronze A2 + silver again.
+  6. Validate row counts and persist them for Phase 2.
+
+[Local: build TARGET wheel, upload to the SAME UC volume, then
+ ``pipelines.update()`` each pipeline's configuration to swap the value
+ behind the SOURCE profile's pipeline-config key from the SOURCE wheel
+ path to the TARGET wheel path. Pipeline IDs DO NOT change, so DLT
+ checkpoints (which are pipeline-scoped) are preserved.]
+
+Phase 2 (TARGET wheel):
+  1. Drop a small new batch of customers + transactions JSON files
+     into the original source paths (5 each).
+  2. Re-run bronze pipeline. Auto Loader sees the new files via the
+     existing checkpoint and ingests them on top of SOURCE's tables.
+  3. Re-run silver pipeline.
+  4. Validate: every Phase 1 row still present (compared to the
+     persisted Phase 1 counts), bronze grew by >= 5 rows per source,
+     silver did not regress, dataflowspec persisted by SOURCE reads
+     cleanly through TARGET's dataclasses.
+
+One config key, one wheel, one ``%pip install``
+-----------------------------------------------
+The runner notebook is the SOURCE profile's runner -- byte-for-byte the
+file the customer would have on the source version. It reads exactly
+ONE pipeline-config key (``dlt_meta_whl`` for LEGACY) and runs ONE
+``%pip install $dlt_meta_whl`` line. For LEGACY -> CURRENT cross-
+namespace upgrades the source runner's ``from src.* import …`` keeps
+resolving because the v0.0.11 wheel bundles a real top-level ``src``
+package: once ``%pip install`` lands the wheel, the runner's
+``from src.dataflow_pipeline import …`` walks normal import machinery,
+finds ``src/`` in site-packages, runs its ``__init__`` (which registers
+the ``src.<sub>`` -> ``databricks.labs.sdp_meta.<sub>`` aliases), and
+resolves. This does NOT depend on a ``.pth`` firing -- serverless
+``%pip install`` does not re-trigger ``site.py``'s ``.pth`` scan, which
+is exactly why resolution goes through a real package rather than a
+startup hook.
+
+Usage
+-----
+
+    # Default: v0.0.10 -> v0.0.11 (legacy -> current)
+    python integration_tests/run_backward_compat_tests.py \\
+        --uc_catalog_name=<catalog>
+
+    # Future: v0.0.11 -> v0.0.12 (current -> current)
+    python integration_tests/run_backward_compat_tests.py \\
+        --uc_catalog_name=<catalog> \\
+        --source_version=v0.0.11 \\
+        --target_version=v0.0.12
+
+    # Custom branches with explicit profile pins
+    python integration_tests/run_backward_compat_tests.py \\
+        --uc_catalog_name=<catalog> \\
+        --source_version=feature/legacy-bugfix --source_profile=legacy \\
+        --target_version=feature/sdp-meta     --target_profile=current
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import traceback
+import uuid
+import warnings
+import webbrowser
+from dataclasses import dataclass, field
+from datetime import timedelta
+from typing import Dict, Optional
+
+# Add project root to Python path so ``databricks.labs.sdp_meta`` resolves
+# (we only use it for the WorkspaceInstaller helper, not anything that's
+# version-sensitive between phases).
+project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.append(project_root)
+
+from databricks.sdk import WorkspaceClient  # noqa: E402
+from databricks.sdk.service import compute, jobs  # noqa: E402
+from databricks.sdk.service.catalog import SchemasAPI, VolumeInfo, VolumeType  # noqa: E402
+from databricks.sdk.service.pipelines import NotebookLibrary, PipelineLibrary  # noqa: E402
+from databricks.sdk.service.workspace import ImportFormat, Language  # noqa: E402
+
+from databricks.labs.sdp_meta.identifiers import validate_uc_identifier  # noqa: E402
+
+from integration_tests.version_profiles import (  # noqa: E402
+    DEFAULT_SOURCE_REF,
+    DEFAULT_TARGET_REF,
+    KNOWN_PROFILES,
+    VersionProfile,
+    is_cross_namespace_upgrade,
+    resolve_profile,
+)
+from integration_tests.wheel_builder import GitRefWheelBuilder  # noqa: E402
+
+
+@dataclass
+class BCRunnerConf:
+    """Per-run state for the backward-compat orchestrator.
+
+    Mirrors ``SDPMetaRunnerConf`` from ``run_integration_tests.py`` but
+    pared down to the surface this test actually uses (cloudfiles +
+    bronze/silver), and adds the wheel-swap fields. Profile-driven --
+    every version-line knob (distribution, runner notebook, onboarding
+    template, pipeline-config key, compat shim) lives on
+    ``source_profile`` / ``target_profile``, never on this dataclass.
+    """
+
+    run_id: str
+    uc_catalog_name: str
+    source_ref: str
+    target_ref: str
+    source_profile: VersionProfile
+    target_profile: VersionProfile
+    profile: Optional[str] = None  # databricks-cli profile (NOT the version profile)
+    username: Optional[str] = None
+
+    # Where wheels come from at install time.
+    #
+    #   "local"  -- build wheels from <source_ref> + <target_ref> with
+    #               GitRefWheelBuilder, upload to UC volume, runners
+    #               and wheel-tasks reference the UC volume paths
+    #               (default; matches what real customers do --
+    #               install a pre-built artifact).
+    #   "git"    -- skip the local build entirely. Runners
+    #               ``%pip install git+<git_repo_url>@<ref>`` directly
+    #               and the Phase 1 onboarding wheel-task resolves
+    #               the same git URL via JobEnvironment.dependencies.
+    #               Faster local iteration; requires the cluster to
+    #               have egress to ``git_repo_url``.
+    install_mode: str = "local"
+    git_repo_url: str = "https://github.com/databrickslabs/dlt-meta.git"
+    # When True, skip the git-worktree checkout for the TARGET main
+    # wheel and run ``setup.py bdist_wheel`` against the developer's
+    # working tree instead. Use ONLY for iterating on uncommitted
+    # target-side changes (bundled compat shim, post-rename CLI
+    # aliases, etc.) before they're pushed to ``target_ref``. Source
+    # ALWAYS comes from the pinned ref -- the source side is the
+    # customer's already-released wheel and has nothing to do with
+    # local edits.
+    build_target_from_worktree: bool = False
+
+    # Schema names (one per layer + one for dataflowspec). Per-run
+    # suffix avoids collisions when two devs hit the same UC catalog.
+    sdp_meta_schema: str = ""
+    bronze_schema: str = ""
+    silver_schema: str = ""
+
+    # Volume + workspace paths.
+    uc_volume_name: str = "dlt_meta_files"
+    volume_info: Optional[VolumeInfo] = None
+    uc_volume_path: str = ""
+    runners_nb_path: str = ""
+    int_tests_dir: str = "integration_tests"
+
+    # Local + remote wheel paths.
+    #
+    # ``source_main_whl`` -- main wheel built from --source_version.
+    # ``target_main_whl`` -- main wheel built from --target_version.
+    #
+    # No companion compat-shim wheel: the target wheel bundles its own
+    # legacy-namespace compat surface (a real ``src`` package +
+    # ``dlt_meta`` package) when needed, so a single wheel install is
+    # always enough for both same-namespace and cross-namespace
+    # upgrades.
+    source_main_whl_local: str = ""
+    target_main_whl_local: str = ""
+    source_main_whl_remote: str = ""
+    target_main_whl_remote: str = ""
+
+    # Generated onboarding-file output paths (one per group) --
+    # gitignored.
+    a1_onboarding_file: str = ""
+    a2_onboarding_file: str = ""
+
+    # Pipeline IDs (created in Phase 1, reused in Phase 2).
+    bronze_a1_pipeline_id: str = ""
+    bronze_a2_pipeline_id: str = ""
+    silver_pipeline_id: str = ""
+
+    # Job IDs (one job per phase).
+    phase1_job_id: Optional[int] = None
+    phase2_job_id: Optional[int] = None
+
+    # Phase output CSV paths inside the workspace + local copies.
+    phase1_output_ws: str = ""
+    phase2_output_ws: str = ""
+
+    # Incremental seed shape. The two staging dirs we ship in the repo
+    # contain exactly this many rows; the validator uses these as the
+    # >= floor for bronze growth in Phase 2.
+    phase2_customer_delta: int = 5
+    phase2_transaction_delta: int = 5
+
+    # Cached per-pipeline configuration dictionaries. Built once in
+    # Phase 1 (under SOURCE) and again in Phase 2 (under TARGET).
+    # Stored on the conf so logging + error messages can introspect.
+    _phase1_pipeline_configs: Dict[str, Dict[str, str]] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        self.sdp_meta_schema = self.sdp_meta_schema or f"sdp_meta_dataflowspecs_bc_{self.run_id}"
+        self.bronze_schema = self.bronze_schema or f"sdp_meta_bronze_bc_{self.run_id}"
+        self.silver_schema = self.silver_schema or f"sdp_meta_silver_bc_{self.run_id}"
+        self.a1_onboarding_file = (
+            f"integration_tests/conf/json/backward_compat_onboarding_{self.run_id}.json"
+        )
+        self.a2_onboarding_file = (
+            f"integration_tests/conf/json/backward_compat_onboarding_A2_{self.run_id}.json"
+        )
+
+    @property
+    def is_cross_namespace_upgrade(self) -> bool:
+        """Whether SOURCE and TARGET use different runner-import namespaces.
+
+        Used purely for logging and gate decisions; no separate compat
+        shim wheel is built or installed -- the target wheel is
+        responsible for bundling its own legacy-namespace compat
+        surface when the namespace changes.
+        """
+        return is_cross_namespace_upgrade(
+            source=self.source_profile, target=self.target_profile
+        )
+
+
+class BackwardCompatRunner:
+    """Two-phase orchestrator: SOURCE -> TARGET wheel swap.
+
+    Mirrors ``SDPMETARunner`` from ``run_integration_tests.py`` for the
+    upload + workflow primitives, but adds the phase boundary and the
+    pipeline reconfig step. Kept as a separate class so the existing
+    test runner stays untouched.
+    """
+
+    # Per-phase wait ceiling for ``jobs.run_now().result(...)``. Phase 1
+    # is the long pole: six pipeline runs in sequence (onboard A1 ->
+    # bronze A1 -> silver -> onboard A2 -> bronze A2 -> silver) plus
+    # the validate notebook task. Each serverless DLT pipeline run
+    # incurs a cold-start charge (~1-2 min) on top of its actual
+    # processing window. Override at runtime with --phase_timeout_min
+    # if a slow workspace pushes Phase 1 past the wall.
+    DEFAULT_PHASE_TIMEOUT_MIN = 30
+
+    def __init__(self, args: dict, ws: WorkspaceClient) -> None:
+        self.args = args
+        self.ws = ws
+        self.base_dir = "integration_tests"
+        self.phase_timeout_min = int(
+            args.get("phase_timeout_min") or self.DEFAULT_PHASE_TIMEOUT_MIN
+        )
+
+    # ----- helpers --------------------------------------------------------
+
+    def _my_username(self) -> str:
+        return self.ws.current_user.me().user_name
+
+    def _build_runner_conf(self) -> BCRunnerConf:
+        run_id = uuid.uuid4().hex[:12]
+        username = self._my_username()
+
+        source_ref = self.args.get("source_version") or DEFAULT_SOURCE_REF
+        target_ref = self.args.get("target_version") or DEFAULT_TARGET_REF
+        source_profile = resolve_profile(
+            source_ref, profile_override=self.args.get("source_profile")
+        )
+        target_profile = resolve_profile(
+            target_ref, profile_override=self.args.get("target_profile")
+        )
+
+        install_mode = (self.args.get("install_mode") or "local").lower()
+        if install_mode not in ("local", "git"):
+            raise ValueError(
+                f"--install_mode must be 'local' or 'git'; got {install_mode!r}"
+            )
+
+        build_target_from_worktree = bool(
+            self.args.get("build_target_from_worktree")
+        )
+        if build_target_from_worktree and install_mode != "local":
+            raise ValueError(
+                "--build_target_from_worktree only makes sense with "
+                "--install_mode=local; got "
+                f"install_mode={install_mode!r}."
+            )
+
+        conf = BCRunnerConf(
+            run_id=run_id,
+            uc_catalog_name=self.args["uc_catalog_name"],
+            source_ref=source_ref,
+            target_ref=target_ref,
+            source_profile=source_profile,
+            target_profile=target_profile,
+            profile=self.args.get("profile"),
+            username=username,
+            install_mode=install_mode,
+            git_repo_url=self.args.get("git_repo_url")
+            or BCRunnerConf.__dataclass_fields__["git_repo_url"].default,
+            build_target_from_worktree=build_target_from_worktree,
+        )
+        conf.runners_nb_path = (
+            f"/Users/{username}/dlt_meta_int_tests/backward_compat/{run_id}"
+        )
+        conf.phase1_output_ws = (
+            f"{conf.runners_nb_path}/integration-test-output_phase1.csv"
+        )
+        conf.phase2_output_ws = (
+            f"{conf.runners_nb_path}/integration-test-output_phase2.csv"
+        )
+
+        if conf.is_cross_namespace_upgrade and not (
+            target_ref.startswith("v0.0.")
+            or target_ref.startswith("v0.1")
+            or target_ref == "feature/sdp-meta"
+        ):
+            # Cross-namespace upgrades only work when the target wheel
+            # bundles a legacy-namespace compat surface. v0.0.11 and later
+            # CURRENT-profile builds do; arbitrary unrecognised refs
+            # might not. Surface a warning so the user knows to verify
+            # the target wheel actually ships the real ``src`` package
+            # before running.
+            warnings.warn(
+                f"Cross-namespace upgrade requested ({source_profile.name!r} "
+                f"-> {target_profile.name!r}) with target_ref={target_ref!r}. "
+                "The target wheel MUST bundle a legacy-namespace compat "
+                "surface (a real `src` package + `dlt_meta` package "
+                "re-exporting `databricks.labs.sdp_meta.*`) for the source "
+                "runner notebook's "
+                "`from src.* import …` to keep resolving. Verify the "
+                "wheel before running, or pin source/target profiles "
+                "explicitly.",
+                stacklevel=2,
+            )
+
+        return conf
+
+    # ----- wheel build + upload ------------------------------------------
+
+    def build_wheels(self, conf: BCRunnerConf) -> None:
+        """Build SOURCE main + TARGET main wheels.
+
+        Skipped entirely when ``install_mode == "git"`` -- in that case
+        runners and wheel-tasks resolve git URLs at install time and
+        nothing has to be uploaded.
+
+        Only ONE wheel per side is built. For cross-namespace upgrades
+        (LEGACY -> CURRENT) the target wheel BUNDLES a legacy-namespace
+        compat surface (a real ``src`` package + ``dlt_meta`` package
+        re-exporting ``databricks.labs.sdp_meta.*``, configured in the
+        top-level ``setup.py``) so we don't need a separate companion
+        wheel to deliver it.
+        """
+        if conf.install_mode == "git":
+            print(
+                f"=== install_mode=git: skipping local wheel build; "
+                f"all installs will resolve from {conf.git_repo_url!r} ==="
+            )
+            return
+
+        builder = GitRefWheelBuilder()
+        try:
+            # SOURCE wheel always comes from the pinned ref -- it
+            # represents the customer's already-released wheel, which
+            # has no relationship to local working-tree edits.
+            print(
+                f"=== Building SOURCE wheel ({conf.source_profile.name}) from "
+                f"ref={conf.source_ref!r} ==="
+            )
+            conf.source_main_whl_local = str(builder.build(conf.source_ref))
+
+            # TARGET wheel: optionally bypass git for unreleased
+            # target-side changes still living in the developer's
+            # working tree. See ``BCRunnerConf.build_target_from_worktree``.
+            if conf.build_target_from_worktree:
+                print(
+                    f"=== Building TARGET wheel ({conf.target_profile.name}) from "
+                    "LOCAL WORKING TREE (--build_target_from_worktree) ==="
+                )
+                conf.target_main_whl_local = str(builder.build_from_worktree())
+            else:
+                print(
+                    f"=== Building TARGET wheel ({conf.target_profile.name}) from "
+                    f"ref={conf.target_ref!r} ==="
+                )
+                conf.target_main_whl_local = str(builder.build(conf.target_ref))
+        finally:
+            builder.cleanup()
+
+    def upload_wheel(self, conf: BCRunnerConf, local_path: str, remote_subdir: str) -> str:
+        """Upload a single .whl to ``<volume>/wheels/<remote_subdir>/<name>``.
+
+        Returns the absolute UC volume path of the uploaded wheel,
+        suitable for ``%pip install`` from a Databricks notebook.
+        """
+        wheel_name = os.path.basename(local_path)
+        remote = f"{conf.uc_volume_path}wheels/{remote_subdir}/{wheel_name}"
+        with open(local_path, "rb") as fh:
+            self.ws.files.upload(file_path=remote, contents=fh, overwrite=True)
+        print(f"  uploaded -> {remote}")
+        return remote
+
+    # ----- install-spec resolver ----------------------------------------
+
+    def _git_install_spec(
+        self,
+        conf: BCRunnerConf,
+        ref: str,
+        *,
+        subdir: Optional[str] = None,
+    ) -> str:
+        """Build a pip-compatible ``git+<url>@<ref>[#subdirectory=...]`` URL.
+
+        Both ``%pip install`` and ``JobEnvironment.dependencies`` accept
+        this form (assuming the cluster has egress to the repo host).
+        """
+        spec = f"git+{conf.git_repo_url}@{ref}"
+        if subdir:
+            spec = f"{spec}#subdirectory={subdir}"
+        return spec
+
+    def install_spec_source_main(self, conf: BCRunnerConf) -> str:
+        """Pip-installable spec for the SOURCE main wheel."""
+        if conf.install_mode == "git":
+            return self._git_install_spec(conf, conf.source_ref)
+        return conf.source_main_whl_remote
+
+    def install_spec_target_main(self, conf: BCRunnerConf) -> str:
+        """Pip-installable spec for the TARGET main wheel."""
+        if conf.install_mode == "git":
+            return self._git_install_spec(conf, conf.target_ref)
+        return conf.target_main_whl_remote
+
+    # ----- UC + onboarding generation ------------------------------------
+
+    def initialize_uc_resources(self, conf: BCRunnerConf) -> None:
+        api = SchemasAPI(self.ws.api_client)
+        for s, comment in (
+            (conf.sdp_meta_schema, "sdp_meta dataflowspec schema (backward-compat run)"),
+            (conf.bronze_schema, "bronze schema (backward-compat run)"),
+            (conf.silver_schema, "silver schema (backward-compat run)"),
+        ):
+            api.create(catalog_name=conf.uc_catalog_name, name=s, comment=comment)
+        vol = self.ws.volumes.create(
+            catalog_name=conf.uc_catalog_name,
+            schema_name=conf.sdp_meta_schema,
+            name=conf.uc_volume_name,
+            volume_type=VolumeType.MANAGED,
+        )
+        conf.volume_info = vol
+        conf.uc_volume_path = (
+            f"/Volumes/{vol.catalog_name}/{vol.schema_name}/{vol.name}/"
+        )
+        print(f"UC volume ready: {conf.uc_volume_path}")
+
+    def generate_onboarding_files(self, conf: BCRunnerConf) -> None:
+        """Render onboarding JSON from the SOURCE profile's templates.
+
+        Each profile owns its onboarding shape (LEGACY templates strip
+        v0.0.11-only fields like ``rowFilter``; CURRENT templates use
+        the full v0.0.11+ shape). We render from the source profile's
+        templates so Phase 1 onboards exactly what the customer would
+        have onboarded on the source version.
+        """
+        subs = {
+            "{uc_volume_path}": conf.uc_volume_path,
+            "{uc_catalog_name}": conf.uc_catalog_name,
+            "{bronze_schema}": conf.bronze_schema,
+            "{silver_schema}": conf.silver_schema,
+        }
+        for tmpl, out in (
+            (conf.source_profile.onboarding_a1_template, conf.a1_onboarding_file),
+            (conf.source_profile.onboarding_a2_template, conf.a2_onboarding_file),
+        ):
+            with open(tmpl, "r") as fh:
+                text = fh.read()
+            for k, v in subs.items():
+                text = text.replace(k, v or "")
+            payload = json.loads(text)
+            with open(out, "w") as fh:
+                json.dump(payload, fh, indent=4)
+            print(
+                f"  rendered onboarding from {tmpl} ({conf.source_profile.name}) "
+                f"-> {out}"
+            )
+
+    # ----- workspace upload ---------------------------------------------
+
+    def upload_files(self, conf: BCRunnerConf) -> None:
+        # Resources (data + ddl) -- the same trees the existing
+        # cloudfiles integration test consumes, plus our two
+        # ``customers_phase2/`` and ``transactions_phase2/`` staging
+        # dirs.
+        for root, _dirs, files in os.walk(f"{conf.int_tests_dir}/resources"):
+            for fname in files:
+                with open(os.path.join(root, fname), "rb") as content:
+                    self.ws.files.upload(
+                        file_path=f"{conf.uc_volume_path}{root}/{fname}",
+                        contents=content,
+                        overwrite=True,
+                    )
+
+        # Conf (silver transformations + DQE rules + the rendered
+        # onboarding files we just generated). Only .json -- the
+        # backward-compat test is JSON-only by design (YAML support
+        # is a v0.0.11-only addition).
+        for root, _dirs, files in os.walk(f"{conf.int_tests_dir}/conf/json"):
+            for fname in files:
+                if not fname.endswith(".json"):
+                    continue
+                with open(os.path.join(root, fname), "rb") as content:
+                    self.ws.files.upload(
+                        file_path=f"{conf.uc_volume_path}{root}/{fname}",
+                        contents=content,
+                        overwrite=True,
+                    )
+
+        # Runner notebooks (under <runners_nb_path>/runners/ -- mirrors
+        # the existing test's contract).
+        self.ws.workspace.mkdirs(f"{conf.runners_nb_path}/runners")
+        local_runners = f"{conf.int_tests_dir}/notebooks/backward_compat_runners"
+        for nb in os.listdir(local_runners):
+            with open(os.path.join(local_runners, nb), "rb") as fh:
+                self.ws.workspace.upload(
+                    path=f"{conf.runners_nb_path}/runners/{nb}",
+                    format=ImportFormat.SOURCE,
+                    language=Language.PYTHON,
+                    content=fh.read(),
+                )
+
+        if conf.install_mode == "git":
+            print(
+                "  install_mode=git: skipping wheel uploads "
+                "(cluster will resolve git URLs at install time)."
+            )
+        else:
+            # Wheels go under wheels/<source|target>/ so the same upload
+            # routine works for arbitrary version pairs without
+            # colliding if source and target build distinct wheels with
+            # the same filename (e.g. main vs feature/sdp-meta both
+            # producing
+            # ``databricks_labs_sdp_meta-0.0.11-py3-none-any.whl``).
+            conf.source_main_whl_remote = self.upload_wheel(
+                conf, conf.source_main_whl_local, "source"
+            )
+            conf.target_main_whl_remote = self.upload_wheel(
+                conf, conf.target_main_whl_local, "target"
+            )
+
+    # ----- pipeline create / update --------------------------------------
+
+    def _runner_notebook_filename(self, conf: BCRunnerConf) -> str:
+        """File name (basename) of the SOURCE profile's runner notebook.
+
+        Used by both ``create_pipeline`` (sets the library path) and
+        ``upload_files`` (decides which file to upload from the local
+        ``backward_compat_runners/`` directory).
+        """
+        return os.path.basename(conf.source_profile.runner_notebook_local_path)
+
+    def _build_phase1_pipeline_config(
+        self,
+        conf: BCRunnerConf,
+        layer: str,
+        group: str,
+    ) -> Dict[str, str]:
+        """Pipeline configuration for Phase 1 (SOURCE wheel).
+
+        One key, one wheel: the SOURCE profile's ``pipeline_config_whl_key``
+        maps to the SOURCE main wheel path. The SOURCE runner notebook
+        reads that key and runs a single ``%pip install $key`` line.
+
+        ``pipelines.maxFlowRetryAttempts=0`` makes DLT fail an update
+        on the FIRST flow failure rather than retrying the failing
+        flow up to its default attempts. For an integration test
+        we want fast, deterministic failure -- a true bug doesn't
+        get less true with three more attempts, and waiting through
+        the retry budget doubles or triples the diagnose-fix-rerun
+        cycle on broken specs.
+        """
+        return {
+            "layer": layer,
+            conf.source_profile.pipeline_config_whl_key: (
+                self.install_spec_source_main(conf)
+            ),
+            f"{layer}.group": group,
+            f"{layer}.dataflowspecTable": (
+                f"{conf.uc_catalog_name}.{conf.sdp_meta_schema}.{layer}_dataflowspec"
+            ),
+            "pipelines.externalSink.enabled": "true",
+            "pipelines.maxFlowRetryAttempts": "0",
+        }
+
+    def _build_phase2_pipeline_config(
+        self,
+        conf: BCRunnerConf,
+        layer: str,
+        group: str,
+    ) -> Dict[str, str]:
+        """Pipeline configuration for Phase 2 (TARGET wheel).
+
+        Same SOURCE-profile pipeline-config key as Phase 1 -- the
+        runner notebook is the customer's source-version runner and
+        only knows the key IT was wired with. We swap the VALUE behind
+        that key from the SOURCE wheel path to the TARGET wheel path
+        so the same notebook installs the new wheel via the same
+        ``%pip install`` line. No second key, no second wheel.
+
+        For LEGACY -> CURRENT cross-namespace upgrades, the TARGET
+        wheel is responsible for bundling its own legacy-namespace
+        compat surface (a real ``src`` package + ``dlt_meta`` package)
+        so the SOURCE runner's ``from src.* import …`` keeps resolving
+        through normal import machinery. The orchestrator does not
+        deliver a separate companion wheel.
+        """
+        return {
+            "layer": layer,
+            conf.source_profile.pipeline_config_whl_key: (
+                self.install_spec_target_main(conf)
+            ),
+            f"{layer}.group": group,
+            f"{layer}.dataflowspecTable": (
+                f"{conf.uc_catalog_name}.{conf.sdp_meta_schema}.{layer}_dataflowspec"
+            ),
+            "pipelines.externalSink.enabled": "true",
+            # See _build_phase1_pipeline_config for why we disable
+            # flow-level retries in this test.
+            "pipelines.maxFlowRetryAttempts": "0",
+        }
+
+    def create_pipeline(
+        self,
+        conf: BCRunnerConf,
+        name: str,
+        layer: str,
+        group: str,
+        target_schema: str,
+    ) -> str:
+        """Create a DLT pipeline pinned to the SOURCE wheel.
+
+        Phase 2 swaps the wheel via ``swap_pipelines_to_target`` rather
+        than recreating the pipeline; that preserves the pipeline ID
+        AND the per-pipeline DLT checkpoints, which is the customer-
+        upgrade scenario we're modelling.
+        """
+        configuration = self._build_phase1_pipeline_config(conf, layer, group)
+        conf._phase1_pipeline_configs[name] = configuration
+        runner_path = (
+            f"{conf.runners_nb_path}/runners/{self._runner_notebook_filename(conf)}"
+        )
+        created = self.ws.pipelines.create(
+            catalog=conf.uc_catalog_name,
+            name=name,
+            serverless=True,
+            configuration=configuration,
+            libraries=[
+                PipelineLibrary(
+                    notebook=NotebookLibrary(path=runner_path)
+                )
+            ],
+            schema=target_schema,
+        )
+        if created is None or not created.pipeline_id:
+            raise RuntimeError(f"Pipeline {name!r} creation failed")
+        print(f"  created pipeline {name!r} -> {created.pipeline_id}")
+        return created.pipeline_id
+
+    def create_all_pipelines(self, conf: BCRunnerConf) -> None:
+        conf.bronze_a1_pipeline_id = self.create_pipeline(
+            conf,
+            f"backward-compat-bronze-A1-{conf.run_id}",
+            "bronze",
+            "A1",
+            conf.bronze_schema,
+        )
+        conf.bronze_a2_pipeline_id = self.create_pipeline(
+            conf,
+            f"backward-compat-bronze-A2-{conf.run_id}",
+            "bronze",
+            "A2",
+            conf.bronze_schema,
+        )
+        conf.silver_pipeline_id = self.create_pipeline(
+            conf,
+            f"backward-compat-silver-{conf.run_id}",
+            "silver",
+            "A1",
+            conf.silver_schema,
+        )
+
+    def swap_pipelines_to_target(self, conf: BCRunnerConf) -> None:
+        """Update every pipeline's configuration to point at TARGET wheel.
+
+        Pipeline IDs and DLT checkpoints are preserved; only the value
+        behind the SOURCE-defined pipeline-config key changes (from
+        SOURCE wheel path to TARGET wheel path). The runner notebook,
+        the libraries list, the schema, and every other pipeline
+        attribute stay byte-identical.
+
+        Note on whl-typed PipelineLibrary entries: serverless DLT
+        rejects them with ``InvalidParameterValue: Whl libraries are
+        not supported``, so the legacy-namespace compat surface cannot
+        be delivered as a separate pipeline library. Bundling it
+        directly into the main wheel sidesteps that: the wheel ships a
+        real top-level ``src`` package, so after ``%pip install`` the
+        runner's ``from src.* import …`` resolves through normal import
+        machinery -- no separate library, and no reliance on a ``.pth``
+        startup hook (which serverless ``%pip install`` would not fire
+        anyway).
+        """
+        targets = (
+            (conf.bronze_a1_pipeline_id, "bronze", "A1", conf.bronze_schema),
+            (conf.bronze_a2_pipeline_id, "bronze", "A2", conf.bronze_schema),
+            (conf.silver_pipeline_id, "silver", "A1", conf.silver_schema),
+        )
+        for pid, layer, group, _target_schema in targets:
+            config = self._build_phase2_pipeline_config(conf, layer, group)
+            existing = self.ws.pipelines.get(pid)
+            self.ws.pipelines.update(
+                pipeline_id=pid,
+                catalog=existing.spec.catalog,
+                name=existing.spec.name,
+                serverless=True,
+                configuration=config,
+                libraries=existing.spec.libraries,
+                schema=existing.spec.schema,
+            )
+            print(
+                f"  swapped pipeline {pid} -> "
+                f"{conf.target_profile.name} wheel spec"
+            )
+
+    # ----- workflow building --------------------------------------------
+
+    def build_phase1_job(self, conf: BCRunnerConf):
+        """Phase 1 workflow: onboard A1 -> bronze A1 -> onboard A2 ->
+        bronze A2 -> silver -> validate_phase1.
+
+        Mirrors the existing cloudfiles A1+A2 happy path exactly
+        (see ``IntegrationTestRunner.create_cloudfiles_workflow_spec``
+        in ``run_integration_tests.py``), with EVERY pipeline pinned
+        to the SOURCE wheel and the validation notebook set to the
+        backward-compat ``validate_phase1.py`` (which persists
+        per-table counts to a UC volume scratch file for Phase 2 to
+        read back).
+
+        Note: silver runs ONCE, AFTER bronze_A2. We do not run silver
+        between bronze_A1 and bronze_A2 because the
+        ``customers_silver_flow`` append flow reads from a
+        ``customers_delta`` bronze table that is produced by the A2
+        onboarding spec, not by A1. Inserting a silver step after A1
+        would fail with ``TABLE_OR_VIEW_NOT_FOUND`` on
+        ``customers_delta`` -- the canonical cloudfiles workflow has
+        the same constraint.
+        """
+        # Onboarding wheel-tasks must resolve against the SOURCE wheel.
+        # The wheel distribution name comes from the source profile
+        # (e.g. LEGACY -> "dlt_meta", CURRENT -> "databricks_labs_sdp_meta").
+        # The dependency itself is whatever ``install_spec_source_main``
+        # returns -- a UC volume path in local mode, a git URL in git mode.
+        env_key = "bc_phase1_env"
+        environments = [
+            jobs.JobEnvironment(
+                environment_key=env_key,
+                spec=compute.Environment(
+                    client="1",
+                    dependencies=[self.install_spec_source_main(conf)],
+                ),
+            )
+        ]
+        common_named = {
+            "database": f"{conf.uc_catalog_name}.{conf.sdp_meta_schema}",
+            "bronze_dataflowspec_table": "bronze_dataflowspec",
+            "silver_dataflowspec_table": "silver_dataflowspec",
+            "import_author": "backward_compat",
+            "version": "v1",
+            "env": "it",
+            "uc_enabled": "True",
+        }
+        tasks = [
+            jobs.Task(
+                task_key="phase1_onboard_A1",
+                description=(
+                    f"Phase 1 ({conf.source_profile.name} / {conf.source_ref}): "
+                    "onboard A1 (initial)"
+                ),
+                environment_key=env_key,
+                python_wheel_task=jobs.PythonWheelTask(
+                    package_name=conf.source_profile.distribution,
+                    entry_point="run",
+                    named_parameters={
+                        **common_named,
+                        "onboard_layer": "bronze_silver",
+                        "onboarding_file_path": (
+                            f"{conf.uc_volume_path}{conf.a1_onboarding_file}"
+                        ),
+                        "overwrite": "True",
+                    },
+                ),
+            ),
+            jobs.Task(
+                task_key="phase1_bronze_A1",
+                depends_on=[jobs.TaskDependency(task_key="phase1_onboard_A1")],
+                pipeline_task=jobs.PipelineTask(pipeline_id=conf.bronze_a1_pipeline_id),
+            ),
+            jobs.Task(
+                task_key="phase1_onboard_A2",
+                depends_on=[jobs.TaskDependency(task_key="phase1_bronze_A1")],
+                description=(
+                    f"Phase 1 ({conf.source_profile.name} / {conf.source_ref}): "
+                    "onboard A2 (incremental)"
+                ),
+                environment_key=env_key,
+                python_wheel_task=jobs.PythonWheelTask(
+                    package_name=conf.source_profile.distribution,
+                    entry_point="run",
+                    named_parameters={
+                        **common_named,
+                        "onboard_layer": "bronze",
+                        "onboarding_file_path": (
+                            f"{conf.uc_volume_path}{conf.a2_onboarding_file}"
+                        ),
+                        "overwrite": "False",
+                    },
+                ),
+            ),
+            jobs.Task(
+                task_key="phase1_bronze_A2",
+                depends_on=[jobs.TaskDependency(task_key="phase1_onboard_A2")],
+                pipeline_task=jobs.PipelineTask(pipeline_id=conf.bronze_a2_pipeline_id),
+            ),
+            jobs.Task(
+                task_key="phase1_silver_after_A2",
+                depends_on=[jobs.TaskDependency(task_key="phase1_bronze_A2")],
+                pipeline_task=jobs.PipelineTask(pipeline_id=conf.silver_pipeline_id),
+            ),
+            jobs.Task(
+                task_key="phase1_validate",
+                depends_on=[jobs.TaskDependency(task_key="phase1_silver_after_A2")],
+                notebook_task=jobs.NotebookTask(
+                    notebook_path=f"{conf.runners_nb_path}/runners/validate_phase1.py",
+                    base_parameters={
+                        "uc_catalog_name": conf.uc_catalog_name,
+                        "bronze_schema": conf.bronze_schema,
+                        "silver_schema": conf.silver_schema,
+                        "uc_volume_path": conf.uc_volume_path,
+                        "output_file_path": f"/Workspace{conf.phase1_output_ws}",
+                        "run_id": conf.run_id,
+                    },
+                ),
+            ),
+        ]
+        return self.ws.jobs.create(
+            name=f"backward-compat-phase1-{conf.run_id}",
+            environments=environments,
+            tasks=tasks,
+        )
+
+    def build_phase2_job(self, conf: BCRunnerConf):
+        """Phase 2 workflow: drop incremental seed -> bronze A1 -> silver ->
+        validate_phase2.
+
+        No onboarding. No A2 redo. The dataflowspec persisted by Phase 1
+        IS the spec Phase 2 runs. The only thing that changed between
+        phases is the wheel attached to each pipeline -- swapped via
+        ``pipelines.update()`` BEFORE this job is built.
+        """
+        tasks = [
+            jobs.Task(
+                task_key="phase2_add_incremental",
+                description=(
+                    f"Phase 2 ({conf.target_profile.name} / {conf.target_ref}): "
+                    "drop incremental seed"
+                ),
+                notebook_task=jobs.NotebookTask(
+                    notebook_path=f"{conf.runners_nb_path}/runners/add_phase2_incremental.py",
+                    base_parameters={
+                        "uc_volume_path": conf.uc_volume_path,
+                        "int_tests_dir": conf.int_tests_dir,
+                    },
+                ),
+            ),
+            jobs.Task(
+                task_key="phase2_bronze",
+                depends_on=[jobs.TaskDependency(task_key="phase2_add_incremental")],
+                pipeline_task=jobs.PipelineTask(pipeline_id=conf.bronze_a1_pipeline_id),
+            ),
+            jobs.Task(
+                task_key="phase2_silver",
+                depends_on=[jobs.TaskDependency(task_key="phase2_bronze")],
+                pipeline_task=jobs.PipelineTask(pipeline_id=conf.silver_pipeline_id),
+            ),
+            jobs.Task(
+                task_key="phase2_validate",
+                depends_on=[jobs.TaskDependency(task_key="phase2_silver")],
+                notebook_task=jobs.NotebookTask(
+                    notebook_path=f"{conf.runners_nb_path}/runners/validate_phase2.py",
+                    base_parameters={
+                        "uc_catalog_name": conf.uc_catalog_name,
+                        "bronze_schema": conf.bronze_schema,
+                        "silver_schema": conf.silver_schema,
+                        "sdp_meta_schema": conf.sdp_meta_schema,
+                        "uc_volume_path": conf.uc_volume_path,
+                        "output_file_path": f"/Workspace{conf.phase2_output_ws}",
+                        "run_id": conf.run_id,
+                        "phase2_customer_delta": str(conf.phase2_customer_delta),
+                        "phase2_transaction_delta": str(conf.phase2_transaction_delta),
+                        # validate_phase2 is a regular notebook_task (not
+                        # a DLT runner), so it must %pip install the
+                        # TARGET wheel itself before doing
+                        # ``from src.dataflow_spec import …``.
+                        "target_main_whl": conf.target_main_whl_remote,
+                    },
+                ),
+            ),
+        ]
+        return self.ws.jobs.create(
+            name=f"backward-compat-phase2-{conf.run_id}",
+            tasks=tasks,
+        )
+
+    # ----- launch + result download --------------------------------------
+
+    def launch_job(self, job_id: int, label: str):
+        print(
+            f"=== Launching {label} job_id={job_id} "
+            f"(timeout={self.phase_timeout_min}min) ==="
+        )
+        webbrowser.open(
+            f"{self.ws.config.host}/jobs/{job_id}?o={self.ws.get_workspace_id()}"
+        )
+        run = self.ws.jobs.run_now(job_id=job_id).result(
+            timeout=timedelta(minutes=self.phase_timeout_min)
+        )
+        print(f"=== {label} run finished ===")
+        return run
+
+    def download_phase_output(self, ws_path: str, local_name: str) -> None:
+        try:
+            payload = self.ws.workspace.download(ws_path)
+            with open(local_name, "wb") as out:
+                out.write(payload.read())
+            print(f"  downloaded -> {local_name}")
+        except Exception as exc:
+            print(f"  warn: failed to download {ws_path}: {exc}")
+
+    # ----- cleanup -------------------------------------------------------
+
+    def cleanup(self, conf: BCRunnerConf) -> None:
+        print("=== Cleaning up backward-compat run ===")
+        for pid in (
+            conf.bronze_a1_pipeline_id,
+            conf.bronze_a2_pipeline_id,
+            conf.silver_pipeline_id,
+        ):
+            if pid:
+                try:
+                    self.ws.pipelines.delete(pid)
+                    print(f"  deleted pipeline {pid}")
+                except Exception as exc:
+                    print(f"  warn: pipeline {pid} delete failed: {exc}")
+        for jid in (conf.phase1_job_id, conf.phase2_job_id):
+            if jid:
+                try:
+                    self.ws.jobs.delete(jid)
+                    print(f"  deleted job {jid}")
+                except Exception as exc:
+                    print(f"  warn: job {jid} delete failed: {exc}")
+        if conf.uc_catalog_name:
+            test_schemas = {conf.sdp_meta_schema, conf.bronze_schema, conf.silver_schema}
+            for schema in self.ws.schemas.list(catalog_name=conf.uc_catalog_name):
+                if schema.name in test_schemas:
+                    print(f"  deleting schema {schema.full_name}")
+                    for vol in self.ws.volumes.list(
+                        catalog_name=conf.uc_catalog_name, schema_name=schema.name
+                    ):
+                        try:
+                            self.ws.volumes.delete(vol.full_name)
+                        except Exception as exc:
+                            print(f"    warn: volume delete failed: {exc}")
+                    for table in self.ws.tables.list(
+                        catalog_name=conf.uc_catalog_name, schema_name=schema.name
+                    ):
+                        try:
+                            self.ws.tables.delete(table.full_name)
+                        except Exception as exc:
+                            print(f"    warn: table delete failed: {exc}")
+                    try:
+                        self.ws.schemas.delete(schema.full_name)
+                    except Exception as exc:
+                        print(f"  warn: schema delete failed: {exc}")
+        print("=== Cleanup complete ===")
+
+    # ----- top-level orchestration ---------------------------------------
+
+    def run(self, *, cleanup: bool = False) -> int:
+        """Drive the full two-phase test.
+
+        ``cleanup=True`` runs ``cleanup()`` in a ``finally`` block; with
+        ``cleanup=False`` (the default) we leave UC state in place so a
+        failed run is debuggable. Re-run cleanup later with
+        ``integration_tests/cleanup_script.py`` or rerun this script
+        with ``--cleanup``.
+        """
+        conf = self._build_runner_conf()
+        worktree_note = (
+            " [TARGET wheels: local working tree]"
+            if conf.build_target_from_worktree
+            else ""
+        )
+        print(
+            f"=== Backward-compat run_id={conf.run_id} "
+            f"source={conf.source_ref!r} ({conf.source_profile.name}) -> "
+            f"target={conf.target_ref!r} ({conf.target_profile.name}) "
+            f"install_mode={conf.install_mode!r}{worktree_note} ==="
+        )
+        if conf.is_cross_namespace_upgrade:
+            print(
+                f"  cross-namespace upgrade "
+                f"({conf.source_profile.runner_imports_namespace!r} -> "
+                f"{conf.target_profile.runner_imports_namespace!r}): "
+                "the TARGET wheel is expected to bundle a legacy-namespace "
+                "compat surface (a real `src` package + `dlt_meta` package "
+                "re-exporting `databricks.labs.sdp_meta.*`) so the source "
+                "runner notebook's `from src.* import …` keeps resolving "
+                "via normal import machinery. Phase 2 installs ONE wheel, "
+                "runs ONE %pip install."
+            )
+        rc = 0
+        try:
+            self.build_wheels(conf)
+            self.initialize_uc_resources(conf)
+            self.generate_onboarding_files(conf)
+            self.upload_files(conf)
+            self.create_all_pipelines(conf)
+
+            phase1_label = (
+                f"Phase 1 ({conf.source_profile.name} / {conf.source_ref})"
+            )
+            phase1_job = self.build_phase1_job(conf)
+            conf.phase1_job_id = phase1_job.job_id
+            self.launch_job(phase1_job.job_id, label=phase1_label)
+            self.download_phase_output(
+                conf.phase1_output_ws,
+                f"backward_compat_phase1_{conf.run_id}.csv",
+            )
+
+            print(
+                f"=== Swapping pipelines: {conf.source_profile.name} "
+                f"({conf.source_ref}) -> {conf.target_profile.name} "
+                f"({conf.target_ref}) ==="
+            )
+            self.swap_pipelines_to_target(conf)
+
+            phase2_label = (
+                f"Phase 2 ({conf.target_profile.name} / {conf.target_ref})"
+            )
+            phase2_job = self.build_phase2_job(conf)
+            conf.phase2_job_id = phase2_job.job_id
+            self.launch_job(phase2_job.job_id, label=phase2_label)
+            self.download_phase_output(
+                conf.phase2_output_ws,
+                f"backward_compat_phase2_{conf.run_id}.csv",
+            )
+        except Exception:
+            traceback.print_exc()
+            rc = 1
+        finally:
+            if cleanup:
+                self.cleanup(conf)
+        return rc
+
+
+def get_workspace_client(profile: Optional[str]) -> WorkspaceClient:
+    if os.environ.get("DATABRICKS_APP_PORT"):
+        return WorkspaceClient()
+    if profile:
+        return WorkspaceClient(profile=profile)
+    return WorkspaceClient(
+        host=input("Databricks Workspace URL: "), token=input("Token: ")
+    )
+
+
+def parse_cli() -> dict:
+    profile_choices = sorted(KNOWN_PROFILES)
+    p = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument(
+        "--uc_catalog_name",
+        required=True,
+        help="Unity Catalog name to create per-run schemas/volumes under.",
+    )
+    p.add_argument(
+        "--profile",
+        default=None,
+        help="databricks-cli profile name (defaults to interactive prompt).",
+    )
+    p.add_argument(
+        "--source_version",
+        default=DEFAULT_SOURCE_REF,
+        help=(
+            "Git ref of the SOURCE version to upgrade FROM "
+            f"(default: {DEFAULT_SOURCE_REF}). Tag, branch, or SHA."
+        ),
+    )
+    p.add_argument(
+        "--target_version",
+        default=DEFAULT_TARGET_REF,
+        help=(
+            "Git ref of the TARGET version to upgrade TO "
+            f"(default: {DEFAULT_TARGET_REF}). Tag, branch, or SHA."
+        ),
+    )
+    p.add_argument(
+        "--source_profile",
+        default=None,
+        choices=profile_choices,
+        help=(
+            "Override profile resolution for --source_version. Useful "
+            "when --source_version is a custom branch the registry "
+            "doesn't recognize."
+        ),
+    )
+    p.add_argument(
+        "--target_profile",
+        default=None,
+        choices=profile_choices,
+        help=(
+            "Override profile resolution for --target_version. Useful "
+            "when --target_version is a custom branch the registry "
+            "doesn't recognize."
+        ),
+    )
+    p.add_argument(
+        "--install_mode",
+        default="local",
+        choices=["local", "git"],
+        help=(
+            "How wheels reach the cluster. "
+            "'local' (default): build with GitRefWheelBuilder + upload "
+            "to UC volume (matches what real customers do -- install a "
+            "pre-built artifact, no GitHub egress required). "
+            "'git': skip the local build; runners and wheel-tasks "
+            "resolve via 'pip install git+<repo>@<ref>'. Faster local "
+            "iteration; the cluster MUST have egress to --git_repo_url."
+        ),
+    )
+    p.add_argument(
+        "--git_repo_url",
+        default=BCRunnerConf.__dataclass_fields__["git_repo_url"].default,
+        help=(
+            "Git repository URL used when --install_mode=git "
+            "(default: %(default)s). Ignored when --install_mode=local."
+        ),
+    )
+    p.add_argument(
+        "--build_target_from_worktree",
+        action="store_true",
+        help=(
+            "Build the TARGET main wheel from the developer's local "
+            "working tree instead of from --target_version. The "
+            "SOURCE wheel still comes from --source_version (as a "
+            "released customer would have). Use ONLY for iterating on "
+            "uncommitted target-side changes (bundled compat shim, "
+            "post-rename CLI aliases, etc.) before they're pushed. "
+            "Requires --install_mode=local; the produced wheel is "
+            "uploaded to UC volume the same way ref-built wheels are."
+        ),
+    )
+    p.add_argument(
+        "--phase_timeout_min",
+        type=int,
+        default=BackwardCompatRunner.DEFAULT_PHASE_TIMEOUT_MIN,
+        help=(
+            "Per-phase wall-clock timeout in minutes for "
+            "jobs.run_now().result() (default: %(default)s). Phase 1 "
+            "runs six DLT pipelines sequentially plus a validate "
+            "notebook; bump this if your workspace's serverless cold "
+            "starts push the run past the default."
+        ),
+    )
+    p.add_argument(
+        "--cleanup",
+        action="store_true",
+        help=(
+            "Delete pipelines/jobs/schemas/volumes after the run "
+            "completes (success or fail)."
+        ),
+    )
+    args = vars(p.parse_args())
+    validate_uc_identifier(args["uc_catalog_name"], kind="--uc_catalog_name")
+    return args
+
+
+def main() -> int:
+    args = parse_cli()
+    ws = get_workspace_client(args.get("profile"))
+    runner = BackwardCompatRunner(args, ws)
+    return runner.run(cleanup=args["cleanup"])
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/integration_tests/version_profiles.py
+++ b/integration_tests/version_profiles.py
@@ -1,0 +1,293 @@
+"""Version profiles for the backward-compatibility integration test.
+
+Background
+----------
+
+The backward-compat test simulates a customer pipeline upgrade by:
+
+  1. Building a wheel from the SOURCE git ref (the version the customer is
+     running today).
+  2. Onboarding + running their pipeline on that wheel (Phase 1).
+  3. Building a wheel from the TARGET git ref (the version they want to
+     upgrade to).
+  4. Swapping the wheel attached to every pipeline to the TARGET wheel
+     WITHOUT recreating the pipeline or editing the customer's runner
+     notebook (Phase 2).
+  5. Asserting data preservation, incremental growth, and dataclass
+     compatibility.
+
+Different version-lines of sdp-meta have different "shapes" -- distribution
+name, runner-notebook import style, onboarding-spec fields, pipeline-config
+keys, companion wheels, etc. A ``VersionProfile`` captures everything the
+orchestrator needs to know about ONE version-line so the test stays
+generic across upgrade pairs.
+
+Today two profiles ship out of the box:
+
+  * ``LEGACY``   -- v0.0.1 through v0.0.10. Dist name ``dlt_meta``, runner
+                    imports ``from src.*``, pipeline config key
+                    ``dlt_meta_whl``. One key, one ``%pip install``,
+                    byte-for-byte v0.0.10 customer notebook.
+  * ``CURRENT``  -- v0.0.11 and later (and the ``feature/sdp-meta`` branch
+                    that becomes v0.0.11 at release). Dist name
+                    ``databricks_labs_sdp_meta``, runner imports
+                    ``from databricks.labs.sdp_meta.*``, pipeline config
+                    key ``sdp_meta_whl``. The v0.0.11 main wheel BUNDLES
+                    a legacy-namespace compat surface (a real ``src``
+                    package + ``dlt_meta`` package re-exporting
+                    ``databricks.labs.sdp_meta.*``), so a LEGACY-source
+                    customer who flips their ``dlt_meta_whl`` config from
+                    a v0.0.10 wheel to a v0.0.11 wheel keeps working
+                    without changing any other line in their pipeline
+                    config or runner notebook. Bundling avoids two-wheel/
+                    two-install contracts that don't compose reliably on
+                    serverless DLT.
+
+When a future v0.1.0 changes the contract again, register a new
+``VersionProfile`` and add its ref-prefix to ``KNOWN_PROFILES``. Unknown
+refs (e.g. arbitrary feature branches or SHAs) fall back to ``CURRENT``
+and emit a warning -- callers can override the resolver via the
+``--source_profile`` / ``--target_profile`` CLI flags.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional, Tuple
+
+
+@dataclass(frozen=True)
+class VersionProfile:
+    """Per-version-line knobs the orchestrator uses to build/install/run.
+
+    Each field encodes ONE thing that varies across version-lines:
+
+    Attributes:
+      name: Short, stable identifier used in CLI flags and logs
+        (e.g. ``"legacy"``, ``"current"``).
+      description: Human-readable summary surfaced in ``--help`` and
+        startup logs.
+      ref_prefixes: Tuple of git-ref prefixes this profile owns
+        (e.g. ``("v0.0.1", "v0.0.2", ..., "v0.0.10", "main")`` for
+        LEGACY). Matched as prefixes so a SHA on a release branch still
+        resolves correctly.
+      distribution: pip distribution name produced by this version's
+        ``setup.py`` (e.g. ``"dlt_meta"`` or ``"databricks_labs_sdp_meta"``).
+        Used by the Phase 1 ``PythonWheelTask`` to address the onboarding
+        entry point.
+      pipeline_config_whl_key: The DLT-pipeline ``configuration`` key the
+        runner notebook reads to ``%pip install`` the wheel
+        (e.g. ``"dlt_meta_whl"`` or ``"sdp_meta_whl"``). The key is
+        SOURCE-driven: in Phase 2 the orchestrator must use the SAME key
+        so the customer's runner notebook keeps working.
+      runner_notebook_local_path: Path under the repo root to the
+        runner-notebook source file uploaded into the pipeline. Each
+        profile ships its own runner so the import style + config
+        key match.
+      onboarding_a1_template: Path to the A1 (initial) onboarding
+        template. Each profile uses its own shape so v0.0.11-only fields
+        (``rowFilter`` etc.) only appear when the source is CURRENT.
+      onboarding_a2_template: Path to the A2 (incremental) onboarding
+        template. Same shape constraints as A1.
+      runner_imports_namespace: The Python namespace this profile's
+        runner notebook imports from (e.g. ``"src"`` for LEGACY,
+        ``"databricks.labs.sdp_meta"`` for CURRENT). The orchestrator
+        only uses this to detect cross-namespace upgrades, which is
+        worth knowing even though the legacy-namespace compat is now
+        bundled into the target wheel itself (see CURRENT below) --
+        cross-namespace flag still drives logging and gate decisions.
+
+    Note on legacy-namespace compatibility for cross-namespace upgrades
+    (LEGACY -> CURRENT):
+        Earlier iterations of this test built a SEPARATE compat-shim
+        wheel from ``compat/`` and installed it as a second wheel
+        under a second pipeline-config key. That approach hit two
+        platform constraints:
+
+        1. Serverless DLT rejects ``PipelineLibrary(whl=...)``
+           (``InvalidParameterValue: Whl libraries are not supported``)
+           so we couldn't deliver the shim via DLT's library lifecycle.
+        2. ``%pip install $a $b`` with two notebook-config substitutions
+           composed in one line worked in static checks but did not
+           reliably re-process the shim's ``.pth`` after install in
+           serverless DLT, so ``src.*`` aliases were missing on
+           interpreter startup and the runner notebook's
+           ``from src.dataflow_pipeline import …`` raised
+           ``ModuleNotFoundError``.
+
+        The current design BUNDLES a real top-level ``src`` package
+        (plus a ``dlt_meta`` package) directly into the v0.0.11 main
+        wheel (see top-level ``setup.py``). One ``%pip install`` of one
+        wheel is enough; the runner's ``from src.dataflow_pipeline
+        import …`` then resolves through normal import machinery --
+        Python finds ``src/`` in site-packages, runs its ``__init__``
+        (which registers the ``src.<sub>`` alias map), and resolves the
+        symbol. This deliberately does NOT depend on a ``.pth`` firing
+        at startup (constraint #2 above is exactly why), so it is robust
+        on serverless DLT where the ``.pth`` scan never re-runs. There
+        is no second key, no second wheel, no second install.
+    """
+
+    name: str
+    description: str
+    ref_prefixes: Tuple[str, ...]
+    distribution: str
+    pipeline_config_whl_key: str
+    runner_notebook_local_path: str
+    onboarding_a1_template: str
+    onboarding_a2_template: str
+    runner_imports_namespace: str
+    # Free-form extra package names this profile must install alongside
+    # its main wheel during Phase 1 (rare; reserved for future profiles
+    # that may need an unconditional helper package).
+    extra_install_subdirs: Tuple[str, ...] = field(default_factory=tuple)
+
+
+LEGACY = VersionProfile(
+    name="legacy",
+    description="v0.0.1 through v0.0.10 (dlt_meta distribution, src.* imports)",
+    ref_prefixes=(
+        "v0.0.1",
+        "v0.0.2",
+        "v0.0.3",
+        "v0.0.4",
+        "v0.0.5",
+        "v0.0.6",
+        "v0.0.7",
+        "v0.0.8",
+        "v0.0.9",
+        "v0.0.10",
+        "main",  # main historically tracked the LEGACY shape pre-v0.0.11.
+    ),
+    distribution="dlt_meta",
+    pipeline_config_whl_key="dlt_meta_whl",
+    runner_notebook_local_path=(
+        "integration_tests/notebooks/backward_compat_runners/init_dlt_meta_pipeline.py"
+    ),
+    onboarding_a1_template=(
+        "integration_tests/conf/json/backward_compat-cloudfiles-onboarding.template"
+    ),
+    onboarding_a2_template=(
+        "integration_tests/conf/json/backward_compat-cloudfiles-onboarding_A2.template"
+    ),
+    runner_imports_namespace="src",
+)
+
+
+CURRENT = VersionProfile(
+    name="current",
+    description=(
+        "v0.0.11 and later (databricks-labs-sdp-meta distribution, "
+        "databricks.labs.sdp_meta imports)"
+    ),
+    ref_prefixes=(
+        "v0.0.11",
+        "v0.0.12",  # placeholder for the next release; treat any later
+                    # tag as CURRENT until a profile says otherwise.
+        "v0.1",
+        "feature/sdp-meta",
+    ),
+    distribution="databricks_labs_sdp_meta",
+    pipeline_config_whl_key="sdp_meta_whl",
+    runner_notebook_local_path=(
+        "integration_tests/notebooks/backward_compat_runners/init_sdp_meta_pipeline.py"
+    ),
+    onboarding_a1_template="integration_tests/conf/json/cloudfiles-onboarding.template",
+    onboarding_a2_template="integration_tests/conf/json/cloudfiles-onboarding_A2.template",
+    runner_imports_namespace="databricks.labs.sdp_meta",
+)
+
+
+KNOWN_PROFILES = {
+    LEGACY.name: LEGACY,
+    CURRENT.name: CURRENT,
+}
+
+
+# Public default refs. Surfaced separately so the orchestrator's
+# argparse defaults stay readable.
+DEFAULT_SOURCE_REF = "v0.0.10"
+DEFAULT_TARGET_REF = "feature/sdp-meta"
+
+
+def resolve_profile(ref: str, *, profile_override: Optional[str] = None) -> VersionProfile:
+    """Resolve a git ref to a :class:`VersionProfile`.
+
+    Resolution order:
+      1. If ``profile_override`` is supplied, look it up by name in
+         :data:`KNOWN_PROFILES` and return that profile (raises ValueError
+         if unknown). This is the explicit-override path used by the
+         CLI's ``--source_profile`` / ``--target_profile`` flags.
+      2. Otherwise, find the first profile whose ``ref_prefixes``
+         contains a prefix that ``ref`` starts with (longest first, so
+         ``"v0.0.10"`` wins over ``"v0.0.1"``).
+      3. If no profile matches, return :data:`CURRENT` and log a
+         warning. Custom branches and SHAs typically reflect work on
+         top of the latest contract, so CURRENT is the safer default
+         than LEGACY.
+
+    Args:
+      ref: A git ref the wheel builder will check out (tag, branch,
+        or SHA).
+      profile_override: Optional explicit profile name to bypass
+        prefix-based resolution.
+
+    Returns:
+      The matched :class:`VersionProfile`.
+
+    Raises:
+      ValueError: If ``profile_override`` is supplied but unknown.
+    """
+    if profile_override is not None:
+        try:
+            return KNOWN_PROFILES[profile_override]
+        except KeyError as exc:
+            valid = ", ".join(sorted(KNOWN_PROFILES))
+            raise ValueError(
+                f"Unknown profile name: {profile_override!r}. "
+                f"Valid options: {valid}."
+            ) from exc
+
+    candidates = []
+    for profile in KNOWN_PROFILES.values():
+        for prefix in profile.ref_prefixes:
+            if ref == prefix or ref.startswith(f"{prefix}."):
+                # Tag-style match: exact or dotted-suffix
+                # (so ``v0.0.10`` matches itself and ``v0.0.10.post1``).
+                candidates.append((len(prefix), profile))
+                break
+            if ref == prefix or ref.startswith(f"{prefix}/"):
+                # Branch-style match (``feature/sdp-meta`` etc.).
+                candidates.append((len(prefix), profile))
+                break
+    if candidates:
+        # Longest prefix wins so ``v0.0.10`` resolves to LEGACY even
+        # though both ``v0.0.1`` and ``v0.0.10`` are listed.
+        candidates.sort(key=lambda c: c[0], reverse=True)
+        return candidates[0][1]
+
+    print(
+        f"warn: ref={ref!r} did not match any registered version "
+        f"profile; defaulting to {CURRENT.name!r}. Override with "
+        "--source_profile / --target_profile if this is wrong."
+    )
+    return CURRENT
+
+
+def is_cross_namespace_upgrade(
+    *, source: VersionProfile, target: VersionProfile
+) -> bool:
+    """Return True if source and target use different runner-import namespaces.
+
+    Cross-namespace upgrades (e.g. LEGACY's ``src.*`` -> CURRENT's
+    ``databricks.labs.sdp_meta.*``) rely on the target wheel to bundle
+    a legacy-namespace compat shim so the source's runner notebook
+    keeps resolving its imports unchanged. There is no separate compat
+    shim wheel to build or install: the target wheel handles its own
+    compatibility surface.
+
+    The orchestrator uses this flag for logging and for guarding against
+    obviously-wrong upgrade pairs (e.g. CURRENT -> LEGACY downgrade,
+    where the LEGACY wheel cannot satisfy a CURRENT runner's imports).
+    """
+    return source.runner_imports_namespace != target.runner_imports_namespace

--- a/integration_tests/wheel_builder.py
+++ b/integration_tests/wheel_builder.py
@@ -1,0 +1,352 @@
+"""Git-ref-based wheel builder for backward-compatibility integration tests.
+
+The backward-compatibility test runs Phase 1 against a v0.0.10 wheel and
+Phase 2 against a v0.0.11 wheel built from the ``feature/sdp-meta`` branch.
+Building both wheels from the SAME local clone — without polluting the
+working tree — is what this module does.
+
+Mechanism
+---------
+
+For each requested git ref:
+
+1. Create a fresh ``git worktree`` under a sibling directory
+   (``.bc_wheels/<ref-slug>/``). A worktree is a cheap second checkout
+   of the same repo at the requested ref; the primary checkout the user
+   is editing is left alone.
+2. Run ``python setup.py bdist_wheel`` inside the worktree to produce the
+   ``.whl`` artifact in ``<worktree>/dist/``.
+3. Copy the wheel out to ``.bc_wheels/dist/`` (a stable per-run location)
+   so callers don't have to keep the worktree alive.
+4. Remove the worktree (idempotent on subsequent calls — we ``--force``).
+
+The builder is intentionally minimal: no virtualenv, no
+``pip wheel . --no-deps``, no ``python -m build``. Just ``setup.py
+bdist_wheel`` because that's what every released ref of this repo (and
+the current ``feature/sdp-meta`` branch) supports out of the box without
+extra dependencies. Build dependencies (``setuptools``, ``wheel``) are
+expected on the developer's PATH already — the same ``pip install -e .``
+they ran for unit tests covers it.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+
+_DEFAULT_BUILD_ROOT = ".bc_wheels"
+
+
+class WheelBuilderError(RuntimeError):
+    """Raised when a wheel build fails."""
+
+
+def _slugify_ref(ref: str) -> str:
+    """Make a filesystem-safe slug for a git ref.
+
+    ``feature/sdp-meta`` -> ``feature_sdp-meta``. Tags like ``v0.0.10`` are
+    already filesystem-safe but the slash-replacement still applies.
+    """
+    return ref.replace("/", "_").replace("\\", "_").replace(":", "_")
+
+
+def _run(cmd: list[str], cwd: Optional[Path] = None) -> None:
+    """Run a subprocess command, surfacing stderr/stdout on failure."""
+    print(f"  $ {' '.join(cmd)}{' (in ' + str(cwd) + ')' if cwd else ''}")
+    proc = subprocess.run(
+        cmd,
+        cwd=str(cwd) if cwd else None,
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        raise WheelBuilderError(
+            f"Command failed (exit {proc.returncode}): {' '.join(cmd)}\n"
+            f"--- stdout ---\n{proc.stdout}\n"
+            f"--- stderr ---\n{proc.stderr}"
+        )
+
+
+class GitRefWheelBuilder:
+    """Builds Python wheels from arbitrary git refs of the local repo.
+
+    Parameters
+    ----------
+    repo_root : Path | str | None
+        Root of the git repo to build from. Defaults to the directory two
+        levels up from this file (i.e. the project root).
+    build_root : Path | str | None
+        Directory where worktrees and the final ``dist/`` lives. Defaults
+        to ``<repo_root>/.bc_wheels`` and is git-ignored via the existing
+        ``.gitignore`` (we add a top-level entry in this PR).
+
+    Usage
+    -----
+
+        builder = GitRefWheelBuilder()
+        v010_whl = builder.build("v0.0.10")
+        v011_whl = builder.build("feature/sdp-meta")
+        # Both paths are absolute, both wheels live under <repo>/.bc_wheels/dist/.
+        builder.cleanup()
+    """
+
+    def __init__(
+        self,
+        repo_root: Optional[os.PathLike] = None,
+        build_root: Optional[os.PathLike] = None,
+    ) -> None:
+        if repo_root is None:
+            repo_root = Path(__file__).resolve().parent.parent
+        self.repo_root: Path = Path(repo_root).resolve()
+        if build_root is None:
+            build_root = self.repo_root / _DEFAULT_BUILD_ROOT
+        self.build_root: Path = Path(build_root).resolve()
+        self.dist_dir: Path = self.build_root / "dist"
+        self._worktrees: list[Path] = []
+
+    # --- public API -------------------------------------------------------
+
+    def build(
+        self,
+        ref: str,
+        *,
+        fetch: bool = True,
+        subdir: Optional[str] = None,
+    ) -> Path:
+        """Build a wheel from ``ref`` and return its absolute path.
+
+        ``ref`` is anything ``git checkout`` understands: a tag
+        (``v0.0.10``), a branch (``main``, ``feature/sdp-meta``), or a
+        SHA. When ``fetch`` is True (the default), the builder runs
+        ``git fetch origin <ref>`` first so freshly-pushed remote refs
+        are visible locally.
+
+        ``subdir`` (optional) tells the builder to run ``setup.py
+        bdist_wheel`` inside ``<worktree>/<subdir>`` instead of the
+        worktree root. Use this to build sibling packages that ship
+        their own setup.py (e.g. the ``compat/`` directory of the
+        v0.0.11 ref builds the ``dlt_meta`` compatibility wheel).
+
+        Worktree paths are slugified per (ref, subdir) so two builds
+        from the same ref but different subdirs don't collide.
+        """
+        self._ensure_repo()
+        if fetch:
+            self._fetch(ref)
+
+        slug = _slugify_ref(ref)
+        if subdir:
+            slug = f"{slug}__{_slugify_ref(subdir)}"
+        worktree = self.build_root / "worktrees" / slug
+        self._add_worktree(worktree, ref)
+        try:
+            build_cwd = worktree / subdir if subdir else worktree
+            if not build_cwd.exists():
+                raise WheelBuilderError(
+                    f"subdir={subdir!r} not found in ref={ref!r} "
+                    f"(expected: {build_cwd})"
+                )
+            self._build_in_worktree(build_cwd)
+            built = self._collect_wheel(build_cwd)
+            self.dist_dir.mkdir(parents=True, exist_ok=True)
+            target = self.dist_dir / built.name
+            shutil.copy2(built, target)
+            print(f"  -> built wheel for ref={ref!r}{f' subdir={subdir!r}' if subdir else ''}: {target}")
+            return target.resolve()
+        finally:
+            self._remove_worktree(worktree)
+
+    def build_from_worktree(self, *, subdir: Optional[str] = None) -> Path:
+        """Build a wheel directly from the developer's working tree.
+
+        ``ref``-less companion to :meth:`build` for the case where the
+        contributor wants to test changes that are NOT yet committed
+        to any git ref. No fetch, no ``git worktree add``, no extra
+        checkout: ``setup.py bdist_wheel`` runs in
+        ``<repo_root>[/<subdir>]`` directly, so any uncommitted edits
+        in the working tree are picked up.
+
+        The produced wheel is still copied into ``<build_root>/dist/``
+        (the same location as ref-based builds) so callers can use it
+        interchangeably. The wheel's filename is whatever the local
+        ``setup.py`` says (e.g. ``dlt_meta-0.0.11-py3-none-any.whl``);
+        if a same-named wheel from a previous ref-based build is
+        already in ``dist/``, this build silently overwrites it.
+
+        Use ONLY for development. Production / CI runs should pin a
+        specific git ref via :meth:`build` so the artifact is
+        reproducible from version control.
+        """
+        build_cwd = self.repo_root / subdir if subdir else self.repo_root
+        if not build_cwd.exists():
+            raise WheelBuilderError(
+                f"subdir={subdir!r} not found in working tree "
+                f"(expected: {build_cwd})"
+            )
+        print(
+            f"  building wheel from local working tree"
+            f"{f' subdir={subdir!r}' if subdir else ''} (no git checkout)"
+        )
+        self._build_in_worktree(build_cwd)
+        built = self._collect_wheel(build_cwd)
+        self.dist_dir.mkdir(parents=True, exist_ok=True)
+        target = self.dist_dir / built.name
+        shutil.copy2(built, target)
+        print(f"  -> built wheel from worktree: {target}")
+        return target.resolve()
+
+    def cleanup(self) -> None:
+        """Remove leftover worktrees (no-op if all builds succeeded)."""
+        for wt in list(self._worktrees):
+            self._remove_worktree(wt)
+
+    # --- internals --------------------------------------------------------
+
+    def _ensure_repo(self) -> None:
+        if not (self.repo_root / ".git").exists():
+            raise WheelBuilderError(
+                f"repo_root={self.repo_root} does not contain a .git directory; "
+                "GitRefWheelBuilder requires a real git checkout."
+            )
+
+    def _fetch(self, ref: str) -> None:
+        """Best-effort `git fetch origin <ref>` so remote refs resolve.
+
+        Failures here are non-fatal: a developer working offline against a
+        local-only ref shouldn't be blocked. The subsequent ``git worktree
+        add`` will surface a clear error if the ref truly doesn't exist.
+        """
+        try:
+            _run(["git", "fetch", "origin", ref], cwd=self.repo_root)
+        except WheelBuilderError as exc:
+            print(f"  warn: git fetch origin {ref} failed (continuing): {exc}")
+
+    def _add_worktree(self, worktree: Path, ref: str) -> None:
+        if worktree.exists():
+            self._remove_worktree(worktree)
+        worktree.parent.mkdir(parents=True, exist_ok=True)
+        # ``--detach`` avoids creating a branch that pins the ref; we
+        # just want a checkout. ``--force`` skips the safety check
+        # that errors if a previous worktree path was abandoned.
+        #
+        # Branches that only exist as remote-tracking refs (e.g.
+        # ``feature/sdp-meta`` on a fresh clone whose only local
+        # branch is ``main``) are NOT resolvable as bare ``<ref>``
+        # by ``git worktree add``. Try the bare ref first; on
+        # ``invalid reference`` fall back to ``origin/<ref>`` once.
+        # Tags + SHAs always resolve unprefixed.
+        candidates = [ref]
+        if "/" not in ref or not ref.startswith(("origin/", "refs/")):
+            candidates.append(f"origin/{ref}")
+        last_err: Optional[WheelBuilderError] = None
+        for candidate in candidates:
+            try:
+                _run(
+                    [
+                        "git",
+                        "worktree",
+                        "add",
+                        "--detach",
+                        "--force",
+                        str(worktree),
+                        candidate,
+                    ],
+                    cwd=self.repo_root,
+                )
+                self._worktrees.append(worktree)
+                if candidate != ref:
+                    print(
+                        f"  note: ref={ref!r} resolved as {candidate!r} "
+                        "(local branch missing; using remote-tracking ref)."
+                    )
+                return
+            except WheelBuilderError as exc:
+                last_err = exc
+                continue
+        # Out of candidates -- surface the last error.
+        assert last_err is not None
+        raise last_err
+
+    def _build_in_worktree(self, build_cwd: Path) -> None:
+        # Clean up any prior dist/ inside the build dir so we know
+        # exactly which wheel was just produced.
+        dist = build_cwd / "dist"
+        if dist.exists():
+            shutil.rmtree(dist)
+        _run(
+            [sys.executable, "setup.py", "bdist_wheel"],
+            cwd=build_cwd,
+        )
+
+    def _collect_wheel(self, build_cwd: Path) -> Path:
+        dist = build_cwd / "dist"
+        wheels = sorted(dist.glob("*.whl"))
+        if not wheels:
+            raise WheelBuilderError(
+                f"setup.py bdist_wheel produced no .whl in {dist}"
+            )
+        if len(wheels) > 1:
+            # Pick the newest (mtime). Multiple wheels are unexpected — log
+            # the rest so a flaky build is debuggable.
+            print(
+                f"  warn: multiple wheels produced in {dist}, picking newest: "
+                f"{[w.name for w in wheels]}"
+            )
+            wheels.sort(key=lambda p: p.stat().st_mtime)
+        return wheels[-1]
+
+    def _remove_worktree(self, worktree: Path) -> None:
+        if not worktree.exists():
+            if worktree in self._worktrees:
+                self._worktrees.remove(worktree)
+            return
+        try:
+            _run(
+                ["git", "worktree", "remove", "--force", str(worktree)],
+                cwd=self.repo_root,
+            )
+        except WheelBuilderError as exc:
+            # Last-resort filesystem cleanup. ``git worktree remove``
+            # occasionally fails on transient locks; the worktree
+            # directory itself is just files, so removing it directly is
+            # safe — git will reconcile via ``git worktree prune`` next
+            # time.
+            print(
+                f"  warn: 'git worktree remove' failed ({exc}); "
+                f"falling back to rmtree on {worktree}"
+            )
+            shutil.rmtree(worktree, ignore_errors=True)
+        finally:
+            if worktree in self._worktrees:
+                self._worktrees.remove(worktree)
+
+
+def main() -> int:
+    """CLI entry point: build wheels for one or more refs.
+
+    Usage::
+
+        python integration_tests/wheel_builder.py v0.0.10 feature/sdp-meta
+    """
+    if len(sys.argv) < 2:
+        print(__doc__)
+        print("Usage: python integration_tests/wheel_builder.py <ref> [<ref> ...]")
+        return 2
+    builder = GitRefWheelBuilder()
+    try:
+        for ref in sys.argv[1:]:
+            print(f"Building wheel for ref={ref!r} ...")
+            path = builder.build(ref)
+            print(f"  -> {path}")
+    finally:
+        builder.cleanup()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,28 @@
+[pytest]
+# The compat shim emits two DeprecationWarning families on purpose:
+#
+#   1. The package-level "The 'dlt_meta' package is deprecated and will
+#      be removed in a future version" warning, fired once per
+#      ``import dlt_meta`` (and our compat tests purge ``sys.modules``
+#      to re-trigger fresh imports across cases).
+#   2. Per-alias "'src.X' is a v0.0.10 compatibility alias and will be
+#      removed in v0.1.0" warnings, fired on first attribute access
+#      through each ``src.<sub>`` alias.
+#
+# Both are intentional API signals to v0.0.10 customers, so dedicated
+# tests in ``TestDeprecationWarningBehaviour`` already assert they
+# fire. In every OTHER test the warnings are noise that drowns the
+# pytest summary -- 30+ identical lines per run. Silence the two
+# specific message patterns here while keeping the global default
+# (warnings still visible) for everything else, so a NEW
+# DeprecationWarning from a real upstream library would still be
+# surfaced normally.
+#
+# Tests that assert these warnings DO fire wrap the import in a
+# ``warnings.catch_warnings()`` + ``simplefilter("always")`` block,
+# which overrides this file's filterwarnings rule for the duration of
+# that block. So silencing here doesn't make the assertion tests pass
+# vacuously -- it only suppresses output for the tests that don't care.
+filterwarnings =
+    ignore:The 'dlt_meta' package is deprecated.*:DeprecationWarning
+    ignore:'src\..*' is a v0\.0\.10 compatibility alias.*:DeprecationWarning

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,44 @@ This is the primary package following Databricks Labs namespace conventions.
 Package structure: databricks.labs.sdp_meta
 
 For backwards compatibility wrapper (dlt-meta package), see the compat/ directory.
+
+Legacy v0.0.10 ``src.*`` import compatibility
+---------------------------------------------
+The wheel produced by this setup also bundles two compat surfaces
+sourced from ``compat/``:
+
+  * ``dlt_meta`` (from ``compat/dlt_meta/``) -- flat re-export
+    package for v0.0.10 users who already migrated to
+    ``from dlt_meta import …``. Shipping it inside the v0.0.11 main
+    wheel means ``pip install databricks-labs-sdp-meta`` is the only
+    thing customers need; they don't have to track a second package.
+  * ``src`` (from ``compat/src/``) -- real Python package whose
+    ``__init__.py`` populates ``sys.modules`` with ``src.<sub>`` ->
+    ``databricks.labs.sdp_meta.<sub>`` aliases at import time. This
+    is what makes a v0.0.10 customer's runner notebook keep working
+    unchanged after their wheel is upgraded to v0.0.11. The
+    customer's ``from src.dataflow_pipeline import …`` line resolves
+    through normal Python import machinery: load ``src/__init__.py``,
+    register aliases, fetch the canonical module from
+    ``sys.modules``.
+
+The earlier iteration of this surface relied on a ``dlt_meta.pth``
+file at the wheel's purelib root to lazy-load the alias map at
+interpreter startup via CPython's ``site.py``. That worked on a
+normal ``pip install`` followed by a fresh ``python`` process, but
+serverless DLT's ``%pip install`` magic does NOT trigger a fresh
+``site.py`` ``.pth`` scan -- it lays files into site-packages and
+hands the next cell back to the SAME interpreter, so the freshly-
+installed ``.pth`` is silently ignored. Resolving through a real
+package (``compat/src/``) sidesteps the ``.pth`` lifecycle entirely.
+
+The standalone ``compat/`` package remains as a no-op PyPI redirect
+(``install_requires=["databricks-labs-sdp-meta>=0.0.11"]``) so
+``pip install dlt-meta`` keeps working from PyPI; it ships a
+duplicate of the same shim it would otherwise install transitively,
+which pip detects as already-satisfied and no-ops.
 """
-from setuptools import setup, find_namespace_packages
+from setuptools import setup, find_namespace_packages, find_packages
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
@@ -24,6 +60,7 @@ IT_REQUIREMENTS = ["typer[all]==0.6.1"]
 
 MCP_REQUIREMENTS = ["mcp>=1.0,<2.0"]
 
+
 setup(
     name="databricks-labs-sdp-meta",
     version="0.0.11",
@@ -37,8 +74,31 @@ setup(
     description="Databricks Labs SDP-META Framework (formerly DLT-META)",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    package_dir={"": "src"},
-    packages=find_namespace_packages(where="src", include=["databricks.*"]),
+    # Three roots, one wheel:
+    #   ``""`` -> ``src/``           : canonical ``databricks.labs.sdp_meta``
+    #   ``dlt_meta`` -> ``compat/dlt_meta``  : flat re-export shim
+    #   ``src`` -> ``compat/src``    : v0.0.10 ``src.*`` re-export package
+    #
+    # The exact-match keys (``dlt_meta``, ``src``) win over the ``""``
+    # glob, so the source-layout ``src/`` dir (which holds the
+    # canonical namespace) is scanned via ``find_namespace_packages``
+    # while the legacy ``src`` PACKAGE is sourced from
+    # ``compat/src/__init__.py``. There is no on-disk collision -- the
+    # source-layout ``src/`` directory has no ``__init__.py`` so
+    # ``find_namespace_packages(where="src")`` can't accidentally pick
+    # it up as a package itself.
+    package_dir={
+        "": "src",
+        "dlt_meta": "compat/dlt_meta",
+        "src": "compat/src",
+    },
+    packages=(
+        find_namespace_packages(where="src", include=["databricks.*"])
+        + find_packages(
+            where="compat",
+            include=["dlt_meta", "dlt_meta.*", "src", "src.*"],
+        )
+    ),
     entry_points={
         "console_scripts": [
             "sdp-meta=databricks.labs.sdp_meta.__main__:main",

--- a/src/databricks/labs/sdp_meta/cli.py
+++ b/src/databricks/labs/sdp_meta/cli.py
@@ -1012,6 +1012,18 @@ class SDPMeta:
         cmd.onboarding_file_path = updated_ob_file_path
 
 
+# Backwards-compatibility alias for v0.0.10 customers.
+#
+# v0.0.10 published the entry-class as ``DLTMeta``; v0.0.11 renamed it to
+# ``SDPMeta``. The ``compat/dlt_meta`` shim's ``src.*`` import alias maps
+# ``src.cli`` to this module, so ``from src.cli import DLTMeta`` resolves
+# only if ``DLTMeta`` is bound here (the shim aliases module objects, not
+# individual symbols). Mirrors the ``DLT_META_RUNNER_NOTEBOOK`` rebind
+# at the top of this file. Will be removed in v0.1.0 alongside the rest
+# of the ``src.*`` shim.
+DLTMeta = SDPMeta
+
+
 def onboard(sdp_meta: SDPMeta, flags: dict = None):
     logger.info("Please answer a couple of questions to for launching SDP META onboarding job")
     flags = flags or {}

--- a/src/databricks/labs/sdp_meta/config.py
+++ b/src/databricks/labs/sdp_meta/config.py
@@ -157,6 +157,16 @@ class WorkspaceConfig(_Config["WorkspaceConfig"]):
     sdp_meta_onboard_group: str
     serverless: bool
     num_workers: int
+    # ``connect`` is declared on the parent ``_Config`` as a class
+    # annotation, but ``_Config`` is NOT a @dataclass, so the
+    # annotation is *not* picked up as a dataclass field on this
+    # subclass. Re-declaring it here (with a default of None so it
+    # doesn't break the positional-arg ordering for the required
+    # fields above) is what makes ``from_dict(..., connect=connect)``
+    # below resolve to a real keyword argument. ``__post_init__`` on
+    # ``_Config`` then materializes a default ConnectConfig if
+    # callers leave it as None.
+    connect: Optional[ConnectConfig] = None
 
     @classmethod
     def from_dict(cls, raw: dict):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 """Shared pytest configuration for the dlt-meta / sdp-meta unit-test suite.
 
-Two pieces of cross-cutting test hygiene live here:
+Three pieces of cross-cutting test hygiene live here:
 
 1. Block ``webbrowser.open`` for the whole test session.
 
@@ -31,10 +31,29 @@ Two pieces of cross-cutting test hygiene live here:
    ``webbrowser`` module, which honours the ``$BROWSER`` env var when
    picking the launcher. Pointing it at ``true`` (the Unix no-op
    command) makes the OS layer a silent no-op too. Belt and braces.
+
+3. Pin ``PYSPARK_PYTHON`` / ``PYSPARK_DRIVER_PYTHON`` to the running
+   interpreter.
+
+   When pyspark spawns Python workers it picks the executable from
+   ``$PYSPARK_PYTHON`` (worker) and ``$PYSPARK_DRIVER_PYTHON``
+   (driver), falling back to ``python3`` on ``PATH``. On a developer
+   machine that has multiple Python interpreters installed (e.g. a
+   system Python 3.14 alongside this venv's 3.10), the worker happily
+   grabs the wrong one and the JVM blows up with
+   ``[PYTHON_VERSION_MISMATCH] Python in worker has different
+   version (3, 14) than that in driver 3.10``. Pinning both env vars
+   to ``sys.executable`` at conftest import time makes the suite
+   reproducible across environments without requiring developers to
+   set the vars by hand.
+
+   ``setdefault`` again -- a developer can still override with
+   ``PYSPARK_PYTHON=/path/to/python pytest ...`` if they need to.
 """
 from __future__ import annotations
 
 import os
+import sys
 
 # 1. App-side opt-out flag — read by cli._maybe_open_url.
 os.environ.setdefault("SDP_META_NO_BROWSER", "1")
@@ -42,3 +61,30 @@ os.environ.setdefault("SDP_META_NO_BROWSER", "1")
 # 2. OS-side fallback — Python's webbrowser module respects $BROWSER.
 #    `true` exits 0 immediately and never paints anything to the screen.
 os.environ.setdefault("BROWSER", "true")
+
+# 3. Pin pyspark worker + driver Python to the current interpreter
+#    so the JVM doesn't pick a stray python3 off $PATH and crash with
+#    PYTHON_VERSION_MISMATCH on machines that have multiple Pythons.
+os.environ.setdefault("PYSPARK_PYTHON", sys.executable)
+os.environ.setdefault("PYSPARK_DRIVER_PYTHON", sys.executable)
+
+# 4. Bump the JVM heap so the per-class shared SparkSession can absorb
+#    the cumulative state from ~730 tests without ``OutOfMemoryError:
+#    Java heap space``.
+#
+#    Why this is needed: ``tests/utils.py`` builds Spark in
+#    ``setUpClass`` and intentionally never stops it (so subsequent
+#    classes' ``getOrCreate()`` reuses the same JVM). Each test
+#    leaves behind broadcast variables, query plans, codegen output,
+#    etc.; the default 512MB local-mode heap can't hold all of it
+#    by the time the suite finishes the readers / writers / pipeline
+#    families.
+#
+#    ``PYSPARK_SUBMIT_ARGS`` is the only way to pass driver-memory
+#    in local mode -- ``spark.driver.memory`` set after the JVM is
+#    already up is ignored (the heap is fixed at JVM startup). The
+#    trailing ``pyspark-shell`` token is required by the launcher.
+os.environ.setdefault(
+    "PYSPARK_SUBMIT_ARGS",
+    "--driver-memory 4g --conf spark.driver.maxResultSize=1g pyspark-shell",
+)

--- a/tests/test_backward_compat_v0_0_10.py
+++ b/tests/test_backward_compat_v0_0_10.py
@@ -1,0 +1,480 @@
+"""Backward-compatibility tests: v0.0.11 must not break v0.0.10 customers.
+
+When a customer upgrades the wheel from v0.0.10 to v0.0.11, three
+independent surfaces have to keep working without any action on their
+side:
+
+1. **Persisted dataflowspec Delta tables.** The customer's existing
+   ``bronze_dataflowspec`` / ``silver_dataflowspec`` Delta tables were
+   written by v0.0.10 code and physically lack the v0.0.11 columns
+   (``clusterByAuto``, ``cdcApplyChangesFlows``,
+   ``cdcApplyChangesFlowsSchemas``, ``rowFilter``,
+   ``quarantineRowFilter``). When v0.0.11's
+   :func:`get_bronze_dataflow_spec` / :func:`get_silver_dataflow_spec`
+   read those tables, :meth:`DataflowSpecUtils.populate_additional_df_cols`
+   must backfill the missing columns with ``None`` so the dataclass
+   instantiation succeeds.
+
+2. **v0.0.10-format onboarding files.** A customer who re-runs
+   onboarding with their old onboarding JSON (no new fields) must end
+   up with a persisted spec where every v0.0.11-new field is ``None``.
+
+3. **DataflowPipeline runtime.** A pipeline constructed from a legacy
+   v0.0.10 spec (new fields ``None``) must take the legacy code paths
+   — no row-filter dispatch, no multi-source CDC dispatch, no
+   ``clusterByAuto`` behaviour.
+
+The fixtures here are intentionally pinned to the v0.0.10
+``BronzeDataflowSpec`` / ``SilverDataflowSpec`` shapes (24 / 25
+fields, sourced from ``git show v0.0.10:src/dataflow_spec.py``).
+
+If a future PR adds a field to either dataclass, the contract is:
+
+    1. Add the new field to ``additional_bronze_df_columns`` /
+       ``additional_silver_df_columns`` in :class:`DataflowSpecUtils`
+       so reads of legacy persisted Delta tables backfill ``None``.
+    2. Extend ``NEW_BRONZE_FIELDS_AT_READ`` /
+       ``NEW_SILVER_FIELDS_AT_READ`` below so this suite asserts the
+       new field reads back as ``None``.
+    3. Extend ``EXPECTED_BRONZE_DEFAULTS_AT_ONBOARDING`` /
+       ``EXPECTED_SILVER_DEFAULTS_AT_ONBOARDING`` with the value the
+       onboarding parser persists when the field is absent in the
+       JSON. Use ``None`` unless the field has a deliberate
+       non-``None`` default (e.g. boolean opt-in flags default to
+       ``False``, see ``clusterByAuto``).
+
+A new dataclass field that doesn't make it into the additional lists
+will break customer pipelines on upgrade, and these tests will fail —
+which is exactly what we want.
+"""
+import copy
+import json
+import sys
+import unittest
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+# Mock pyspark.pipelines BEFORE importing runtime modules — the test
+# runner doesn't ship a Spark version with pyspark.pipelines yet, so the
+# production imports inside dataflow_pipeline.py would otherwise fail.
+# (Mirrors the pattern in tests/test_dataflow_pipeline.py.)
+sys.modules["pyspark.pipelines"] = MagicMock()
+
+from tests.utils import SDPFrameworkTestCase  # noqa: E402
+from databricks.labs.sdp_meta.dataflow_pipeline import DataflowPipeline  # noqa: E402
+from databricks.labs.sdp_meta.dataflow_spec import (  # noqa: E402
+    BronzeDataflowSpec,
+    DataflowSpecUtils,
+    SilverDataflowSpec,
+)
+from databricks.labs.sdp_meta.onboard_dataflowspec import OnboardDataflowspec  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Frozen v0.0.10 fixtures
+# ---------------------------------------------------------------------------
+
+# v0.0.10 ``BronzeDataflowSpec`` field set, in dataclass declaration order.
+# Sourced verbatim from ``git show v0.0.10:src/dataflow_spec.py``. DO NOT
+# add v0.0.11 fields here — that's the entire point of the fixture.
+V0_0_10_BRONZE_ROW = {
+    "dataFlowId": "100",
+    "dataFlowGroup": "A1",
+    "sourceFormat": "cloudFiles",
+    "sourceDetails": {"path": "tests/resources/data/customers"},
+    "readerConfigOptions": {"cloudFiles.format": "json"},
+    "targetFormat": "delta",
+    "targetDetails": {
+        "database": "bronze",
+        "table": "customers",
+        "path": "/tmp/sdp_meta_compat/bronze/customers",
+    },
+    "tableProperties": {},
+    "schema": None,
+    "partitionColumns": [],
+    "cdcApplyChanges": None,
+    "applyChangesFromSnapshot": None,
+    "dataQualityExpectations": None,
+    "quarantineTargetDetails": {},
+    "quarantineTableProperties": {},
+    "appendFlows": [],
+    "appendFlowsSchemas": {},
+    "version": "v1",
+    "createDate": datetime(2025, 1, 1),
+    "createdBy": "v0_0_10_user",
+    "updateDate": datetime(2025, 1, 1),
+    "updatedBy": "v0_0_10_user",
+    "clusterBy": [],
+    "sinks": [],
+}
+
+# v0.0.10 ``SilverDataflowSpec`` field set.
+V0_0_10_SILVER_ROW = {
+    "dataFlowId": "200",
+    "dataFlowGroup": "A1",
+    "sourceFormat": "delta",
+    "sourceDetails": {
+        "database": "bronze",
+        "table": "customers",
+        "path": "/tmp/sdp_meta_compat/bronze/customers",
+    },
+    "readerConfigOptions": {},
+    "targetFormat": "delta",
+    "targetDetails": {
+        "database": "silver",
+        "table": "customers",
+        "path": "/tmp/sdp_meta_compat/silver/customers",
+    },
+    "tableProperties": {},
+    "selectExp": ["id", "email"],
+    "whereClause": [],
+    "partitionColumns": [],
+    "cdcApplyChanges": None,
+    "applyChangesFromSnapshot": None,
+    "dataQualityExpectations": None,
+    "quarantineTargetDetails": {},
+    "quarantineTableProperties": {},
+    "appendFlows": [],
+    "appendFlowsSchemas": {},
+    "version": "v1",
+    "createDate": datetime(2025, 1, 1),
+    "createdBy": "v0_0_10_user",
+    "updateDate": datetime(2025, 1, 1),
+    "updatedBy": "v0_0_10_user",
+    "clusterBy": [],
+    "sinks": [],
+}
+
+# Fields added in v0.0.11. The expected default per field depends on the
+# upgrade path:
+#
+#   - Read-time path (persisted Delta dataflowspec table missing these
+#     columns): every field is backfilled to ``None`` by
+#     :meth:`DataflowSpecUtils.populate_additional_df_cols`.
+#
+#   - Onboarding path (customer re-runs onboarding with their old
+#     v0.0.10 JSON): every field defaults to ``None`` EXCEPT
+#     ``clusterByAuto``, which deliberately defaults to ``False``
+#     because it's a boolean opt-in flag and ``False`` is the natural
+#     "feature disabled" state (see ``__get_cluster_by_auto`` in
+#     ``onboard_dataflowspec.py``). Both ``None`` and ``False`` are
+#     non-breaking: the runtime treats them identically (no
+#     auto-clustering — same behaviour as v0.0.10 which had no such
+#     field at all).
+NEW_BRONZE_FIELDS_AT_READ = [
+    "clusterByAuto",
+    "cdcApplyChangesFlows",
+    "cdcApplyChangesFlowsSchemas",
+    "rowFilter",
+    "quarantineRowFilter",
+]
+NEW_SILVER_FIELDS_AT_READ = [
+    "clusterByAuto",
+    "cdcApplyChangesFlows",
+    "rowFilter",
+    "quarantineRowFilter",
+]
+# ``cdcApplyChangesFlowsSchemas`` defaults to ``{}`` (empty map), not
+# ``None``, because :meth:`OnboardDataflowspec.get_cdc_apply_changes_flows_json`
+# returns ``(None, {})`` when the field is absent (line 1515 in
+# ``onboard_dataflowspec.py``). The runtime treats ``None`` and ``{}``
+# identically — both fail the ``if dataflow_spec.cdcApplyChangesFlowsSchemas``
+# truthiness check — so this is non-breaking. Only bronze has
+# ``cdcApplyChangesFlowsSchemas``; silver flows always read from Delta
+# upstream and don't carry per-flow schemas.
+EXPECTED_BRONZE_DEFAULTS_AT_ONBOARDING = {
+    "clusterByAuto": False,
+    "cdcApplyChangesFlows": None,
+    "cdcApplyChangesFlowsSchemas": {},
+    "rowFilter": None,
+    "quarantineRowFilter": None,
+}
+EXPECTED_SILVER_DEFAULTS_AT_ONBOARDING = {
+    "clusterByAuto": False,
+    "cdcApplyChangesFlows": None,
+    "rowFilter": None,
+    "quarantineRowFilter": None,
+}
+
+
+# ---------------------------------------------------------------------------
+# 1. Persisted dataflowspec Delta-table compatibility (no Spark needed)
+# ---------------------------------------------------------------------------
+
+class TestV010PersistedDataflowSpecCompatibility(unittest.TestCase):
+    """Read-time backfill: ``populate_additional_df_cols`` + dataclass init.
+
+    Models the path :func:`get_bronze_dataflow_spec` /
+    :func:`get_silver_dataflow_spec` take when reading a customer's
+    v0.0.10-written dataflowspec Delta table.
+    """
+
+    def test_populate_additional_bronze_columns_backfills_v0_0_11_new_fields(self):
+        legacy_row = copy.deepcopy(V0_0_10_BRONZE_ROW)
+        # Sanity: the fixture lacks every v0.0.11 field.
+        for field in NEW_BRONZE_FIELDS_AT_READ:
+            self.assertNotIn(
+                field, legacy_row,
+                f"Fixture is wrong: {field!r} must not be in a v0.0.10 row",
+            )
+
+        target_row = DataflowSpecUtils.populate_additional_df_cols(
+            legacy_row, DataflowSpecUtils.additional_bronze_df_columns,
+        )
+
+        for field in NEW_BRONZE_FIELDS_AT_READ:
+            self.assertIn(
+                field, target_row,
+                f"{field!r} not backfilled — additional_bronze_df_columns is incomplete",
+            )
+            self.assertIsNone(
+                target_row[field],
+                f"{field!r} backfilled with {target_row[field]!r}; expected None",
+            )
+
+    def test_populate_additional_silver_columns_backfills_v0_0_11_new_fields(self):
+        legacy_row = copy.deepcopy(V0_0_10_SILVER_ROW)
+        for field in NEW_SILVER_FIELDS_AT_READ:
+            self.assertNotIn(
+                field, legacy_row,
+                f"Fixture is wrong: {field!r} must not be in a v0.0.10 row",
+            )
+
+        target_row = DataflowSpecUtils.populate_additional_df_cols(
+            legacy_row, DataflowSpecUtils.additional_silver_df_columns,
+        )
+
+        for field in NEW_SILVER_FIELDS_AT_READ:
+            self.assertIn(
+                field, target_row,
+                f"{field!r} not backfilled — additional_silver_df_columns is incomplete",
+            )
+            self.assertIsNone(
+                target_row[field],
+                f"{field!r} backfilled with {target_row[field]!r}; expected None",
+            )
+
+    def test_bronze_dataflow_spec_constructs_from_v0_0_10_legacy_row(self):
+        """``BronzeDataflowSpec(**backfilled_legacy_row)`` must not raise.
+
+        If this fails (typically ``TypeError: __init__() missing N required
+        positional arguments``), customer pipelines crash on first read of
+        their v0.0.10-written ``bronze_dataflowspec`` Delta table.
+        """
+        target_row = DataflowSpecUtils.populate_additional_df_cols(
+            copy.deepcopy(V0_0_10_BRONZE_ROW),
+            DataflowSpecUtils.additional_bronze_df_columns,
+        )
+        spec = BronzeDataflowSpec(**target_row)
+
+        for field in NEW_BRONZE_FIELDS_AT_READ:
+            self.assertIsNone(getattr(spec, field))
+        # Sanity: existing v0.0.10 fields preserved.
+        self.assertEqual(spec.dataFlowId, "100")
+        self.assertEqual(spec.sourceFormat, "cloudFiles")
+
+    def test_silver_dataflow_spec_constructs_from_v0_0_10_legacy_row(self):
+        target_row = DataflowSpecUtils.populate_additional_df_cols(
+            copy.deepcopy(V0_0_10_SILVER_ROW),
+            DataflowSpecUtils.additional_silver_df_columns,
+        )
+        spec = SilverDataflowSpec(**target_row)
+
+        for field in NEW_SILVER_FIELDS_AT_READ:
+            self.assertIsNone(getattr(spec, field))
+        self.assertEqual(spec.dataFlowId, "200")
+        self.assertEqual(spec.sourceFormat, "delta")
+
+
+# ---------------------------------------------------------------------------
+# 2. v0.0.10 onboarding-file compatibility (Spark needed)
+# ---------------------------------------------------------------------------
+
+class TestV010OnboardingFileCompatibility(SDPFrameworkTestCase):
+    """v0.0.10 onboarding JSON → v0.0.11 onboarding code → persisted spec.
+
+    The existing ``test_onboard_bronze_silver_with_v10`` in
+    ``tests/test_onboard_dataflowspec.py`` only asserts row count.
+    Here we round-trip through the real Delta read path and verify
+    every persisted spec has the v0.0.11-new fields defaulted to
+    ``None`` — proving an upgrading customer who re-runs onboarding
+    against their old JSON file doesn't accidentally pick up unintended
+    values for the new fields.
+    """
+
+    def _onboard_v0_0_10(self):
+        params = copy.deepcopy(self.onboarding_bronze_silver_params_map)
+        params["onboarding_file_path"] = self.onboarding_json_v10_file
+        OnboardDataflowspec(self.spark, params).onboard_dataflow_specs()
+        return params
+
+    def _read_specs(self, params, layer, spec_class, additional_cols):
+        """Read all rows from the persisted dataflowspec Delta table and
+        construct dataclass instances via the same backfill path the
+        runtime uses (``populate_additional_df_cols`` + ``Spec(**row)``).
+
+        We bypass :func:`get_bronze_dataflow_spec` /
+        :func:`get_silver_dataflow_spec` because those require
+        ``spark.conf`` keys (``layer``, ``<layer>.group`` /
+        ``<layer>.dataflowIds``) for runtime filtering — irrelevant to
+        the backward-compat surface under test, and they'd force us to
+        either iterate per-group or fabricate a dataflow_ids list.
+        """
+        table_key = f"{layer}_dataflowspec_table"
+        df = self.spark.read.table(f"{params['database']}.{params[table_key]}")
+        specs = []
+        for row in df.collect():
+            target_row = DataflowSpecUtils.populate_additional_df_cols(
+                row.asDict(), additional_cols,
+            )
+            specs.append(spec_class(**target_row))
+        return specs
+
+    def test_v0_0_10_onboarding_persists_safe_defaults_for_new_bronze_fields(self):
+        params = self._onboard_v0_0_10()
+        bronze_specs = self._read_specs(
+            params, "bronze", BronzeDataflowSpec,
+            DataflowSpecUtils.additional_bronze_df_columns,
+        )
+        self.assertGreater(
+            len(bronze_specs), 0,
+            "v0.0.10 onboarding produced no bronze specs",
+        )
+        for spec in bronze_specs:
+            for field, expected in EXPECTED_BRONZE_DEFAULTS_AT_ONBOARDING.items():
+                actual = getattr(spec, field)
+                self.assertEqual(
+                    actual, expected,
+                    f"v0.0.10 onboarding produced bronze spec with {field}="
+                    f"{actual!r} on dataFlowId={spec.dataFlowId}; "
+                    f"expected {expected!r} for backward compatibility",
+                )
+
+    def test_v0_0_10_onboarding_persists_safe_defaults_for_new_silver_fields(self):
+        params = self._onboard_v0_0_10()
+        silver_specs = self._read_specs(
+            params, "silver", SilverDataflowSpec,
+            DataflowSpecUtils.additional_silver_df_columns,
+        )
+        self.assertGreater(
+            len(silver_specs), 0,
+            "v0.0.10 onboarding produced no silver specs",
+        )
+        for spec in silver_specs:
+            for field, expected in EXPECTED_SILVER_DEFAULTS_AT_ONBOARDING.items():
+                actual = getattr(spec, field)
+                self.assertEqual(
+                    actual, expected,
+                    f"v0.0.10 onboarding produced silver spec with {field}="
+                    f"{actual!r} on dataFlowId={spec.dataFlowId}; "
+                    f"expected {expected!r} for backward compatibility",
+                )
+
+
+# ---------------------------------------------------------------------------
+# 3. DataflowPipeline runtime compatibility (Spark needed, dp mocked)
+# ---------------------------------------------------------------------------
+
+class TestV010DataflowPipelineRuntimeCompatibility(SDPFrameworkTestCase):
+    """A v0.0.10-shape spec (new fields ``None``) must reach legacy code paths.
+
+    The ``write_layer_table`` dispatch order is, for bronze:
+
+        1. snapshot source     → ``apply_changes_from_snapshot``
+        2. dataQualityExpectations → ``write_layer_with_dqe``
+        3. cdcApplyChangesFlows (v0.0.11)  → ``cdc_apply_changes_flows``
+        4. cdcApplyChanges     → ``cdc_apply_changes``
+        5. else                → ``_write_standard_table``
+
+    A v0.0.10 spec hits branch 3 only if the customer's legacy
+    onboarding file accidentally contained ``cdcApplyChangesFlows`` —
+    impossible by definition, but guarded here too.
+    """
+
+    def _legacy_bronze_spec(self, **overrides):
+        target_row = DataflowSpecUtils.populate_additional_df_cols(
+            copy.deepcopy(V0_0_10_BRONZE_ROW),
+            DataflowSpecUtils.additional_bronze_df_columns,
+        )
+        target_row.update(overrides)
+        return BronzeDataflowSpec(**target_row)
+
+    def test_dataflow_pipeline_init_with_legacy_bronze_spec_is_safe(self):
+        """Init from a legacy spec must not raise; row-filter helpers return None."""
+        # UC ON — even so, with rowFilter / quarantineRowFilter unset
+        # (None on the legacy spec), the helpers must return None.
+        self.spark.conf.set("spark.databricks.unityCatalog.enabled", "True")
+        self.addCleanup(
+            self.spark.conf.unset, "spark.databricks.unityCatalog.enabled",
+        )
+
+        spec = self._legacy_bronze_spec()
+        view_name = f"{spec.targetDetails['table']}_inputview"
+        pipeline = DataflowPipeline(self.spark, spec, view_name, None)
+
+        self.assertIsNone(pipeline._get_row_filter())
+        self.assertIsNone(pipeline._get_quarantine_row_filter())
+        # Multi-source AUTO CDC parsed-attribute is None on legacy specs.
+        self.assertIsNone(pipeline.cdcApplyChangesFlows)
+        # Single-source CDC default is also None.
+        self.assertIsNone(pipeline.cdcApplyChanges)
+
+    @patch("databricks.labs.sdp_meta.dataflow_pipeline.dp")
+    def test_legacy_bronze_spec_dispatches_to_standard_write(self, mock_dp):
+        """No DQE, no CDC, no row filter → ``_write_standard_table`` (i.e. ``dp.table``)."""
+        mock_dp.table = MagicMock(return_value=lambda func: func)
+        mock_dp.create_streaming_table = MagicMock()
+        mock_dp.create_auto_cdc_flow = MagicMock()
+        mock_dp.expect_all_or_drop = MagicMock(return_value=lambda func: func)
+
+        spec = self._legacy_bronze_spec()
+        view_name = f"{spec.targetDetails['table']}_inputview"
+        pipeline = DataflowPipeline(self.spark, spec, view_name, None)
+        pipeline.read_bronze = MagicMock()
+
+        pipeline.write_bronze()
+
+        # Standard write fired.
+        self.assertGreaterEqual(mock_dp.table.call_count, 1)
+        # No CDC dispatch.
+        mock_dp.create_streaming_table.assert_not_called()
+        mock_dp.create_auto_cdc_flow.assert_not_called()
+        # Standard write never carries a row_filter on a legacy spec.
+        _, kwargs = mock_dp.table.call_args
+        self.assertIsNone(kwargs.get("row_filter"))
+
+    @patch("databricks.labs.sdp_meta.dataflow_pipeline.dp")
+    def test_legacy_bronze_spec_with_single_source_cdc_dispatches_to_legacy_cdc(
+        self, mock_dp,
+    ):
+        """``cdcApplyChanges`` (legacy single-source) → ``cdc_apply_changes`` path.
+
+        The dispatch must NOT take the v0.0.11 multi-source
+        ``cdc_apply_changes_flows`` branch (``cdcApplyChangesFlows`` is
+        ``None`` on a legacy spec).
+        """
+        mock_dp.create_streaming_table = MagicMock()
+        mock_dp.create_auto_cdc_flow = MagicMock()
+        mock_dp.table = MagicMock(return_value=lambda func: func)
+
+        cdc_payload = json.dumps({
+            "keys": ["id"],
+            "sequence_by": "operation_date",
+            "scd_type": "1",
+        })
+        spec = self._legacy_bronze_spec(cdcApplyChanges=cdc_payload)
+        # Legacy spec carries no multi-source CDC.
+        self.assertIsNone(spec.cdcApplyChangesFlows)
+
+        view_name = f"{spec.targetDetails['table']}_inputview"
+        pipeline = DataflowPipeline(self.spark, spec, view_name, None)
+        pipeline.read_bronze = MagicMock()
+        pipeline.write_bronze()
+
+        # Legacy CDC path: exactly one streaming table + one auto-CDC flow.
+        mock_dp.create_streaming_table.assert_called_once()
+        mock_dp.create_auto_cdc_flow.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_bundle_loaders.py
+++ b/tests/test_bundle_loaders.py
@@ -1,0 +1,471 @@
+"""Tests for the interactive ``_load_bundle_*_config`` loaders + cli.py dispatchers.
+
+These functions translate ``WorkspaceInstaller`` prompts into the
+typed dataclasses (``BundlePrepareWheelCommand``, ``BundleValidateCommand``,
+``BundleAddFlowCommand``) that drive the actual ``bundle ...``
+runners. Pre-existing tests cover the runners end-to-end via rendered
+templates, but the loader prompt-translation layer was almost entirely
+uncovered (lines 1133-1236 of ``bundle.py``, ~85 stmts) along with the
+matching three-line cli.py dispatchers (``bundle_prepare_wheel``,
+``bundle_validate``, ``bundle_add_flow``).
+
+The loaders are pure prompt-translation: feed them a fake ``wsi`` that
+returns canned answers and assert the resulting command dataclass.
+
+Bonus targets:
+- ``_build_source_details`` ``eventhub`` and ``snapshot`` branches
+  (lines 850-874) — also pure functions, also missed by the existing
+  ``_sdp_meta_sanity_checks`` end-to-end tests because those only
+  drive the ``cloudFiles`` and ``delta`` paths.
+- The ``_volume_path_exists`` helper's NotFound branch.
+"""
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from databricks.labs.sdp_meta.bundle import (
+    BundleAddFlowCommand,
+    BundlePrepareWheelCommand,
+    BundleValidateCommand,
+    FlowSpec,
+    _build_source_details,
+    _load_bundle_add_flow_config,
+    _load_bundle_prepare_wheel_config,
+    _load_bundle_validate_config,
+)
+
+
+def _make_wsi(*, questions: dict, choices: dict) -> MagicMock:
+    """Build a fake ``WorkspaceInstaller`` returning canned answers.
+
+    ``_question(text, default=...)`` -> looks up by EXACT prompt text.
+    ``_choice(text, choices)`` -> looks up by EXACT prompt text.
+
+    Using exact prompt text is intentional: if the loader's prompt
+    wording changes, the test fails loud and we update both at once,
+    rather than the test silently matching a now-obsolete prompt.
+    """
+    wsi = MagicMock()
+
+    def _question_side_effect(text, default=None):
+        if text not in questions:
+            raise AssertionError(
+                f"unexpected _question prompt: {text!r}; "
+                f"known prompts: {list(questions)}"
+            )
+        return questions[text]
+
+    def _choice_side_effect(text, options, **_):
+        if text not in choices:
+            raise AssertionError(
+                f"unexpected _choice prompt: {text!r}; "
+                f"known prompts: {list(choices)}"
+            )
+        return choices[text]
+
+    wsi._question.side_effect = _question_side_effect
+    wsi._choice.side_effect = _choice_side_effect
+    return wsi
+
+
+# A patch target that sidesteps ``_load_bundle_prepare_wheel_config``'s
+# UC-identifier validation. The real ``prompt_uc_identifier`` retries
+# on validation failure; we just want it to return what the user typed.
+_IDENT_PATCH = "databricks.labs.sdp_meta.bundle._ident_prompt"
+
+
+class TestLoadBundlePrepareWheelConfig(unittest.TestCase):
+    """``bundle_prepare_wheel`` interactive parameter loader."""
+
+    def test_minimal_inputs_no_pip_mirror(self):
+        """Empty pip mirror prompts -> ``pip_index_url`` / extras are None."""
+        wsi = _make_wsi(
+            questions={
+                "pip --index-url (blank to use default / $PIP_INDEX_URL)": "",
+                "pip --extra-index-url (space-separated, blank for none)": "",
+            },
+            choices={
+                "Auto-create the schema and volume if they don't exist?": "True",
+            },
+        )
+        with patch(_IDENT_PATCH, side_effect=lambda _wsi, _text, **_kw: {
+            "Unity Catalog catalog name": "main",
+            "UC schema for the wheel volume": "sdp_meta_dataflowspecs",
+            "UC volume name": "sdp_meta_wheels",
+        }[_text]):
+            with patch.dict("os.environ", {}, clear=False) as _:
+                cfg = _load_bundle_prepare_wheel_config(wsi)
+
+        self.assertIsInstance(cfg, BundlePrepareWheelCommand)
+        self.assertEqual(cfg.uc_catalog, "main")
+        self.assertEqual(cfg.uc_schema, "sdp_meta_dataflowspecs")
+        self.assertEqual(cfg.uc_volume, "sdp_meta_wheels")
+        self.assertIsNone(cfg.pip_index_url)
+        self.assertIsNone(cfg.pip_extra_index_urls)
+        self.assertTrue(cfg.create_if_missing)
+
+    def test_pip_mirror_and_multiple_extras(self):
+        wsi = _make_wsi(
+            questions={
+                "pip --index-url (blank to use default / $PIP_INDEX_URL)":
+                    "https://pypi.internal.example.com/simple",
+                "pip --extra-index-url (space-separated, blank for none)":
+                    "https://m1.example.com/simple https://m2.example.com/simple",
+            },
+            choices={
+                "Auto-create the schema and volume if they don't exist?": "False",
+            },
+        )
+        with patch(_IDENT_PATCH, side_effect=lambda _wsi, _text, **_kw: {
+            "Unity Catalog catalog name": "prod",
+            "UC schema for the wheel volume": "wheels",
+            "UC volume name": "vol",
+        }[_text]):
+            cfg = _load_bundle_prepare_wheel_config(wsi)
+
+        self.assertEqual(cfg.pip_index_url, "https://pypi.internal.example.com/simple")
+        self.assertEqual(
+            cfg.pip_extra_index_urls,
+            ["https://m1.example.com/simple", "https://m2.example.com/simple"],
+        )
+        self.assertFalse(cfg.create_if_missing)
+
+
+class TestLoadBundleValidateConfig(unittest.TestCase):
+    """``bundle_validate`` interactive parameter loader."""
+
+    def test_default_bundle_dir_no_target(self):
+        wsi = _make_wsi(
+            questions={
+                "Bundle directory": ".",
+                "Bundle target (blank for default)": "",
+            },
+            choices={},
+        )
+        cfg = _load_bundle_validate_config(wsi)
+        self.assertIsInstance(cfg, BundleValidateCommand)
+        self.assertEqual(cfg.bundle_dir, ".")
+        self.assertIsNone(cfg.target)
+
+    def test_custom_dir_and_target(self):
+        wsi = _make_wsi(
+            questions={
+                "Bundle directory": "/path/to/bundle",
+                "Bundle target (blank for default)": "prod",
+            },
+            choices={},
+        )
+        cfg = _load_bundle_validate_config(wsi)
+        self.assertEqual(cfg.bundle_dir, "/path/to/bundle")
+        self.assertEqual(cfg.target, "prod")
+
+
+class TestLoadBundleAddFlowConfig(unittest.TestCase):
+    """``bundle_add_flow`` interactive parameter loader.
+
+    Five source-format branches × {single, csv} mode = 6 distinct
+    code paths. We cover one representative test per source-format
+    branch plus the csv shortcut.
+    """
+
+    def test_csv_mode_skips_per_flow_prompts(self):
+        wsi = _make_wsi(
+            questions={
+                "Bundle directory": ".",
+                "Path to CSV file": "my_flows.csv",
+            },
+            choices={
+                "Add a single flow or batch from CSV?": "csv",
+                "Dry run (preview only, no file write)?": "True",
+            },
+        )
+        cfg = _load_bundle_add_flow_config(wsi)
+        self.assertIsInstance(cfg, BundleAddFlowCommand)
+        self.assertEqual(cfg.from_csv, "my_flows.csv")
+        self.assertEqual(cfg.flows, [])
+        self.assertTrue(cfg.dry_run)
+
+    def _single_flow_questions(self, source_format: str, **extras):
+        """Common per-flow prompts plus source-format specific ones."""
+        base = {
+            "Bundle directory": ".",
+            "Bronze table name (leave blank if silver-only)": "orders_bronze",
+            "Silver table name (blank = same as bronze)": "",
+            "data_flow_id (use `auto` to auto-increment)": "auto",
+            "data_flow_group (blank = use bundle default)": "",
+        }
+        base.update(extras)
+        return base, {
+            "Add a single flow or batch from CSV?": "single",
+            "Dry run (preview only, no file write)?": "False",
+            "Source format": source_format,
+        }
+
+    def test_single_flow_cloudfiles_branch(self):
+        questions, choices = self._single_flow_questions(
+            "cloudFiles",
+            **{
+                "Source path (e.g. /Volumes/raw/landing/orders/)": "/Volumes/raw/orders/",
+                "Source schema DDL path (blank to skip)": "",
+            },
+        )
+        wsi = _make_wsi(questions=questions, choices=choices)
+        cfg = _load_bundle_add_flow_config(wsi)
+        self.assertEqual(len(cfg.flows), 1)
+        flow = cfg.flows[0]
+        self.assertEqual(flow.source_format, "cloudFiles")
+        self.assertEqual(flow.source_path, "/Volumes/raw/orders/")
+        self.assertIsNone(flow.source_schema_path)
+        self.assertEqual(flow.bronze_table, "orders_bronze")
+
+    def test_single_flow_delta_branch(self):
+        questions, choices = self._single_flow_questions(
+            "delta",
+            **{
+                "Source database": "raw",
+                "Source table": "orders_raw",
+            },
+        )
+        wsi = _make_wsi(questions=questions, choices=choices)
+        cfg = _load_bundle_add_flow_config(wsi)
+        flow = cfg.flows[0]
+        self.assertEqual(flow.source_format, "delta")
+        self.assertEqual(flow.source_database, "raw")
+        self.assertEqual(flow.source_table, "orders_raw")
+
+    def test_single_flow_kafka_branch(self):
+        questions, choices = self._single_flow_questions(
+            "kafka",
+            **{
+                "kafka.bootstrap.servers": "broker.example.com:9092",
+                "subscribe (topic name)": "events",
+            },
+        )
+        wsi = _make_wsi(questions=questions, choices=choices)
+        cfg = _load_bundle_add_flow_config(wsi)
+        flow = cfg.flows[0]
+        self.assertEqual(flow.source_format, "kafka")
+        self.assertEqual(flow.kafka_bootstrap_servers, "broker.example.com:9092")
+        self.assertEqual(flow.kafka_topic, "events")
+
+    def test_single_flow_eventhub_branch(self):
+        questions, choices = self._single_flow_questions(
+            "eventhub",
+            **{
+                "eventhub.namespace": "my-eh-ns",
+                "eventhub.name": "events",
+            },
+        )
+        wsi = _make_wsi(questions=questions, choices=choices)
+        cfg = _load_bundle_add_flow_config(wsi)
+        flow = cfg.flows[0]
+        self.assertEqual(flow.source_format, "eventhub")
+        # eventhub uses kafka_bootstrap_servers and kafka_topic as the carrier
+        # for the namespace and name (it's the EH-via-Kafka-API pattern).
+        self.assertEqual(flow.kafka_bootstrap_servers, "my-eh-ns")
+        self.assertEqual(flow.kafka_topic, "events")
+
+    def test_single_flow_snapshot_branch(self):
+        questions, choices = self._single_flow_questions(
+            "snapshot",
+            **{
+                "Snapshot source path (e.g. /Volumes/raw/snapshots/orders/)":
+                    "/Volumes/raw/snapshots/orders/",
+            },
+        )
+        wsi = _make_wsi(questions=questions, choices=choices)
+        cfg = _load_bundle_add_flow_config(wsi)
+        flow = cfg.flows[0]
+        self.assertEqual(flow.source_format, "snapshot")
+        self.assertEqual(flow.source_path, "/Volumes/raw/snapshots/orders/")
+
+
+class TestBuildSourceDetails(unittest.TestCase):
+    """``_build_source_details`` branches the ``_sdp_meta_sanity_checks``
+    e2e tests don't reach: ``eventhub``, ``snapshot``, and the
+    ``ValueError`` validation branches.
+    """
+
+    def test_kafka_requires_bootstrap_and_topic(self):
+        spec = FlowSpec(source_format="kafka")
+        with self.assertRaises(ValueError) as cm:
+            _build_source_details(spec, "main")
+        self.assertIn("kafka_bootstrap_servers", str(cm.exception))
+        self.assertIn("kafka_topic", str(cm.exception))
+
+    def test_kafka_with_schema_path_includes_it(self):
+        spec = FlowSpec(
+            source_format="kafka",
+            kafka_bootstrap_servers="b:9092",
+            kafka_topic="t",
+            source_schema_path="/path/schema.ddl",
+        )
+        details = _build_source_details(spec, "main")
+        self.assertEqual(details["kafka.bootstrap.servers"], "b:9092")
+        self.assertEqual(details["subscribe"], "t")
+        self.assertEqual(details["startingOffsets"], "earliest")
+        self.assertEqual(details["source_schema_path"], "/path/schema.ddl")
+
+    def test_eventhub_requires_topic(self):
+        spec = FlowSpec(source_format="eventhub", kafka_bootstrap_servers="ns")
+        with self.assertRaises(ValueError) as cm:
+            _build_source_details(spec, "main")
+        self.assertIn("eventhub.name", str(cm.exception))
+
+    def test_eventhub_full_mapping(self):
+        spec = FlowSpec(
+            source_format="eventhub",
+            kafka_bootstrap_servers="prod-ns",
+            kafka_topic="events",
+            source_schema_path="/p/s.ddl",
+        )
+        details = _build_source_details(spec, "main")
+        self.assertEqual(details["eventhub.namespace"], "prod-ns")
+        self.assertEqual(details["eventhub.name"], "events")
+        self.assertEqual(details["eventhub.port"], "9093")
+        # Placeholders propagate when the user hasn't filled them yet.
+        self.assertEqual(details["eventhub.accessKeyName"], "<your-sas-policy-name>")
+        self.assertEqual(details["eventhub.accessKeySecretName"], "<your-secret-name>")
+        self.assertEqual(details["eventhub.secretsScopeName"], "<your-secret-scope>")
+        self.assertEqual(details["kafka.sasl.mechanism"], "PLAIN")
+        self.assertEqual(details["kafka.security.protocol"], "SASL_SSL")
+        self.assertEqual(details["source_schema_path"], "/p/s.ddl")
+
+    def test_eventhub_namespace_falls_back_to_placeholder(self):
+        spec = FlowSpec(
+            source_format="eventhub",
+            kafka_topic="events",
+            # kafka_bootstrap_servers (carrying namespace) intentionally unset
+        )
+        details = _build_source_details(spec, "main")
+        self.assertEqual(details["eventhub.namespace"], "<your-eventhub-namespace>")
+
+    def test_snapshot_with_explicit_source_path(self):
+        spec = FlowSpec(
+            source_format="snapshot",
+            source_path="/Volumes/raw/snapshots/orders/",
+            snapshot_format="parquet",
+        )
+        details = _build_source_details(spec, "main")
+        self.assertEqual(details["source_path_dev"], "/Volumes/raw/snapshots/orders/")
+        self.assertEqual(details["snapshot_format"], "parquet")
+
+    def test_snapshot_falls_back_to_template_path(self):
+        spec = FlowSpec(source_format="snapshot", bronze_table="orders")
+        details = _build_source_details(spec, "main")
+        self.assertEqual(
+            details["source_path_dev"],
+            "/Volumes/main/landing/snapshots/orders/",
+        )
+        # Default snapshot_format is ``delta``.
+        self.assertEqual(details["snapshot_format"], "delta")
+
+
+class TestCliBundleDispatchers(unittest.TestCase):
+    """The cli.py thin dispatchers (``bundle_prepare_wheel``,
+    ``bundle_validate``, ``bundle_add_flow``) just glue the loader to
+    its runner. They were uncovered because the in-process tests
+    avoided constructing an SDPMeta + wsi pair. Exercising them is
+    cheap and adds 30+ lines of coverage.
+    """
+
+    def test_bundle_prepare_wheel_calls_loader_then_runner(self):
+        from databricks.labs.sdp_meta.cli import bundle_prepare_wheel
+
+        sdp_meta = MagicMock()
+        loader_result = BundlePrepareWheelCommand(
+            uc_catalog="main",
+            uc_schema="sdp_meta_dataflowspecs",
+            uc_volume="sdp_meta_wheels",
+        )
+        with (
+            patch(
+                "databricks.labs.sdp_meta.bundle._load_bundle_prepare_wheel_config",
+                return_value=loader_result,
+            ) as mock_loader,
+            patch(
+                "databricks.labs.sdp_meta.bundle.bundle_prepare_wheel"
+            ) as mock_run,
+        ):
+            mock_run.return_value = 0
+            bundle_prepare_wheel(sdp_meta, flags={})
+            mock_loader.assert_called_once_with(sdp_meta._wsi)
+            mock_run.assert_called_once_with(loader_result)
+
+    def test_bundle_validate_calls_loader_then_runner_success(self):
+        from databricks.labs.sdp_meta.cli import bundle_validate
+
+        sdp_meta = MagicMock()
+        loader_result = BundleValidateCommand(bundle_dir=".", target=None)
+        with (
+            patch(
+                "databricks.labs.sdp_meta.bundle._load_bundle_validate_config",
+                return_value=loader_result,
+            ),
+            patch(
+                "databricks.labs.sdp_meta.bundle.bundle_validate",
+                return_value=0,
+            ),
+        ):
+            # Successful run (rc == 0) must NOT call sys.exit.
+            bundle_validate(sdp_meta, flags={})
+
+    def test_bundle_validate_exits_when_runner_returns_nonzero(self):
+        from databricks.labs.sdp_meta.cli import bundle_validate
+
+        sdp_meta = MagicMock()
+        loader_result = BundleValidateCommand(bundle_dir=".", target=None)
+        with (
+            patch(
+                "databricks.labs.sdp_meta.bundle._load_bundle_validate_config",
+                return_value=loader_result,
+            ),
+            patch(
+                "databricks.labs.sdp_meta.bundle.bundle_validate",
+                return_value=2,
+            ),
+            self.assertRaises(SystemExit) as cm,
+        ):
+            bundle_validate(sdp_meta, flags={})
+        self.assertEqual(cm.exception.code, 2)
+
+    def test_bundle_add_flow_calls_loader_then_runner_success(self):
+        from databricks.labs.sdp_meta.cli import bundle_add_flow
+
+        sdp_meta = MagicMock()
+        loader_result = BundleAddFlowCommand(bundle_dir=".", flows=[])
+        with (
+            patch(
+                "databricks.labs.sdp_meta.bundle._load_bundle_add_flow_config",
+                return_value=loader_result,
+            ),
+            patch(
+                "databricks.labs.sdp_meta.bundle.bundle_add_flow",
+                return_value=0,
+            ),
+        ):
+            bundle_add_flow(sdp_meta, flags={})
+
+    def test_bundle_add_flow_exits_when_runner_fails(self):
+        from databricks.labs.sdp_meta.cli import bundle_add_flow
+
+        sdp_meta = MagicMock()
+        loader_result = BundleAddFlowCommand(bundle_dir=".", flows=[])
+        with (
+            patch(
+                "databricks.labs.sdp_meta.bundle._load_bundle_add_flow_config",
+                return_value=loader_result,
+            ),
+            patch(
+                "databricks.labs.sdp_meta.bundle.bundle_add_flow",
+                return_value=1,
+            ),
+            self.assertRaises(SystemExit) as cm,
+        ):
+            bundle_add_flow(sdp_meta, flags={})
+        self.assertEqual(cm.exception.code, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cli_helpers.py
+++ b/tests/test_cli_helpers.py
@@ -1,0 +1,195 @@
+"""Targeted tests for small private helpers in
+``databricks.labs.sdp_meta.cli`` that the existing ``test_cli.py``
+suite does not exercise.
+
+These helpers are pure plumbing -- WorkspaceClient mock interactions,
+git-URL string formatting, UC schema/volume probing -- and are
+straightforward to cover. Adding tests here pushes overall package
+coverage past the 90% threshold without touching the much larger
+end-to-end flows in ``test_cli.py``.
+"""
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from databricks.sdk.errors import NotFound, DatabricksError
+from databricks.sdk.service.catalog import VolumeType
+
+from databricks.labs.sdp_meta.cli import (
+    _ensure_uc_schema_and_volume,
+    _git_wheel_source,
+    _volume_path_exists,
+)
+
+
+class TestGitWheelSourceBuilder(unittest.TestCase):
+    """``_git_wheel_source`` produces a pip-compatible source URL."""
+
+    def test_returns_none_when_no_git_url_and_no_branch(self):
+        # Neither flag set -> None signals "user wants a non-git
+        # source" (PyPI / local path); caller falls back accordingly.
+        self.assertIsNone(_git_wheel_source({}))
+
+    def test_defaults_git_url_when_only_branch_given(self):
+        # Branch alone -> defaults the URL to the public dlt-meta
+        # repo so users don't have to spell it out for upstream
+        # branch builds.
+        result = _git_wheel_source({"git_branch": "feature/sdp-meta"})
+        self.assertEqual(
+            result,
+            "git+https://github.com/databrickslabs/dlt-meta.git@feature/sdp-meta",
+        )
+
+    def test_prefixes_git_plus_when_user_url_omits_it(self):
+        # pip wants ``git+<https-url>`` for git sources; auto-prefix
+        # so users don't have to think about it.
+        result = _git_wheel_source(
+            {"git_url": "https://github.com/foo/bar.git", "git_branch": "main"}
+        )
+        self.assertEqual(result, "git+https://github.com/foo/bar.git@main")
+
+    def test_keeps_existing_git_plus_prefix_intact(self):
+        # User who already typed ``git+...`` should NOT see ``git+git+``.
+        result = _git_wheel_source({"git_url": "git+ssh://git@host/repo.git"})
+        self.assertEqual(result, "git+ssh://git@host/repo.git")
+
+    def test_url_without_branch_omits_at_suffix(self):
+        result = _git_wheel_source({"git_url": "https://github.com/foo/bar.git"})
+        self.assertEqual(result, "git+https://github.com/foo/bar.git")
+
+
+class TestVolumePathExistsProbe(unittest.TestCase):
+    """``_volume_path_exists`` returns False on every error -- it's
+    just an informational pre-flight before the upload."""
+
+    def _ws_with_metadata_outcome(self, *, raises=None):
+        """Return a WorkspaceClient mock whose ``files.get_metadata``
+        either succeeds or raises ``raises`` once when called."""
+        ws = MagicMock()
+        if raises is not None:
+            ws.files.get_metadata.side_effect = raises
+        return ws
+
+    def test_returns_true_when_metadata_call_succeeds(self):
+        ws = self._ws_with_metadata_outcome()
+        self.assertTrue(_volume_path_exists(ws, "/Volumes/c/s/v/file.whl"))
+        ws.files.get_metadata.assert_called_once_with(
+            file_path="/Volumes/c/s/v/file.whl",
+        )
+
+    def test_returns_false_on_not_found(self):
+        ws = self._ws_with_metadata_outcome(raises=NotFound("nope"))
+        self.assertFalse(_volume_path_exists(ws, "/Volumes/c/s/v/missing.whl"))
+
+    def test_returns_false_on_databricks_error(self):
+        # Defensive branch: any other SDK error is also "treat as
+        # absent" because the function is purely a UI hint.
+        ws = self._ws_with_metadata_outcome(raises=DatabricksError("transient"))
+        self.assertFalse(_volume_path_exists(ws, "/Volumes/c/s/v/file.whl"))
+
+
+class TestEnsureUcSchemaAndVolume(unittest.TestCase):
+    """``_ensure_uc_schema_and_volume`` covers the four
+    schema-exists/volume-exists branches with create-on-missing
+    toggled."""
+
+    def _ws_with_schemas_api(self, *, schema_raises=None, volume_raises=None):
+        ws = MagicMock()
+        # We patch ``SchemasAPI`` at the call site below; just
+        # configure ws.volumes.read here.
+        if volume_raises is not None:
+            ws.volumes.read.side_effect = volume_raises
+        return ws
+
+    def _patch_schemas_api(self, *, get_raises=None):
+        """Return a MagicMock that ``SchemasAPI(api_client)`` returns
+        whose ``.get`` either succeeds or raises ``get_raises``."""
+        api_instance = MagicMock()
+        if get_raises is not None:
+            api_instance.get.side_effect = get_raises
+        return api_instance
+
+    def test_no_op_when_schema_and_volume_both_exist(self):
+        ws = self._ws_with_schemas_api()
+        api_instance = self._patch_schemas_api()
+        with patch(
+            "databricks.labs.sdp_meta.cli.SchemasAPI",
+            return_value=api_instance,
+        ):
+            _ensure_uc_schema_and_volume(
+                ws, "main", "sdp_meta", "wheels",
+                create_if_missing=True,
+            )
+        api_instance.get.assert_called_once_with(full_name="main.sdp_meta")
+        ws.volumes.read.assert_called_once_with(name="main.sdp_meta.wheels")
+        # Nothing created on the happy path.
+        api_instance.create.assert_not_called()
+        ws.volumes.create.assert_not_called()
+
+    def test_creates_schema_when_missing_and_create_if_missing_true(self):
+        ws = self._ws_with_schemas_api()
+        api_instance = self._patch_schemas_api(get_raises=NotFound("nope"))
+        with patch(
+            "databricks.labs.sdp_meta.cli.SchemasAPI",
+            return_value=api_instance,
+        ):
+            _ensure_uc_schema_and_volume(
+                ws, "main", "sdp_meta", "wheels",
+                create_if_missing=True,
+            )
+        api_instance.create.assert_called_once_with(
+            catalog_name="main",
+            name="sdp_meta",
+            comment="sdp_meta wheel schema",
+        )
+
+    def test_creates_volume_when_missing_and_create_if_missing_true(self):
+        ws = self._ws_with_schemas_api(volume_raises=NotFound("nope"))
+        api_instance = self._patch_schemas_api()
+        with patch(
+            "databricks.labs.sdp_meta.cli.SchemasAPI",
+            return_value=api_instance,
+        ):
+            _ensure_uc_schema_and_volume(
+                ws, "main", "sdp_meta", "wheels",
+                create_if_missing=True,
+            )
+        ws.volumes.create.assert_called_once_with(
+            catalog_name="main",
+            schema_name="sdp_meta",
+            name="wheels",
+            volume_type=VolumeType.MANAGED,
+        )
+
+    def test_raises_not_found_for_missing_schema_when_create_if_missing_false(self):
+        ws = self._ws_with_schemas_api()
+        api_instance = self._patch_schemas_api(get_raises=NotFound("nope"))
+        with patch(
+            "databricks.labs.sdp_meta.cli.SchemasAPI",
+            return_value=api_instance,
+        ):
+            with self.assertRaises(NotFound):
+                _ensure_uc_schema_and_volume(
+                    ws, "main", "sdp_meta", "wheels",
+                    create_if_missing=False,
+                )
+        api_instance.create.assert_not_called()
+
+    def test_raises_not_found_for_missing_volume_when_create_if_missing_false(self):
+        ws = self._ws_with_schemas_api(volume_raises=NotFound("nope"))
+        api_instance = self._patch_schemas_api()
+        with patch(
+            "databricks.labs.sdp_meta.cli.SchemasAPI",
+            return_value=api_instance,
+        ):
+            with self.assertRaises(NotFound):
+                _ensure_uc_schema_and_volume(
+                    ws, "main", "sdp_meta", "wheels",
+                    create_if_missing=False,
+                )
+        ws.volumes.create.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_compat_optional_runtime_predicate.py
+++ b/tests/test_compat_optional_runtime_predicate.py
@@ -1,0 +1,186 @@
+"""Regression tests for ``compat.dlt_meta._optional_runtime_import_error``.
+
+The shim runs as an import side-effect of ``import dlt_meta`` (and
+transitively, ``import src.<sub>`` via the bundled ``compat/src``
+package). On serverless DLT runtimes that lack Lakeflow SDP, the
+top-level ``from pyspark import pipelines as dp`` line in
+``databricks.labs.sdp_meta.dataflow_pipeline`` blows up. We must
+recognize every shape that failure takes and route to a stub instead
+of bubbling the exception out -- otherwise the customer's
+``from src.dataflow_spec import …`` (which doesn't even need
+``pyspark.pipelines``) crashes during alias registration.
+
+The runtime-shape catalogue is:
+
+1. ``ModuleNotFoundError(name='pyspark.pipelines')`` -- no pyspark.
+2. ``ImportError("cannot import name 'pipelines' from 'pyspark'")``
+   -- pyspark exists, ``pipelines`` submodule is absent.
+3. **The case this file specifically guards against:** a runtime
+   where ``pyspark.pipelines`` exists *as a module*, attempts
+   ``from dlt import *`` at module load, falls through to
+   ``raise PySparkException(errorClass="PIPELINES_NOT_SUPPORTED")``,
+   and PySpark's *own* exception constructor crashes with a
+   ``TypeError`` because the runtime's ``error-conditions.json`` for
+   ``PIPELINES_NOT_SUPPORTED`` requires substitutions that PySpark
+   didn't supply (``messageParameters=None`` -> ``set(None)``).
+
+The CSV from a real customer-simulated phase 2 run exhibits case
+(3): the inner exception is ``TypeError: 'NoneType' object is not
+iterable`` thrown from ``pyspark/errors/utils.py`` while raising
+``PIPELINES_NOT_SUPPORTED``. Only catching ``ImportError`` lets that
+``TypeError`` escape and the ``import src.dataflow_spec`` line in
+``validate_phase2.py`` fails even though dataflow_spec doesn't need
+``pyspark.pipelines`` at all.
+
+These tests pin the predicate behaviour for all three shapes so a
+future refactor can't silently regress (3).
+"""
+from __future__ import annotations
+
+import os
+import sys
+import types
+import unittest
+
+# The compat package lives in ``compat/`` at the repo root. Add it to
+# ``sys.path`` exactly like ``test_compat.py`` does. We import the
+# predicate directly rather than going through ``import dlt_meta``,
+# which would trigger the registration walk and (on a normal CI
+# runner) succeed -- this file is testing the predicate itself, not
+# the registration.
+_compat_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), "compat")
+if _compat_dir not in sys.path:
+    sys.path.insert(0, _compat_dir)
+
+
+def _load_predicate():
+    """Import ``_optional_runtime_import_error`` without firing the
+    package's import-time registration walk.
+
+    We can't ``from dlt_meta import _optional_runtime_import_error``
+    directly because the module's body calls ``_flat_reexport_or_stub``
+    and ``_register_src_aliases`` at import time. To get just the
+    function, we read the source and exec it in a fresh module
+    namespace seeded with the stdlib imports the function needs. The
+    function is pure (it only inspects the exception's traceback
+    chain), so this is safe and avoids carrying any compat-package
+    side effects across tests.
+    """
+    pkg_init = os.path.join(_compat_dir, "dlt_meta", "__init__.py")
+    with open(pkg_init, encoding="utf-8") as fh:
+        source = fh.read()
+
+    namespace: dict = {
+        "__name__": "_dlt_meta_predicate_under_test",
+        "__file__": pkg_init,
+    }
+    # The function only needs ``os`` from the module-level imports;
+    # injecting it explicitly keeps us from running the rest of the
+    # module body.
+    namespace["os"] = os
+
+    # Slice out just the predicate definition. The function ends at
+    # the next top-level ``def`` (we look for the line that follows
+    # ``return False`` and starts with ``def `` at column 0).
+    start = source.index("def _optional_runtime_import_error")
+    # End at the start of the NEXT top-level def, which is
+    # ``def _make_stub_module``.
+    end = source.index("def _make_stub_module", start)
+    exec(source[start:end], namespace)  # noqa: S102 (intentional)
+    return namespace["_optional_runtime_import_error"]
+
+
+_optional_runtime_import_error = _load_predicate()
+
+
+def _make_traceback_through(filename: str) -> types.TracebackType:
+    """Build an exception with a traceback that passes through *filename*.
+
+    We can't fabricate a TracebackType from scratch (the type isn't
+    constructible from Python). Instead, we exec a tiny snippet whose
+    ``co_filename`` we set to *filename*, raise inside it, and
+    capture the resulting traceback. The snippet itself is trivial.
+    """
+    src = "raise RuntimeError('synthetic')\n"
+    code = compile(src, filename, "exec")
+    try:
+        exec(code, {})  # noqa: S102 (synthetic frame, intentional)
+    except RuntimeError as exc:
+        return exc.__traceback__  # type: ignore[return-value]
+    raise AssertionError("synthetic exception was not raised")
+
+
+class TestKnownImportErrorShapes(unittest.TestCase):
+    """The two ImportError shapes the predicate has always recognized."""
+
+    def test_module_not_found_pyspark_pipelines(self):
+        exc = ModuleNotFoundError("No module named 'pyspark.pipelines'")
+        exc.name = "pyspark.pipelines"
+        self.assertTrue(_optional_runtime_import_error(exc))
+
+    def test_module_not_found_pipelines_short_name(self):
+        exc = ModuleNotFoundError("No module named 'pipelines'")
+        exc.name = "pipelines"
+        self.assertTrue(_optional_runtime_import_error(exc))
+
+    def test_cannot_import_name_pipelines_from_pyspark(self):
+        exc = ImportError("cannot import name 'pipelines' from 'pyspark'")
+        self.assertTrue(_optional_runtime_import_error(exc))
+
+
+class TestBuggyPySparkErrorFormatter(unittest.TestCase):
+    """The case from ``backward_compat_phase2_905606092b4e.csv``.
+
+    Specifically: a ``TypeError`` raised from inside
+    ``pyspark/pipelines/__init__.py`` (whose own raise-line crashes
+    in the PySpark error formatter). The exception type is *not*
+    ``ImportError``, but the traceback frame is in
+    ``pyspark/pipelines/``, so the predicate must still recognize it
+    as the SDP-runtime-missing case.
+    """
+
+    def test_typeerror_with_traceback_through_pyspark_pipelines(self):
+        tb = _make_traceback_through(
+            "/databricks/python/lib/python3.12/site-packages/"
+            "pyspark/pipelines/__init__.py"
+        )
+        exc = TypeError("'NoneType' object is not iterable")
+        exc.__traceback__ = tb
+        self.assertTrue(_optional_runtime_import_error(exc))
+
+    def test_typeerror_through_chained_context(self):
+        """Predicate also walks ``__context__`` (PEP 3134 chaining)."""
+        inner_tb = _make_traceback_through(
+            "/some/runtime/pyspark/pipelines/__init__.py"
+        )
+        inner = ModuleNotFoundError("No module named 'dlt'")
+        inner.__traceback__ = inner_tb
+
+        outer = TypeError("'NoneType' object is not iterable")
+        outer.__context__ = inner
+        # outer.__traceback__ stays None, so the predicate must reach
+        # ``inner`` via __context__ to spot the pyspark.pipelines frame.
+        self.assertTrue(_optional_runtime_import_error(outer))
+
+
+class TestUnrelatedExceptionsAreReRaised(unittest.TestCase):
+    """The predicate must NOT swallow real bugs."""
+
+    def test_typeerror_outside_pyspark_pipelines_returns_false(self):
+        tb = _make_traceback_through("/home/user/myproject/utils.py")
+        exc = TypeError("real bug, please fix")
+        exc.__traceback__ = tb
+        self.assertFalse(_optional_runtime_import_error(exc))
+
+    def test_unrelated_module_not_found_returns_false(self):
+        exc = ModuleNotFoundError("No module named 'totally_made_up_pkg'")
+        exc.name = "totally_made_up_pkg"
+        self.assertFalse(_optional_runtime_import_error(exc))
+
+    def test_value_error_with_no_traceback_returns_false(self):
+        exc = ValueError("not even close")
+        self.assertFalse(_optional_runtime_import_error(exc))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_compat_src_aliases.py
+++ b/tests/test_compat_src_aliases.py
@@ -1,0 +1,865 @@
+"""Tests for the v0.0.10 ``src.*`` import compatibility shim.
+
+The shim's job: a v0.0.10 customer notebook with ``from src.X import Y``
+lines must keep working on v0.0.11 (with a ``DeprecationWarning``)
+instead of failing with ``ModuleNotFoundError: No module named 'src'``.
+
+This file covers four independent surfaces:
+
+1. **Module-level alias resolution** — every v0.0.10 ``src.<sub>`` module
+   resolves to the canonical ``databricks.labs.sdp_meta.<sub>``.
+2. **Symbol-level access** — ``DLTMeta`` (renamed to ``SDPMeta`` in
+   v0.0.11), ``DLT_META_RUNNER_NOTEBOOK`` (renamed to
+   ``SDP_META_RUNNER_NOTEBOOK``), and the unchanged classes
+   (``DataflowPipeline``, ``BronzeDataflowSpec``, ``DLTSink``…) all
+   resolve through the alias.
+3. **Deprecation warning behaviour** — fires once per alias per process
+   on first attribute access, not on the eager registration walk, and
+   not on subsequent accesses.
+4. **Optional-runtime stub** — when ``pyspark.pipelines`` is missing,
+   accessing a stub'd module raises a clear ``Lakeflow SDP runtime``
+   error rather than ``ModuleNotFoundError: src`` or the historical
+   silent ``cannot import name`` failure mode.
+
+A separate fresh-interpreter ``subprocess`` test
+(``test_pth_loads_dlt_meta_at_startup``) exercises the ``.pth``
+auto-load path — the actual customer experience after
+``pip install dlt-meta``.
+"""
+import os
+import subprocess
+import sys
+import textwrap
+import unittest
+import warnings
+from unittest.mock import MagicMock
+
+# Mock pyspark.pipelines BEFORE importing the shim or anything from
+# databricks.labs.sdp_meta — the test runner doesn't ship a Spark
+# version with pyspark.pipelines yet. (Mirrors tests/test_compat.py.)
+sys.modules.setdefault("pyspark.pipelines", MagicMock())
+
+# Make the compat package importable without installing it as a wheel.
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_COMPAT_DIR = os.path.join(_REPO_ROOT, "compat")
+if _COMPAT_DIR not in sys.path:
+    sys.path.insert(0, _COMPAT_DIR)
+
+
+def _purge_dlt_meta_and_src() -> None:
+    """Remove cached compat modules so the next ``import`` is fresh.
+
+    Each test that exercises the registration path needs a clean
+    ``sys.modules`` so module-level state (``_WARNED_ALIASES``, the
+    ``src`` alias entries) is rebuilt rather than reused from a prior
+    test's import.
+    """
+    for key in list(sys.modules):
+        if key == "dlt_meta" or key.startswith("dlt_meta."):
+            del sys.modules[key]
+        elif key == "src" or key.startswith("src."):
+            del sys.modules[key]
+
+
+class TestSubmoduleAliasMapMatchesV0_0_10(unittest.TestCase):
+    """The hand-pinned ``_SRC_SUBMODULES`` must match the v0.0.10 publication."""
+
+    # Verbatim from ``git ls-tree v0.0.10 -- 'src/*.py' --name-only``
+    # minus ``__init__.py`` (which is the package itself, registered
+    # under the ``src`` top-level alias rather than ``src.__init__``).
+    EXPECTED_V0_0_10_SUBMODULES = frozenset({
+        "__about__",
+        "__main__",
+        "cli",
+        "config",
+        "dataflow_pipeline",
+        "dataflow_spec",
+        "install",
+        "metastore_ops",
+        "onboard_dataflowspec",
+        "pipeline_readers",
+        "pipeline_writers",
+        "uninstall",
+    })
+
+    def test_pinned_alias_set_matches_v0_0_10(self):
+        _purge_dlt_meta_and_src()
+        import dlt_meta  # noqa: F401  (fresh import to register aliases)
+
+        from dlt_meta import _SRC_SUBMODULES
+        self.assertEqual(
+            frozenset(_SRC_SUBMODULES),
+            self.EXPECTED_V0_0_10_SUBMODULES,
+            "_SRC_SUBMODULES drifted from the v0.0.10 src/*.py set. If you "
+            "intend the change, also update the v0.0.10 ground-truth list "
+            "in this test.",
+        )
+
+
+class TestSrcModuleAliasing(unittest.TestCase):
+    """`from src.X import Y` resolves to ``databricks.labs.sdp_meta.X.Y``."""
+
+    def setUp(self):
+        _purge_dlt_meta_and_src()
+        import dlt_meta  # noqa: F401  (triggers alias registration)
+
+    def test_top_level_src_alias_resolves(self):
+        import src
+        self.assertIs(sys.modules["src"], sys.modules["dlt_meta"])
+        # ``__version__`` is a flat re-export on dlt_meta itself, so
+        # accessing it via the ``src`` alias proves the package alias
+        # is wired.
+        self.assertTrue(hasattr(src, "__version__") or hasattr(src, "DataflowPipeline"))
+
+    def test_dataflow_pipeline_alias_resolves(self):
+        from src.dataflow_pipeline import DataflowPipeline
+        from databricks.labs.sdp_meta.dataflow_pipeline import (
+            DataflowPipeline as Canonical,
+        )
+        self.assertIs(DataflowPipeline, Canonical)
+
+    def test_dataflow_spec_aliases_resolve(self):
+        from src.dataflow_spec import (
+            BronzeDataflowSpec,
+            SilverDataflowSpec,
+            DataflowSpecUtils,
+            DLTSink,
+        )
+        from databricks.labs.sdp_meta.dataflow_spec import (
+            BronzeDataflowSpec as B,
+            SilverDataflowSpec as S,
+            DataflowSpecUtils as U,
+            DLTSink as D,
+        )
+        self.assertIs(BronzeDataflowSpec, B)
+        self.assertIs(SilverDataflowSpec, S)
+        self.assertIs(DataflowSpecUtils, U)
+        self.assertIs(DLTSink, D)
+
+    def test_pipeline_writers_aliases_resolve(self):
+        from src.pipeline_writers import AppendFlowWriter, DLTSinkWriter
+        from databricks.labs.sdp_meta.pipeline_writers import (
+            AppendFlowWriter as A,
+            DLTSinkWriter as D,
+        )
+        self.assertIs(AppendFlowWriter, A)
+        self.assertIs(DLTSinkWriter, D)
+
+    def test_metastore_ops_aliases_resolve(self):
+        from src.metastore_ops import (
+            DeltaPipelinesMetaStoreOps,
+            DeltaPipelinesInternalTableOps,
+        )
+        from databricks.labs.sdp_meta.metastore_ops import (
+            DeltaPipelinesMetaStoreOps as M,
+            DeltaPipelinesInternalTableOps as I_,
+        )
+        self.assertIs(DeltaPipelinesMetaStoreOps, M)
+        self.assertIs(DeltaPipelinesInternalTableOps, I_)
+
+    def test_onboard_dataflowspec_alias_resolves(self):
+        from src.onboard_dataflowspec import OnboardDataflowspec
+        from databricks.labs.sdp_meta.onboard_dataflowspec import (
+            OnboardDataflowspec as Canonical,
+        )
+        self.assertIs(OnboardDataflowspec, Canonical)
+
+    def test_pipeline_readers_alias_resolves(self):
+        from src.pipeline_readers import PipelineReaders
+        from databricks.labs.sdp_meta.pipeline_readers import (
+            PipelineReaders as P,
+        )
+        self.assertIs(PipelineReaders, P)
+
+    def test_install_alias_resolves(self):
+        from src.install import WorkspaceInstaller
+        from databricks.labs.sdp_meta.install import WorkspaceInstaller as W
+        self.assertIs(WorkspaceInstaller, W)
+
+    def test_config_alias_resolves(self):
+        from src.config import WorkspaceConfig
+        from databricks.labs.sdp_meta.config import WorkspaceConfig as W
+        self.assertIs(WorkspaceConfig, W)
+
+    def test_about_alias_resolves(self):
+        from src.__about__ import __version__
+        from databricks.labs.sdp_meta.__about__ import __version__ as canonical
+        self.assertEqual(__version__, canonical)
+
+
+class TestRenamedSymbolAliasing(unittest.TestCase):
+    """v0.0.10 → v0.0.11 symbol renames must resolve via ``src.cli``.
+
+    This is the C1 review point: ``DLTMeta`` was renamed to ``SDPMeta``
+    in v0.0.11. Module-level aliasing alone (``src.cli`` →
+    ``databricks.labs.sdp_meta.cli``) doesn't fix this — the rebind
+    ``DLTMeta = SDPMeta`` in ``cli.py`` does.
+    """
+
+    def setUp(self):
+        _purge_dlt_meta_and_src()
+        import dlt_meta  # noqa: F401
+
+    def test_dltmeta_resolves_via_src_cli_alias(self):
+        from src.cli import DLTMeta
+        from databricks.labs.sdp_meta.cli import SDPMeta
+        self.assertIs(
+            DLTMeta, SDPMeta,
+            "DLTMeta must be a rebind of SDPMeta in cli.py for the "
+            "src.cli alias to work — see C1 in the review.",
+        )
+
+    def test_runner_notebook_constant_resolves_via_src_cli_alias(self):
+        from src.cli import DLT_META_RUNNER_NOTEBOOK
+        from databricks.labs.sdp_meta.cli import SDP_META_RUNNER_NOTEBOOK
+        self.assertEqual(DLT_META_RUNNER_NOTEBOOK, SDP_META_RUNNER_NOTEBOOK)
+
+    def test_other_cli_symbols_resolve(self):
+        from src.cli import (
+            OnboardCommand,
+            DeployCommand,
+            onboard,
+            deploy,
+            main,
+        )
+        from databricks.labs.sdp_meta.cli import (
+            OnboardCommand as OC,
+            DeployCommand as DC,
+            onboard as on,
+            deploy as dep,
+            main as mn,
+        )
+        self.assertIs(OnboardCommand, OC)
+        self.assertIs(DeployCommand, DC)
+        self.assertIs(onboard, on)
+        self.assertIs(deploy, dep)
+        self.assertIs(main, mn)
+
+
+class TestDeprecationWarningBehaviour(unittest.TestCase):
+    """Warning fires once per alias on first ATTRIBUTE access, not on registration."""
+
+    def setUp(self):
+        _purge_dlt_meta_and_src()
+
+    def test_no_warning_on_eager_registration(self):
+        """Importing ``dlt_meta`` itself must not fire src.* alias warnings.
+
+        The ``.pth`` runs ``import dlt_meta`` at every interpreter
+        startup. If the registration walk eagerly emitted warnings, a
+        customer who's already migrated would get N warnings every
+        startup for no reason.
+        """
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            import dlt_meta  # noqa: F401
+
+        src_alias_warnings = [
+            x for x in w
+            if issubclass(x.category, DeprecationWarning)
+            and "is a v0.0.10 compatibility alias" in str(x.message)
+        ]
+        self.assertEqual(
+            src_alias_warnings, [],
+            "Eager registration emitted src.* alias warnings; they "
+            "should fire on first attribute access only.",
+        )
+
+    def test_warning_fires_on_first_attribute_access(self):
+        import dlt_meta  # noqa: F401
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            from src.dataflow_pipeline import DataflowPipeline  # noqa: F401
+
+        relevant = [
+            x for x in w
+            if issubclass(x.category, DeprecationWarning)
+            and "src.dataflow_pipeline" in str(x.message)
+        ]
+        self.assertEqual(
+            len(relevant), 1,
+            f"Expected exactly one DeprecationWarning for src.dataflow_pipeline, "
+            f"got {len(relevant)}: {[str(x.message) for x in relevant]}",
+        )
+
+    def test_warning_fires_only_once_per_alias(self):
+        import dlt_meta  # noqa: F401
+        # First access emits one warning.
+        from src.dataflow_pipeline import DataflowPipeline  # noqa: F401
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            from src.dataflow_pipeline import DataflowPipeline as _Again  # noqa: F401, F811
+
+        relevant = [
+            x for x in w
+            if issubclass(x.category, DeprecationWarning)
+            and "src.dataflow_pipeline" in str(x.message)
+        ]
+        self.assertEqual(
+            relevant, [],
+            "DeprecationWarning re-fired on second access; alias dedup "
+            "is broken (check _WARNED_ALIASES).",
+        )
+
+    def test_warning_message_points_at_canonical_path(self):
+        import dlt_meta  # noqa: F401
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            from src.cli import DLTMeta  # noqa: F401
+
+        relevant = [
+            x for x in w
+            if issubclass(x.category, DeprecationWarning)
+            and "src.cli" in str(x.message)
+        ]
+        self.assertEqual(len(relevant), 1)
+        msg = str(relevant[0].message)
+        self.assertIn("databricks.labs.sdp_meta.cli", msg)
+        self.assertIn("v0.1.0", msg, "Removal version must be in the message")
+
+
+class TestOptOutEnvVar(unittest.TestCase):
+    """``SDP_META_DISABLE_SRC_ALIAS=1`` skips registration and the warning.
+
+    Subprocess-isolated because the env var must be set BEFORE the
+    shim is imported, and our other tests have already loaded it.
+    """
+
+    def _run_in_clean_subprocess(self, env_overrides, code):
+        env = {
+            **os.environ,
+            "PYTHONPATH": os.pathsep.join([_COMPAT_DIR, _REPO_ROOT]),
+            **env_overrides,
+        }
+        return subprocess.run(
+            [sys.executable, "-W", "default::DeprecationWarning", "-c", code],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+    def test_opt_out_env_var_skips_src_aliasing(self):
+        code = textwrap.dedent("""
+            import sys
+            from unittest.mock import MagicMock
+            sys.modules['pyspark.pipelines'] = MagicMock()
+            import dlt_meta  # noqa: F401
+
+            assert 'src' not in sys.modules, (
+                "Opt-out env var must skip the src alias entirely"
+            )
+            assert 'src.dataflow_pipeline' not in sys.modules, (
+                "Opt-out env var must skip every src.<sub> alias"
+            )
+            print('OK')
+        """)
+        result = self._run_in_clean_subprocess(
+            {"SDP_META_DISABLE_SRC_ALIAS": "1"}, code,
+        )
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertEqual(result.stdout.strip(), "OK")
+
+    def test_opt_out_env_var_suppresses_package_warning(self):
+        code = textwrap.dedent("""
+            import sys, warnings
+            from unittest.mock import MagicMock
+            sys.modules['pyspark.pipelines'] = MagicMock()
+
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter('always')
+                import dlt_meta  # noqa: F401
+
+            messages = [str(x.message) for x in w
+                        if issubclass(x.category, DeprecationWarning)]
+            assert all(
+                "'dlt_meta' package is deprecated" not in m
+                for m in messages
+            ), f"Package warning fired under opt-out: {messages}"
+            print('OK')
+        """)
+        result = self._run_in_clean_subprocess(
+            {"SDP_META_DISABLE_SRC_ALIAS": "1"}, code,
+        )
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertEqual(result.stdout.strip(), "OK")
+
+
+class TestPthFileFreshInterpreter(unittest.TestCase):
+    """Fresh-interpreter ``.pth`` exec — the actual customer experience.
+
+    The unit tests above all run after ``import dlt_meta`` has already
+    been triggered (either directly or transitively). The customer's
+    actual failure mode is a notebook whose first line is
+    ``from src.dataflow_pipeline import DataflowPipeline`` with no
+    explicit ``import dlt_meta``. The ``.pth`` is what saves them.
+
+    Rather than build a wheel and install it (slow, env-dependent),
+    we simulate the ``.pth`` exec by running the same line via
+    ``python -c`` AFTER it. This proves the .pth's exec model
+    (CPython site.py only runs lines starting with ``import``)
+    accepts our particular ``import os; …`` line.
+    """
+
+    def test_pth_line_is_well_formed(self):
+        """Confirm the .pth line is one-line, starts with ``import``, no syntax error."""
+        pth_path = os.path.join(_COMPAT_DIR, "dlt_meta.pth")
+        with open(pth_path) as f:
+            lines = [ln for ln in f.read().splitlines() if ln.strip()]
+        self.assertEqual(
+            len(lines), 1,
+            f".pth must be exactly one non-empty line; got {len(lines)}",
+        )
+        self.assertTrue(
+            lines[0].startswith("import "),
+            "CPython site.py only execs .pth lines starting with 'import '. "
+            f"Line was: {lines[0]!r}",
+        )
+        # The line must compile.
+        compile(lines[0], "dlt_meta.pth", "exec")
+
+    def test_pth_line_loads_dlt_meta_when_env_var_unset(self):
+        """Executing the .pth line must populate sys.modules['dlt_meta']."""
+        pth_path = os.path.join(_COMPAT_DIR, "dlt_meta.pth")
+        with open(pth_path) as f:
+            pth_line = next(ln for ln in f.read().splitlines() if ln.strip())
+
+        code = textwrap.dedent(f"""
+            import sys
+            from unittest.mock import MagicMock
+            sys.modules['pyspark.pipelines'] = MagicMock()
+            # Simulate site.py exec'ing the .pth line at startup.
+            {pth_line}
+            assert 'dlt_meta' in sys.modules, "dlt_meta not loaded by .pth"
+            assert 'src' in sys.modules, "src alias not registered after .pth"
+            from src.dataflow_pipeline import DataflowPipeline
+            print(DataflowPipeline.__module__)
+        """)
+        env = {
+            **os.environ,
+            "PYTHONPATH": os.pathsep.join([_COMPAT_DIR, _REPO_ROOT]),
+        }
+        env.pop("SDP_META_DISABLE_SRC_ALIAS", None)
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertEqual(
+            result.stdout.strip(),
+            "databricks.labs.sdp_meta.dataflow_pipeline",
+        )
+
+    def test_pth_line_skips_when_env_var_set(self):
+        pth_path = os.path.join(_COMPAT_DIR, "dlt_meta.pth")
+        with open(pth_path) as f:
+            pth_line = next(ln for ln in f.read().splitlines() if ln.strip())
+
+        code = textwrap.dedent(f"""
+            import sys
+            from unittest.mock import MagicMock
+            sys.modules['pyspark.pipelines'] = MagicMock()
+            {pth_line}
+            assert 'dlt_meta' not in sys.modules, (
+                "Opt-out env var ignored by .pth line"
+            )
+            print('OK')
+        """)
+        env = {
+            **os.environ,
+            "PYTHONPATH": os.pathsep.join([_COMPAT_DIR, _REPO_ROOT]),
+            "SDP_META_DISABLE_SRC_ALIAS": "1",
+        }
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertEqual(result.stdout.strip(), "OK")
+
+
+class TestOptionalRuntimeStub(unittest.TestCase):
+    """When ``pyspark.pipelines`` is unavailable, errors are actionable.
+
+    This was the silent-swallow bug review-point C3: the previous
+    shim did ``except ImportError: pass`` and customers saw confusing
+    ``cannot import name 'DataflowPipeline'`` messages instead of
+    ``Lakeflow SDP runtime not installed``.
+
+    Subprocess-isolated to actually exercise the missing-runtime
+    path (the in-process tests have ``pyspark.pipelines`` mocked).
+    """
+
+    def test_missing_pyspark_pipelines_raises_actionable_error(self):
+        code = textwrap.dedent("""
+            import sys
+
+            # Real pyspark (3.5.x in this dev env) is a working Spark
+            # install but doesn't ship the Lakeflow SDP submodule, so
+            # ``from pyspark import pipelines`` naturally raises
+            # ``ImportError: cannot import name 'pipelines' from
+            # 'pyspark'`` — exactly the failure mode customers see on
+            # legacy DBR runtimes. We do NOT pre-mock pyspark.pipelines
+            # here; the absence is the test condition.
+            assert 'pyspark.pipelines' not in sys.modules, (
+                'Test contract violated: pyspark.pipelines pre-installed'
+            )
+
+            # Importing dlt_meta must not raise — it falls back to stubs.
+            import dlt_meta  # noqa: F401
+
+            # And the flat-reexport surface raises actionably:
+            try:
+                from dlt_meta import DataflowPipeline
+            except ImportError as exc:
+                msg = str(exc)
+                assert 'Lakeflow SDP runtime' in msg, (
+                    f"Flat re-export error must mention Lakeflow SDP: {msg!r}"
+                )
+            else:
+                raise AssertionError(
+                    'Expected ImportError on dlt_meta.DataflowPipeline '
+                    'when pyspark.pipelines is unavailable'
+                )
+
+            # And the src.* stub surface raises actionably too:
+            try:
+                from src.dataflow_pipeline import DataflowPipeline
+            except ImportError as exc:
+                msg = str(exc)
+                assert 'Lakeflow SDP runtime' in msg, (
+                    f"Stub error must mention Lakeflow SDP: {msg!r}"
+                )
+                assert 'pyspark.pipelines' in msg, (
+                    f"Stub error must mention pyspark.pipelines: {msg!r}"
+                )
+                print('OK')
+            else:
+                raise AssertionError(
+                    'Expected ImportError on src.dataflow_pipeline access '
+                    'when pyspark.pipelines is unavailable'
+                )
+        """)
+        env = {
+            **os.environ,
+            "PYTHONPATH": os.pathsep.join([_COMPAT_DIR, _REPO_ROOT]),
+        }
+        env.pop("SDP_META_DISABLE_SRC_ALIAS", None)
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        self.assertEqual(
+            result.returncode, 0,
+            msg=f"stderr: {result.stderr}\nstdout: {result.stdout}",
+        )
+        self.assertEqual(result.stdout.strip(), "OK")
+
+
+class TestSrcFirstImportPath(unittest.TestCase):
+    """The real customer path: ``from src.X import`` with NO prior ``import dlt_meta``.
+
+    Every other test in this file imports ``dlt_meta`` first, which
+    claims ``sys.modules['src']`` via ``setdefault`` so ``compat/src``
+    never runs. But a v0.0.10 notebook's first line is literally
+    ``from src.dataflow_pipeline import …`` -- ``compat/src/__init__``
+    is what runs, and it must bootstrap ``dlt_meta`` so the aliases
+    (and the actionable missing-runtime stubs) get wired identically
+    to the dlt_meta-first path.
+
+    Regression guard for the two consolidated shim bugs:
+      * ``compat/src`` used to silently *skip* a submodule whose
+        canonical target failed to import, so on a non-SDP runtime the
+        access raised ``ModuleNotFoundError: No module named
+        'src.dataflow_pipeline'`` instead of the actionable
+        "Lakeflow SDP runtime" error.
+      * ``compat/src`` carried a shorter submodule list than
+        ``dlt_meta`` (it dropped ``uninstall`` / ``__main__`` /
+        ``__about__``).
+
+    Subprocess-isolated -- a clean interpreter is the only way to make
+    ``compat/src`` (rather than the dlt_meta ``src`` alias) run.
+    """
+
+    def _run(self, code, env_overrides=None):
+        env = {
+            **os.environ,
+            "PYTHONPATH": os.pathsep.join([_COMPAT_DIR, _REPO_ROOT]),
+        }
+        env.pop("SDP_META_DISABLE_SRC_ALIAS", None)
+        if env_overrides:
+            env.update(env_overrides)
+        return subprocess.run(
+            [sys.executable, "-c", code],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+    def test_src_first_missing_runtime_raises_actionable_error(self):
+        # No ``import dlt_meta``, no mocked pyspark.pipelines: a legacy
+        # notebook's first line on a non-SDP runtime. The fix
+        # (compat/src delegates to dlt_meta) makes this raise the
+        # actionable error instead of ModuleNotFoundError.
+        code = textwrap.dedent("""
+            import sys
+            assert 'dlt_meta' not in sys.modules, 'dlt_meta pre-imported'
+            assert 'pyspark.pipelines' not in sys.modules, (
+                'Test contract violated: pyspark.pipelines pre-installed'
+            )
+            try:
+                from src.dataflow_pipeline import DataflowPipeline
+            except ImportError as exc:
+                msg = str(exc)
+                assert 'Lakeflow SDP runtime' in msg, (
+                    f'src-first error must mention Lakeflow SDP: {msg!r}'
+                )
+                assert 'No module named' not in msg, (
+                    f'Regressed to ModuleNotFoundError silent-skip: {msg!r}'
+                )
+                print('OK')
+            else:
+                raise AssertionError(
+                    'Expected ImportError on src.dataflow_pipeline '
+                    'when pyspark.pipelines is unavailable'
+                )
+        """)
+        result = self._run(code)
+        self.assertEqual(
+            result.returncode, 0,
+            msg=f"stderr: {result.stderr}\nstdout: {result.stdout}",
+        )
+        self.assertEqual(result.stdout.strip(), "OK")
+
+    def test_src_first_resolves_full_v0_0_10_surface(self):
+        # With the runtime present (mocked), the src-first path resolves
+        # to the canonical class, and every v0.0.10 submodule is
+        # registered -- including ``uninstall``, which the old
+        # compat/src list dropped (the submodule-list drift bug).
+        code = textwrap.dedent("""
+            import sys
+            from unittest.mock import MagicMock
+            sys.modules['pyspark.pipelines'] = MagicMock()
+            assert 'dlt_meta' not in sys.modules, 'dlt_meta pre-imported'
+
+            from src.dataflow_pipeline import DataflowPipeline
+            from databricks.labs.sdp_meta.dataflow_pipeline import (
+                DataflowPipeline as Canonical,
+            )
+            assert DataflowPipeline is Canonical, 'src-first did not resolve to canonical'
+
+            # ``uninstall`` was absent from the old compat/src submodule
+            # list; the consolidated single list (dlt_meta) includes it.
+            assert 'src.uninstall' in sys.modules, (
+                'src.uninstall not registered -- submodule-list drift regressed'
+            )
+            import databricks.labs.sdp_meta.uninstall as canon_uninstall
+            assert sys.modules['src.uninstall'].__file__ == canon_uninstall.__file__, (
+                'src.uninstall alias does not point at the canonical module'
+            )
+            print('OK')
+        """)
+        result = self._run(code)
+        self.assertEqual(
+            result.returncode, 0,
+            msg=f"stderr: {result.stderr}\nstdout: {result.stdout}",
+        )
+        self.assertEqual(result.stdout.strip(), "OK")
+
+
+class TestStubModuleDunderTolerance(unittest.TestCase):
+    """Stub modules must survive dunder introspection without raising.
+
+    Tools that walk ``sys.modules`` (IPython's
+    ``AutoreloadReliabilityHook``, ``inspect.getmodule``, importlib
+    metadata scanners, traceback formatters) routinely do
+    ``getattr(mod, "__file__", "")`` and similar dunder probes on every
+    loaded module. The original stub raised ``ImportError`` on ANY
+    attribute access -- including ``__file__`` -- which on serverless
+    DLT poisoned IPython's traceback formatter (which itself probes
+    dunders during exception display) and produced the multi-page
+    "Unexpected exception formatting exception. Falling back to
+    standard exception" cascade after every cell of
+    ``validate_phase2.py``.
+
+    The contract these tests pin down:
+
+    1. ``mod.__file__`` is set to a self-describing sentinel string
+       (so the most common probe never even calls ``__getattr__``).
+    2. ``__getattr__`` raises ``AttributeError`` for dunders (PEP 562
+       compliant) -- ``getattr(mod, dunder, default)`` returns the
+       default and ``hasattr(mod, dunder)`` returns False, so
+       introspection tools fall back cleanly.
+    3. Real public attribute access STILL raises the actionable
+       ``ImportError`` so customers writing
+       ``from src.dataflow_pipeline import DataflowPipeline`` see the
+       Lakeflow-SDP-missing message, not a silent ``AttributeError``.
+    """
+
+    def setUp(self) -> None:
+        # Importing the helper directly is fine -- it's a pure
+        # function that builds and returns a fresh ModuleType. None
+        # of the side-effecting registration walks fire.
+        from dlt_meta import _make_stub_module
+        self._make_stub_module = _make_stub_module
+        self.stub = _make_stub_module(
+            "src.dataflow_pipeline",
+            "cannot import name 'pipelines' from 'pyspark'",
+        )
+
+    def test_dunder_file_is_set_to_sentinel(self):
+        """The most common probe path: ``getattr(mod, '__file__', '')``."""
+        self.assertTrue(hasattr(self.stub, "__file__"))
+        self.assertIn("sdp-meta", self.stub.__file__)
+        self.assertIn("src.dataflow_pipeline", self.stub.__file__)
+
+    def test_getattr_with_default_returns_default_for_unset_dunders(self):
+        """``__path__`` is not set; getattr-with-default must NOT raise."""
+        sentinel = object()
+        result = getattr(self.stub, "__path__", sentinel)
+        self.assertIs(result, sentinel)
+
+    def test_hasattr_returns_false_for_unset_dunders(self):
+        """``hasattr`` on an unset dunder must return False, not crash."""
+        self.assertFalse(hasattr(self.stub, "__path__"))
+        self.assertFalse(hasattr(self.stub, "__all__"))
+        self.assertFalse(hasattr(self.stub, "__version__"))
+
+    def test_inspect_getmodule_does_not_raise(self):
+        """``inspect.getmodule`` is what IPython's tb formatter calls."""
+        import inspect
+        # ``inspect.getmodule`` walks ``__file__`` to locate modules.
+        # We don't care what it returns for a synthetic stub -- only
+        # that it doesn't propagate an ImportError.
+        try:
+            inspect.getmodule(self.stub)
+        except ImportError as exc:
+            self.fail(f"inspect.getmodule raised ImportError: {exc}")
+
+    def test_dunder_getattr_raises_attribute_error_not_import_error(self):
+        """PEP 562 contract: ``__getattr__`` for unknown dunders -> AttributeError."""
+        with self.assertRaises(AttributeError):
+            self.stub.__nonexistent_dunder__  # noqa: B018
+
+    def test_public_attribute_still_raises_actionable_import_error(self):
+        """Real customer-facing access must still get the Lakeflow SDP msg."""
+        with self.assertRaises(ImportError) as cm:
+            self.stub.DataflowPipeline  # noqa: B018
+        msg = str(cm.exception)
+        self.assertIn("Lakeflow SDP runtime", msg)
+        self.assertIn("pyspark.pipelines", msg)
+        self.assertIn("src.dataflow_pipeline", msg)
+
+    def test_iterating_sys_modules_safe(self):
+        """The IPython autoreload hook walks ``sys.modules`` and
+        probes dunders on every entry. Simulate that iteration to
+        prove the stub is hook-safe.
+        """
+        import sys
+        try:
+            sys.modules["__sdp_meta_stub_test__"] = self.stub
+            for name, mod in list(sys.modules.items()):
+                if mod is None:
+                    continue
+                # This is exactly what file_module_utils.get_module_file_name
+                # does on serverless DLT.
+                _ = getattr(mod, "__file__", "") or ""
+                # And what inspect.getmodule does:
+                _ = hasattr(mod, "__file__")
+        finally:
+            sys.modules.pop("__sdp_meta_stub_test__", None)
+
+
+class TestPackageGetattrDunderTolerance(unittest.TestCase):
+    """The dlt_meta package-level ``__getattr__`` (set when the SDP
+    runtime is missing) must follow the same dunder-tolerance contract
+    as the stub modules.
+
+    Same failure mode applies: IPython's autoreload hook probes
+    ``dlt_meta.__file__`` etc., and a raised ``ImportError`` would
+    cascade through the traceback formatter the same way.
+
+    This is exercised in a fresh subprocess (no ``pyspark.pipelines``
+    pre-mocked) because the in-process tests have ``pyspark.pipelines``
+    mocked to a ``MagicMock``, which means ``_flat_reexport_or_stub``
+    succeeds normally and never installs the package-level fallback
+    ``__getattr__`` we want to test.
+    """
+
+    def test_package_getattr_dunder_tolerance(self):
+        code = textwrap.dedent("""
+            import sys
+
+            # Same precondition as TestOptionalRuntimeStub: real
+            # pyspark, no pyspark.pipelines, so the shim takes the
+            # missing-runtime path and installs the package-level
+            # ``__getattr__`` fallback on dlt_meta.
+            assert 'pyspark.pipelines' not in sys.modules
+
+            import dlt_meta
+
+            # IPython's autoreload reliability hook probe.
+            # MUST NOT raise ImportError.
+            assert getattr(dlt_meta, '__file__', None) is not None, (
+                'dlt_meta.__file__ should resolve to the package init'
+            )
+
+            # ``hasattr`` on an unknown dunder must return False
+            # (i.e. ``__getattr__`` raised AttributeError, not
+            # ImportError).
+            assert hasattr(dlt_meta, '__nonexistent__') is False, (
+                'hasattr on unknown dunder must return False'
+            )
+
+            # ``getattr(..., default)`` on an unknown dunder must
+            # return the default.
+            sentinel = object()
+            assert getattr(dlt_meta, '__nonexistent__', sentinel) is sentinel
+
+            # And public-name access still gets the actionable
+            # ImportError, not silently masked.
+            try:
+                dlt_meta.DataflowPipeline
+            except ImportError as exc:
+                assert 'Lakeflow SDP runtime' in str(exc)
+            else:
+                raise AssertionError(
+                    'Public attr access should still raise ImportError'
+                )
+
+            print('OK')
+        """)
+        env = {
+            **os.environ,
+            "PYTHONPATH": os.pathsep.join([_COMPAT_DIR, _REPO_ROOT]),
+        }
+        env.pop("SDP_META_DISABLE_SRC_ALIAS", None)
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        self.assertEqual(
+            result.returncode, 0,
+            msg=f"stderr: {result.stderr}\nstdout: {result.stdout}",
+        )
+        self.assertEqual(result.stdout.strip(), "OK")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,284 @@
+"""Unit tests for ``databricks.labs.sdp_meta.config``.
+
+``config.py`` is pure dataclass plumbing (``ConnectConfig``,
+``_Config``, ``WorkspaceConfig``) -- no Spark, no I/O beyond
+filesystem reads. Historically it was at ~59% coverage because no
+tests exercised it directly; the rest of the suite only imported the
+classes by name. These tests cover every branch.
+
+A note on mocking
+-----------------
+``databricks.sdk.core.Config(host=..., token=...)`` looks like a
+plain dataclass-y constructor but actually probes credential sources
+at construction time (env vars, ``~/.databrickscfg``, OAuth metadata
+endpoints, etc.). Letting it run during unit tests blocks the suite
+on network / filesystem / interactive auth -- exactly what we are
+trying to keep out of unit tests.
+
+Tests in this file therefore patch ``Config`` at the
+``databricks.labs.sdp_meta.config.Config`` import site so the
+construction is observable but inert. We assert the kwargs the code
+*would* have passed to ``Config(...)`` rather than the resulting
+real ``Config`` object.
+"""
+from __future__ import annotations
+
+import json
+import unittest
+from dataclasses import dataclass
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from databricks.labs.sdp_meta.__about__ import __version__
+from databricks.labs.sdp_meta.config import (
+    ConnectConfig,
+    WorkspaceConfig,
+    _Config,
+    _CONFIG_VERSION,
+)
+
+
+# A fully-populated ``WorkspaceConfig`` payload used as the canonical
+# fixture for ``from_dict`` / ``from_bytes`` / ``from_file`` tests.
+# Field set mirrors the dataclass exactly so adding a field there
+# without updating the fixture fails loudly here.
+_WORKSPACE_PAYLOAD = {
+    "version": _CONFIG_VERSION,
+    "dbr_version": "14.3.x-scala2.12",
+    "cloud_provider_name": "aws",
+    "dbfs_path": "/dbfs/sdp-meta",
+    "sdp_meta_operation": "deploy_silver",
+    "onboarding_file_path": "/Workspace/onboarding.json",
+    "uc_enabled": True,
+    "uc_catalog_name": "main",
+    "sdp_meta_schema": "sdp_meta",
+    "bronze_dataflow_spec_table": "bronze_dataflowspec",
+    "bronze_dataflow_spec_path": "/Volumes/main/sdp_meta/bronze",
+    "silver_dataflow_spec_table": "silver_dataflowspec",
+    "silver_dataflow_spec_path": "/Volumes/main/sdp_meta/silver",
+    "overwrite_dataflow_spec": False,
+    "dataflow_spec_version": "v1",
+    "bronze_schema": "bronze",
+    "silver_schema": "silver",
+    "sdp_meta_layer": "silver",
+    "sdp_meta_onboard_group": "A1",
+    "serverless": True,
+    "num_workers": 2,
+    "connect": {
+        "host": "https://example.cloud.databricks.com",
+        "token": "fake-token",
+        "profile": "DEFAULT",
+        "cluster_id": "cid-123",
+    },
+}
+
+
+def _fake_databricks_config(**kwargs) -> SimpleNamespace:
+    """Return a SimpleNamespace mimicking ``databricks.sdk.core.Config``.
+
+    Used as the input to ``ConnectConfig.from_databricks_config(cfg)``.
+    Only the attributes that ``from_databricks_config`` actually reads
+    need to be present; everything else is irrelevant.
+    """
+    defaults = dict(
+        host=None,
+        token=None,
+        client_id=None,
+        client_secret=None,
+        azure_client_id=None,
+        azure_tenant_id=None,
+        azure_client_secret=None,
+        azure_environment=None,
+        cluster_id=None,
+        profile=None,
+        debug_headers=False,
+        rate_limit=None,
+        max_connection_pools=None,
+        max_connections_per_pool=None,
+    )
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+class TestConnectConfig(unittest.TestCase):
+    """Cover ``ConnectConfig`` construction, conversion, and round-trip."""
+
+    def test_from_databricks_config_copies_every_field(self):
+        # Use a SimpleNamespace as a stand-in for the real Config so
+        # we don't trigger SDK credential probing.
+        cfg = _fake_databricks_config(
+            host="https://example.cloud.databricks.com",
+            token="fake-token",
+            profile="DEFAULT",
+            cluster_id="cid-123",
+            debug_headers=True,
+        )
+        cc = ConnectConfig.from_databricks_config(cfg)
+        self.assertEqual(cc.host, "https://example.cloud.databricks.com")
+        self.assertEqual(cc.token, "fake-token")
+        self.assertEqual(cc.profile, "DEFAULT")
+        self.assertEqual(cc.cluster_id, "cid-123")
+        self.assertTrue(cc.debug_headers)
+
+    def test_to_databricks_config_brands_with_product_metadata(self):
+        cc = ConnectConfig(host="https://x", token="t")
+        # Patch the imported ``Config`` so construction is inert and
+        # we can inspect the kwargs the code passed in.
+        with patch("databricks.labs.sdp_meta.config.Config") as mock_cfg:
+            cc.to_databricks_config()
+        mock_cfg.assert_called_once()
+        kwargs = mock_cfg.call_args.kwargs
+        self.assertEqual(kwargs["host"], "https://x")
+        self.assertEqual(kwargs["token"], "t")
+        # The whole reason ``to_databricks_config`` exists rather
+        # than callers building Config directly is the product
+        # branding -- regress it loudly if it ever drifts.
+        self.assertEqual(kwargs["product"], "sdp-meta")
+        self.assertEqual(kwargs["product_version"], __version__)
+
+    def test_from_dict_builds_dataclass_from_kwargs(self):
+        cc = ConnectConfig.from_dict({"host": "https://x", "profile": "p"})
+        self.assertEqual(cc.host, "https://x")
+        self.assertEqual(cc.profile, "p")
+        # Fields not in the dict default to None.
+        self.assertIsNone(cc.token)
+
+
+class TestUnderscoreConfigBaseClass(unittest.TestCase):
+    """Cover the abstract base ``_Config`` via WorkspaceConfig."""
+
+    def test_from_bytes_empty_payload_short_circuits_to_empty_dict(self):
+        # ``json.loads("null")`` -> None -> ``not raw`` -> ``{}``. Use
+        # a dataclass with no required fields so the empty-dict
+        # construction succeeds. ``connect`` has to be re-declared
+        # here for the same reason it's re-declared on
+        # ``WorkspaceConfig`` -- ``_Config`` isn't @dataclass so its
+        # annotation isn't picked up by the subclass's dataclass
+        # field set.
+        from typing import Optional as _Opt  # noqa: F401 (used in annotation below)
+
+        @dataclass
+        class _EmptyConfig(_Config["_EmptyConfig"]):
+            connect: _Opt[ConnectConfig] = None
+
+            @classmethod
+            def from_dict(cls, raw):
+                # Mirrors WorkspaceConfig.from_dict pattern but
+                # without _verify_version (this fixture is for
+                # exercising the empty branch).
+                raw.pop("version", None)
+                connect = ConnectConfig.from_dict(raw.pop("connect", {}))
+                return cls(connect=connect)
+
+        result = _EmptyConfig.from_bytes("null")
+        self.assertIsInstance(result, _EmptyConfig)
+        self.assertIsInstance(result.connect, ConnectConfig)
+
+    def test_from_file_reads_json_and_round_trips_through_from_dict(self):
+        with TemporaryDirectory() as td:
+            path = Path(td) / "config.json"
+            path.write_text(json.dumps(_WORKSPACE_PAYLOAD))
+            wc = WorkspaceConfig.from_file(path)
+        self.assertEqual(wc.dbr_version, "14.3.x-scala2.12")
+        self.assertEqual(wc.connect.host, "https://example.cloud.databricks.com")
+
+    def test_verify_version_accepts_current_version(self):
+        wc = WorkspaceConfig.from_dict(dict(_WORKSPACE_PAYLOAD))
+        self.assertIsInstance(wc, WorkspaceConfig)
+
+    def test_verify_version_rejects_unknown_version_with_value_error(self):
+        bad = dict(_WORKSPACE_PAYLOAD, version=999)
+        with self.assertRaises(ValueError) as ctx:
+            WorkspaceConfig.from_dict(bad)
+        msg = str(ctx.exception)
+        self.assertIn("Unsupported config version", msg)
+        self.assertIn("999", msg)
+
+    def test_verify_version_rejects_missing_version_with_value_error(self):
+        bad = {k: v for k, v in _WORKSPACE_PAYLOAD.items() if k != "version"}
+        with self.assertRaises(ValueError) as ctx:
+            WorkspaceConfig.from_dict(bad)
+        self.assertIn("Unsupported config version", str(ctx.exception))
+
+    def test_post_init_defaults_missing_connect_to_empty_connect(self):
+        # Build with empty connect dict -> ConnectConfig() -> not None,
+        # so the __post_init__ ``if connect is None`` branch needs the
+        # connect attribute set to None explicitly. Do that by
+        # overriding after construction.
+        wc = WorkspaceConfig.from_dict(dict(_WORKSPACE_PAYLOAD))
+        wc.connect = None
+        wc.__post_init__()
+        self.assertIsInstance(wc.connect, ConnectConfig)
+        self.assertIsNone(wc.connect.host)
+
+    def test_to_databricks_config_with_populated_connect(self):
+        wc = WorkspaceConfig.from_dict(dict(_WORKSPACE_PAYLOAD))
+        with patch("databricks.labs.sdp_meta.config.Config") as mock_cfg:
+            wc.to_databricks_config()
+        kwargs = mock_cfg.call_args.kwargs
+        self.assertEqual(kwargs["host"], "https://example.cloud.databricks.com")
+        self.assertEqual(kwargs["token"], "fake-token")
+        self.assertEqual(kwargs["product"], "sdp-meta")
+
+    def test_to_databricks_config_with_none_connect_uses_empty_defaults(self):
+        # Exercise the ``if connect is None`` defensive branch.
+        wc = WorkspaceConfig.from_dict(dict(_WORKSPACE_PAYLOAD))
+        wc.connect = None
+        with patch("databricks.labs.sdp_meta.config.Config") as mock_cfg:
+            wc.to_databricks_config()
+        kwargs = mock_cfg.call_args.kwargs
+        # Empty ConnectConfig -> all None -> Config still gets the
+        # product branding (which is the entire point of going
+        # through to_databricks_config rather than Config()
+        # directly).
+        self.assertIsNone(kwargs["host"])
+        self.assertEqual(kwargs["product"], "sdp-meta")
+
+    def test_as_dict_round_trips_dataclass_fields_with_version_stamp(self):
+        wc = WorkspaceConfig.from_dict(dict(_WORKSPACE_PAYLOAD))
+        result = wc.as_dict()
+        # Every populated field shows up.
+        self.assertEqual(result["dbr_version"], "14.3.x-scala2.12")
+        self.assertEqual(result["uc_catalog_name"], "main")
+        # Version stamp wins regardless of input version.
+        self.assertEqual(result["version"], _CONFIG_VERSION)
+        # Nested dataclass got serialized recursively.
+        self.assertEqual(
+            result["connect"]["host"],
+            "https://example.cloud.databricks.com",
+        )
+        # Falsy fields (False, None, 0, "") are SKIPPED -- that's
+        # the documented contract of ``as_dict.inner``. ``num_workers=2``
+        # is truthy so it survives; ``overwrite_dataflow_spec=False``
+        # is falsy so it gets dropped.
+        self.assertIn("num_workers", result)
+        self.assertNotIn("overwrite_dataflow_spec", result)
+
+
+class TestWorkspaceConfig(unittest.TestCase):
+    """End-to-end ``WorkspaceConfig`` -> ``WorkspaceClient`` plumbing."""
+
+    def test_to_workspace_client_returns_configured_workspace_client(self):
+        wc = WorkspaceConfig.from_dict(dict(_WORKSPACE_PAYLOAD))
+        # Patch BOTH the SDK's Config and the WorkspaceClient so
+        # construction is inert and we can inspect the call shape.
+        with patch("databricks.labs.sdp_meta.config.Config") as mock_cfg, patch(
+            "databricks.labs.sdp_meta.config.WorkspaceClient"
+        ) as mock_ws:
+            mock_cfg.return_value = MagicMock(name="FakeConfigInstance")
+            wc.to_workspace_client()
+        mock_ws.assert_called_once()
+        # The WorkspaceClient should be wired through the same Config
+        # instance that to_databricks_config() returned.
+        self.assertIs(
+            mock_ws.call_args.kwargs["config"],
+            mock_cfg.return_value,
+        )
+        # And that Config should have product branding.
+        self.assertEqual(mock_cfg.call_args.kwargs["product"], "sdp-meta")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pipeline_readers.py
+++ b/tests/test_pipeline_readers.py
@@ -195,9 +195,16 @@ class PipelineReadersTests(SDPFrameworkTestCase):
         "quarantineRowFilter": None,
     }
 
-    @classmethod
     def setUp(self):
-        """Set initial resources."""
+        """Set initial resources.
+
+        Note: ``setUp`` is a regular instance method (not @classmethod)
+        because the base class ``SDPFrameworkTestCase.setUp`` is also
+        an instance method. The historical ``@classmethod``
+        annotation here was a bug paired with the matching bug in
+        the base class -- both have been fixed in the same refactor
+        that moved Spark startup into ``setUpClass`` for perf.
+        """
         super().setUp()
         onboardDataFlowSpecs = OnboardDataflowspec(self.spark, self.onboarding_bronze_silver_params_map)
         onboardDataFlowSpecs.onboard_dataflow_specs()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,47 @@
-"""Base test class."""
+"""Shared base test class for the SDP-META unit-test suite.
+
+Spark startup is expensive (3-5s of JVM boot per ``getOrCreate()``). The
+historical version of this file built a fresh ``SparkSession`` in
+``setUp`` (once **per test**) and stopped the underlying
+``SparkContext`` in ``tearDown``. With ~400 tests subclassing
+``SDPFrameworkTestCase`` that paid the cold-start cost once per
+test method, dominating the wall-clock cost of the whole suite.
+
+This refactor splits the work into class-scoped vs instance-scoped
+hooks:
+
+  * ``setUpClass`` (once per test class):
+      - Build the SparkSession + DeltaPipelinesMetaStoreOps /
+        DeltaPipelinesInternalTableOps. These are stateless wrt the
+        per-test DB / tempdir / fixture-path state below, so sharing
+        them across tests in the same class is safe.
+      - Bind every onboarding-fixture path string (``onboarding_*``)
+        to the class. They never change between tests; binding them
+        once is purely a perf win, no semantics change.
+
+  * ``setUp`` (once per test):
+      - Create fresh tempdirs (``onboarding_spec_paths``,
+        ``temp_delta_tables_path``) so per-test write paths are
+        isolated.
+      - Drop+recreate the ``ravi_dlt_demo`` test database so each
+        test starts from a clean catalog state.
+      - Rebuild the ``onboarding_*_params_map`` dicts (they reference
+        the per-test ``onboarding_spec_paths``).
+
+  * ``tearDown`` (once per test):
+      - Drop the per-test database and remove the per-test tempdirs.
+      - **Do NOT call ``sc.stop()``.** Stopping the context in
+        ``tearDown`` was the historical reason ``setUp`` had to
+        rebuild Spark on every test. Leaving the JVM running lets
+        ``getOrCreate()`` return the existing session for the rest
+        of the pytest invocation -- effectively one Spark per
+        ``pytest`` invocation across all classes that share this
+        base.
+
+Test isolation is preserved: every test still sees a fresh database
+and a fresh pair of tempdirs. The only thing shared across tests is
+the SparkSession itself, which is read-only state for the test code.
+"""
 
 
 import shutil
@@ -13,9 +56,14 @@ class SDPFrameworkTestCase(unittest.TestCase):
     """Test class base that sets up a correctly configured SparkSession for querying Delta tables."""
 
     @classmethod
-    def setUp(self):
-        """Set inputs."""
-        # Configurations to speed up tests and reduce memory footprint
+    def setUpClass(cls):
+        """Class-scoped setup -- runs ONCE per test class.
+
+        Builds the SparkSession + Delta-aware ops and binds the
+        immutable fixture-path strings to the class. Per-test state
+        (database, tempdirs, param dicts) is built in ``setUp`` so
+        each test method is still isolated from its peers.
+        """
         builder = (
             SparkSession.builder.appName("SDP-META_UNIT_TESTS")
             .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
@@ -24,60 +72,84 @@ class SDPFrameworkTestCase(unittest.TestCase):
                 "org.apache.spark.sql.delta.catalog.DeltaCatalog",
             )
         )
-        self.spark = configure_spark_with_delta_pip(builder).getOrCreate()
-        self.spark.conf.set("spark.sql.shuffle.partitions", "4")
-        self.spark.conf.set("spark.app.name", "sdp-meta-unit-tests")
-        self.spark.conf.set("spark.master", "local[4]")
-        self.spark.conf.set("spark.databricks.delta.snapshotPartitions", "2")
-        self.spark.conf.set("spark.sql.shuffle.partitions", "5")
-        self.spark.conf.set("delta.log.cacheSize", "3")
-        self.spark.conf.set("spark.databricks.delta.delta.log.cacheSize", "3")
-        self.spark.conf.set("spark.sql.sources.parallelPartitionDiscovery.parallelism", "5")
-        self.deltaPipelinesMetaStoreOps = DeltaPipelinesMetaStoreOps(self.spark)
-        self.deltaPipelinesInternalTableOps = DeltaPipelinesInternalTableOps(self.spark)
-        self.sc = self.spark.sparkContext
-        self.onboarding_spec_paths = tempfile.mkdtemp()
-        self.temp_delta_tables_path = tempfile.mkdtemp()
-        self.onboarding_json_file = "tests/resources/onboarding.json"
-        self.onboarding_json_v7_file = "tests/resources/onboarding_v0.0.7.json"
-        self.onboarding_json_v8_file = "tests/resources/onboarding_v0.0.8.json"
-        self.onboarding_json_v9_file = "tests/resources/onboarding_v0.0.9.json"
-        self.onboarding_json_v10_file = "tests/resources/onboarding_v0.0.10.json"
-        self.onboarding_unsupported_file = "tests/resources/schema.ddl"
-        self.onboarding_v2_json_file = "tests/resources/onboarding_v2.json"
-        self.onboarding_without_ids_json_file = "tests/resources/onboarding_without_ids.json"
-        self.onboarding_invalid_read_options_file = "tests/resources/onboarding_invalid_read_options.json"
-        self.onboarding_json_dups = "tests/resources/onboarding_with_dups.json"
-        self.onboarding_missing_keys_file = "tests/resources/onboarding_missing_keys.json"
-        self.onboarding_type2_json_file = "tests/resources/onboarding_ac_type2.json"
-        self.onboarding_bronze_type2_json_file = "tests/resources/onboarding_ac_bronze_type2.json"
-        self.onboarding_append_flow_json_file = "tests/resources/onboarding_append_flow.json"
-        self.onboarding_silver_fanout_json_file = "tests/resources/onboarding_silverfanout.json"
-        self.onboarding_sink_json_file = "tests/resources/onboarding_sink.json"
-        self.onboarding_multiple_partitions_file = "tests/resources/onboarding_multiple_partitions.json"
-        self.onboarding_apply_changes_from_snapshot_json_file = (
+        cls.spark = configure_spark_with_delta_pip(builder).getOrCreate()
+        cls.spark.conf.set("spark.sql.shuffle.partitions", "4")
+        cls.spark.conf.set("spark.app.name", "sdp-meta-unit-tests")
+        cls.spark.conf.set("spark.master", "local[4]")
+        cls.spark.conf.set("spark.databricks.delta.snapshotPartitions", "2")
+        cls.spark.conf.set("spark.sql.shuffle.partitions", "5")
+        cls.spark.conf.set("delta.log.cacheSize", "3")
+        cls.spark.conf.set("spark.databricks.delta.delta.log.cacheSize", "3")
+        cls.spark.conf.set("spark.sql.sources.parallelPartitionDiscovery.parallelism", "5")
+        cls.deltaPipelinesMetaStoreOps = DeltaPipelinesMetaStoreOps(cls.spark)
+        cls.deltaPipelinesInternalTableOps = DeltaPipelinesInternalTableOps(cls.spark)
+        cls.sc = cls.spark.sparkContext
+
+        # Onboarding fixture paths are stable across tests -- bind once.
+        cls.onboarding_json_file = "tests/resources/onboarding.json"
+        cls.onboarding_json_v7_file = "tests/resources/onboarding_v0.0.7.json"
+        cls.onboarding_json_v8_file = "tests/resources/onboarding_v0.0.8.json"
+        cls.onboarding_json_v9_file = "tests/resources/onboarding_v0.0.9.json"
+        cls.onboarding_json_v10_file = "tests/resources/onboarding_v0.0.10.json"
+        cls.onboarding_unsupported_file = "tests/resources/schema.ddl"
+        cls.onboarding_v2_json_file = "tests/resources/onboarding_v2.json"
+        cls.onboarding_without_ids_json_file = "tests/resources/onboarding_without_ids.json"
+        cls.onboarding_invalid_read_options_file = "tests/resources/onboarding_invalid_read_options.json"
+        cls.onboarding_json_dups = "tests/resources/onboarding_with_dups.json"
+        cls.onboarding_missing_keys_file = "tests/resources/onboarding_missing_keys.json"
+        cls.onboarding_type2_json_file = "tests/resources/onboarding_ac_type2.json"
+        cls.onboarding_bronze_type2_json_file = "tests/resources/onboarding_ac_bronze_type2.json"
+        cls.onboarding_append_flow_json_file = "tests/resources/onboarding_append_flow.json"
+        cls.onboarding_silver_fanout_json_file = "tests/resources/onboarding_silverfanout.json"
+        cls.onboarding_sink_json_file = "tests/resources/onboarding_sink.json"
+        cls.onboarding_multiple_partitions_file = "tests/resources/onboarding_multiple_partitions.json"
+        cls.onboarding_apply_changes_from_snapshot_json_file = (
             "tests/resources/onboarding_applychanges_from_snapshot.json"
         )
-        self.onboarding_silver_apply_changes_from_snapshot_json_file = (
+        cls.onboarding_silver_apply_changes_from_snapshot_json_file = (
             "tests/resources/onboarding_silver_acfs.json"
         )
-        self.onboarding_apply_changes_from_snapshot_json__error_file = (
+        cls.onboarding_apply_changes_from_snapshot_json__error_file = (
             "tests/resources/onboarding_applychanges_from_snapshot_error.json"
         )
         # Multi-source AUTO CDC (issue #294).
-        self.onboarding_bronze_cdc_flows_json_file = (
+        cls.onboarding_bronze_cdc_flows_json_file = (
             "tests/resources/onboarding_bronze_cdc_flows.json"
         )
-        self.onboarding_silver_cdc_flows_json_file = (
+        cls.onboarding_silver_cdc_flows_json_file = (
             "tests/resources/onboarding_silver_cdc_flows.json"
         )
         # Mixed file: N bronze-only rows + 1 silver-only row that uses
         # multi-source AUTO CDC (no silver_transformation_json, no
         # bronze fields on the silver row). This is the natural shape
         # users write for the multi-source CDC silver demo (issue #294).
-        self.onboarding_mixed_bronze_silver_cdc_flows_json_file = (
+        cls.onboarding_mixed_bronze_silver_cdc_flows_json_file = (
             "tests/resources/onboarding_mixed_bronze_silver_cdc_flows.json"
         )
+
+    @classmethod
+    def tearDownClass(cls):
+        """Class-scoped teardown.
+
+        Intentionally does **not** call ``cls.sc.stop()``. Stopping
+        the SparkContext here is what historically forced ``setUp``
+        to spin a fresh JVM on the next test, multiplying Spark
+        startup cost by the test count. Letting ``getOrCreate()``
+        keep returning the same session across all classes in the
+        same pytest invocation is the entire perf win of this
+        refactor.
+        """
+
+    def setUp(self):
+        """Per-test setup -- runs before each test method.
+
+        Builds fresh tempdirs and a clean ``ravi_dlt_demo`` database
+        so each test method is isolated from its peers, and
+        rebuilds the ``onboarding_*_params_map`` dicts (which embed
+        the per-test ``onboarding_spec_paths`` tempdir).
+        """
+        self.onboarding_spec_paths = tempfile.mkdtemp()
+        self.temp_delta_tables_path = tempfile.mkdtemp()
         self.deltaPipelinesMetaStoreOps.drop_database("ravi_dlt_demo")
         self.deltaPipelinesMetaStoreOps.create_database("ravi_dlt_demo", "Unittest")
         self.onboarding_bronze_silver_params_map = {
@@ -106,10 +178,52 @@ class SDPFrameworkTestCase(unittest.TestCase):
             "uc_enabled": "True"
         }
 
-    @classmethod
     def tearDown(self):
-        """Tear down."""
+        """Per-test teardown -- runs after each test method.
+
+        Cleans the per-test database + tempdirs. Crucially does NOT
+        stop the SparkContext (see ``tearDownClass`` docstring for
+        why).
+
+        Test-pollution defense: unconditionally clear any spark.conf
+        keys that tests set during execution and that the rest of
+        the suite cares about. Historically this base class stopped
+        the SparkContext in ``tearDown``, so any conf state died
+        with it; now that Spark persists across tests, we have to
+        reset shared state explicitly. Tests that set their own
+        confs and want fine-grained cleanup still use
+        ``self.addCleanup(self.spark.conf.unset, key)`` directly --
+        this block is just a belt-and-braces fallback for the older
+        tests that pre-date that pattern.
+        """
+        # Defensive: unset confs the tests are known to mutate. Use
+        # try/except so a conf that wasn't set doesn't blow up
+        # tearDown for unrelated tests.
+        #
+        # The dataflow_spec / dataflow_pipeline modules read these
+        # keys at runtime (``layer``, ``<layer>.group``,
+        # ``<layer>.dataflowIds``, ``<layer>.dataflowspecTable``) and
+        # filter the spec dataframe accordingly. Tests that set them
+        # without unsetting in their own tearDown leak the filter
+        # into sibling tests and cause sporadic ``IndexError`` /
+        # missing-row failures depending on collection order.
+        leaky_confs = (
+            "spark.databricks.unityCatalog.enabled",
+            "layer",
+            "bronze.group",
+            "bronze.dataflowIds",
+            "bronze.dataflowspecTable",
+            "silver.group",
+            "silver.dataflowIds",
+            "silver.dataflowspecTable",
+        )
+        for key in leaky_confs:
+            try:
+                self.spark.conf.unset(key)
+            except Exception:  # noqa: BLE001
+                # Conf wasn't set or unset isn't supported on this
+                # Spark version's conf object -- fine, nothing to do.
+                pass
         self.deltaPipelinesMetaStoreOps.drop_database("ravi_dlt_demo")
-        self.sc.stop()
         shutil.rmtree(self.onboarding_spec_paths)
         shutil.rmtree(self.temp_delta_tables_path)


### PR DESCRIPTION
# v0.0.10 → v0.0.11 backward compatibility (issue #289)

**Base:** `feature/sdp-meta` · **Closes:** #289

## TL;DR

A v0.0.10 customer who upgrades the wheel to v0.0.11 and re-runs their
existing notebook unchanged — same `from src.* import …` lines, same
persisted dataflowspec rows, same DLT pipeline IDs / checkpoints —
gets a working incremental run. No notebook edits, no onboarding
redo, no checkpoint resets.


## What changed

- **Compat surface for `src.*` imports.** v0.0.11 wheels bundle a real
  top-level `src/` package that aliases `src.<sub>` →
  `databricks.labs.sdp_meta.<sub>`. Plus `dlt_meta` flat re-exports,
  the `DLTMeta = SDPMeta` rebind, and `DLT_META_RUNNER_NOTEBOOK`
  alias. One-time `DeprecationWarning` per alias per process; opt out
  via `SDP_META_DISABLE_SRC_ALIAS=1`. Removed in v0.1.0.
- **Backward-compat integration test.** New harness in
  `integration_tests/run_backward_compat_tests.py` that builds a
  SOURCE wheel from a git ref, runs phase 1, swaps to a TARGET wheel
  via `pipelines.update()` (pipeline IDs preserved), and validates
  phase 2 — incremental rows ingested, silver retained, persisted
  v0.0.10 dataflowspec rows still deserialize.
- **Test infra speedup.** `SDPFrameworkTestCase` now shares one Spark
  session across the suite — full unit run dropped from 7:22 to 2:43
  (2.7× faster). 774 tests passing, 90% branch coverage.
- **Bug fix.** `WorkspaceConfig.from_dict` was passing `connect=` to
  a constructor that didn't declare it as a dataclass field; fixed.

## How to run

```bash
# Full unit suite
pytest tests/ --ignore=tests/test_backward_compat_v0_0_10.py

# Backward-compat integration test against a real workspace
python integration_tests/run_backward_compat_tests.py \
    --uc_catalog_name=<your_catalog> --profile=<your_profile> \
    --build_target_from_worktree
```



## Migration

```python
# Old (still works in v0.0.11 with DeprecationWarning, removed in v0.1.0)
from src.dataflow_pipeline import DataflowPipeline

# New (canonical)
from databricks.labs.sdp_meta.dataflow_pipeline import DataflowPipeline
```


