### PR TITLE
PyPI-ready sdp-meta, release workflow hardening

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,36 +3,64 @@ name: release
 on:
   push:
     tags:
-      - 'v*' # only release a versioned tag, such as v.X.Y.Z
+      - 'v[0-9]+.[0-9]+.[0-9]+' # semantic version tags only, e.g. v0.1.0
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: databrickslabs-protected-runner-group
+      labels: linux-ubuntu-latest
     environment: release
     permissions:
-      # Used to authenticate to PyPI via OIDC and sign the release's artifacts with sigstore-python.
-      id-token: write
-      # Used to attach signing artifacts to the published release.
-      contents: write
+      id-token: write   # OIDC auth to PyPI
+      contents: write   # attach artifacts to GitHub Release
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
-          python-version: 3.9
-          cache: 'pip' # caching pip dependencies
+          python-version: '3.10'
+          cache: pip
           cache-dependency-path: setup.py
 
-      - name: Install pip
-        run: python -m pip install --upgrade pip
+      - name: Install build tools
+        run: python -m pip install --upgrade pip build
 
-      - name: Install dependencies
-        run: pip install -U -e ".[dev]"
+      - name: Build primary package (databricks-labs-sdp-meta)
+        run: python -m build --outdir dist/primary
 
-      - name: Build dist
-        run: pip wheel -w dist . --no-deps
+      - name: Build compat redirect (dlt-meta)
+        working-directory: compat
+        run: python -m build --outdir ../dist/compat
 
-      - name: Publish a Python distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
+        with:
+          generate_release_notes: true
+          files: |
+            dist/primary/databricks_labs_sdp_meta-*.whl
+            dist/primary/databricks_labs_sdp_meta-*.tar.gz
+            dist/compat/dlt_meta-*.whl
+            dist/compat/dlt_meta-*.tar.gz
+
+      - name: Publish databricks-labs-sdp-meta to PyPI
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+        with:
+          packages-dir: dist/primary
+
+      - name: Publish dlt-meta compat redirect to PyPI
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+        with:
+          packages-dir: dist/compat
+
+      - name: Sign artifacts with Sigstore
+        uses: sigstore/gh-action-sigstore-python@f514d46b907ebcd5bedc05145c03b69c1edd8b46 # v3.0.0
+        with:
+          inputs: |
+            dist/primary/databricks_labs_sdp_meta-*.whl
+            dist/primary/databricks_labs_sdp_meta-*.tar.gz
+            dist/compat/dlt_meta-*.whl
+            dist/compat/dlt_meta-*.tar.gz
+          release-signing-artifacts: true

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ---
 
-[![Documentation](https://img.shields.io/badge/docs-passing-green)](https://databrickslabs.github.io/sdp-meta/) [![PyPI](https://img.shields.io/badge/pypi-v0.1.0-green)](https://pypi.org/project/sdp-meta/) [![Build](https://img.shields.io/github/workflow/status/databrickslabs/sdp-meta/build/main)](https://github.com/databrickslabs/sdp-meta/actions/workflows/onpush.yml) [![Coverage](https://img.shields.io/codecov/c/github/databrickslabs/sdp-meta)](https://codecov.io/gh/databrickslabs/sdp-meta) [![Style](https://img.shields.io/badge/code%20style-flake8-blue)](https://github.com/PyCQA/flake8) [![PyPI Downloads](https://static.pepy.tech/badge/sdp-meta/month)](https://pepy.tech/projects/sdp-meta)
+[![build](https://github.com/databrickslabs/dlt-meta/actions/workflows/onpush.yml/badge.svg)](https://github.com/databrickslabs/dlt-meta/actions/workflows/onpush.yml) [![codecov](https://codecov.io/github/databrickslabs/dlt-meta/graph/badge.svg)](https://codecov.io/github/databrickslabs/dlt-meta) ![linesofcode](https://aschey.tech/tokei/github/databrickslabs/dlt-meta?category=code) [![PyPI](https://img.shields.io/pypi/v/databricks-labs-sdp-meta?label=pypi%20package&cacheSeconds=3600)](https://pypi.org/project/databricks-labs-sdp-meta/) ![PyPI Downloads](https://static.pepy.tech/personalized-badge/databricks-labs-sdp-meta?period=month&units=international_system&left_color=grey&right_color=orange&left_text=PyPI%20downloads&cacheSeconds=3600)
 
 ---
 
@@ -41,7 +41,7 @@ In practice, a single generic pipeline reads the Dataflowspec and uses it to orc
 
 ## High-Level Process Flow:
 
-![SDP-META Architecture](./docs/static/img/sdp-meta-architecture.svg)
+![SDP-META Architecture](https://raw.githubusercontent.com/databrickslabs/dlt-meta/feature/sdp-meta/docs/static/img/sdp-meta-architecture.svg)
 
 ## SDP-META `Lakeflow Spark Declarative Pipelines` Features support
 | Features  | SDP-META Support |
@@ -73,8 +73,8 @@ Refer to the [Getting Started](https://databrickslabs.github.io/sdp-meta/getting
 
 - Python 3.8 – 3.12 (3.10, 3.11, or 3.12 recommended). The pinned `pyspark==3.5.5` test stack does not officially support Python 3.13+; using 3.13 / 3.14 will surface as cloudpickle / recursion errors at test time. See [Troubleshooting](#troubleshooting) below.
 - Databricks CLI v0.213 or later. See [install instructions](https://docs.databricks.com/en/dev-tools/cli/tutorial.html).
-  - macOS: ![macos_install_databricks](docs/static/img/macos_1_databrickslabsmac_installdatabricks.gif)
-  - Windows: ![windows_install_databricks.png](docs/static/img/windows_install_databricks.png)
+  - macOS: ![macos_install_databricks](https://raw.githubusercontent.com/databrickslabs/dlt-meta/feature/sdp-meta/docs/static/img/macos_1_databrickslabsmac_installdatabricks.gif)
+  - Windows: ![windows_install_databricks.png](https://raw.githubusercontent.com/databrickslabs/dlt-meta/feature/sdp-meta/docs/static/img/windows_install_databricks.png)
 - Authenticate your machine to a workspace:
   ```bash
   databricks auth login --host WORKSPACE_HOST
@@ -160,7 +160,7 @@ If you want to run the existing demo files, set up the repo first:
    ```bash
    databricks labs sdp-meta onboard
    ```
-   ![onboardingDLTMeta_2.gif](docs/static/img/onboardingDLTMeta_2.gif)
+   ![onboardingDLTMeta_2.gif](https://raw.githubusercontent.com/databrickslabs/dlt-meta/feature/sdp-meta/docs/static/img/onboardingDLTMeta_2.gif)
 
    Pushes code+data to your workspace, creates an onboarding job, and opens the job URL in your browser.
 
@@ -168,7 +168,7 @@ If you want to run the existing demo files, set up the repo first:
    ```bash
    databricks labs sdp-meta deploy
    ```
-   ![deployingDLTMeta_bronze_silver.gif](docs/static/img/deployingDLTMeta_bronze_silver.gif)
+   ![deployingDLTMeta_bronze_silver.gif](https://raw.githubusercontent.com/databrickslabs/dlt-meta/feature/sdp-meta/docs/static/img/deployingDLTMeta_bronze_silver.gif)
 
    Deploys the Lakeflow Spark Declarative Pipeline and opens its URL in your browser.
 

--- a/setup.py
+++ b/setup.py
@@ -43,8 +43,16 @@ which pip detects as already-satisfied and no-ops.
 """
 from setuptools import setup, find_namespace_packages, find_packages
 
+import re
+
 with open("README.md", "r") as fh:
-    long_description = fh.read()
+    content = fh.read()
+# Strip the top bar section flagged for exclusion (nav links not meaningful on PyPI)
+content = re.sub(
+    r'<!-- Dont remove: exclude package -->.*?<!-- Dont remove: end exclude package -->',
+    '', content, flags=re.DOTALL
+)
+long_description = content
 
 INSTALL_REQUIRES = ["setuptools", "databricks-sdk", "PyYAML>=6.0"]
 


### PR DESCRIPTION

## README
- Replace hardcoded badge versions with dynamic shields.io badges (`pypi/v/databricks-labs-sdp-meta`, live build status, codecov graph, tokei lines-of-code, pepy monthly downloads) — matching DQX/LSQL standard
- Fix all image paths from relative (`./docs/static/img/`) to absolute raw GitHub URLs (`raw.githubusercontent.com/databrickslabs/dlt-meta/feature/sdp-meta/docs/static/img/`) so images render on PyPI and in IDEs
- Remove broken `img.shields.io/github/workflow/status` (deprecated API) and fake hardcoded docs badge

## setup.py
- Strip `<!-- exclude package -->` nav block before setting `long_description` so PyPI page doesn't show GitHub-only top links

## release.yml
- Pin all action SHAs (supply chain security) matching Databricks Labs standard
- Switch to `databrickslabs-protected-runner-group` (matches all other Labs workflows)
- Add `softprops/action-gh-release` step — GitHub Release created automatically on tag push
- Add Sigstore artifact signing (matching DQX)
- Tighten tag filter to `v[0-9]+.[0-9]+.[0-9]+` (semantic versions only)
