### PR TITLE
Update gh_pages to use GitHub Actions Pages environment

### DIFF
--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -1,40 +1,63 @@
-name: Publish Github Pages
+name: Deploy documentation
 
 on:
   push:
-    branches:
-      - main
-defaults:
-  run:
-    working-directory: ./docs
+    branches: [main]
+    paths:
+      - "docs/**"
+      - ".github/workflows/gh_pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
 jobs:
+  build:
+    runs-on:
+      group: databrickslabs-protected-runner-group
+      labels: linux-ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: docs/package-lock.json
+
+      - name: Install dependencies
+        run: cd docs && npm ci
+
+      - name: Build
+        run: cd docs && npm run build
+        env:
+          NODE_ENV: production
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
+        with:
+          path: docs/build
+
   deploy:
     runs-on:
       group: databrickslabs-protected-runner-group
       labels: linux-ubuntu-latest
+    needs: build
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: npm
-          cache-dependency-path: docs/package-lock.json
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build
-        run: npm run build
-
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
-        if: ${{ github.ref == 'refs/heads/main' }}
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs/build
-          publish_branch: public_docs_v1
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5


### PR DESCRIPTION
## Summary
- update `.github/workflows/gh_pages.yml` to use the GitHub Pages artifact/deploy pattern instead of branch-based `peaceiris/actions-gh-pages`
- split workflow into `build` and `deploy` jobs with least-privilege permissions and pinned action SHAs
- add docs/workflow path filters and `workflow_dispatch` for safer and more targeted runs

Closes #320

## Repo settings update required
To make this workflow publish correctly, update repository settings:
- Go to **Settings -> Pages**
- Under **Build and deployment**, set **Source** to **GitHub Actions**

## Test plan
- [ ] Run `Deploy documentation` via `workflow_dispatch` on this branch
- [ ] Verify `build` uploads `docs/build` artifact
- [ ] Verify `deploy` succeeds and emits a Pages URL
- [ ] Confirm site content renders correctly from the published URL