### PR TITLE
remove dead code, fix where-clause shadowing, harden bundle …

### DIFF
--- a/demo/SDP_META_INTERACTIVE_DEMO.py
+++ b/demo/SDP_META_INTERACTIVE_DEMO.py
@@ -2723,7 +2723,6 @@ snapshot_runner_content = (
     "# COMMAND ----------\n"
     "\n"
     "# DBTITLE 1,Snapshot reader for apply_changes_from_snapshot\n"
-    "import dlt\n"
     "from databricks.labs.sdp_meta.dataflow_spec "
     "import BronzeDataflowSpec\n"
     "\n"

--- a/demo/launch_dab_template_demo.py
+++ b/demo/launch_dab_template_demo.py
@@ -89,7 +89,6 @@ from databricks.labs.sdp_meta.bundle import (  # noqa: E402
     BundlePrepareWheelCommand,
     BundleValidateCommand,
     _flows_from_csv,
-    _sdp_meta_sanity_checks,
     bundle_add_flow,
     bundle_init,
     bundle_prepare_wheel,
@@ -868,9 +867,9 @@ def stage_bundle_init(scenario: Scenario, out_dir: Path, uc_catalog_name: str,
     # For the `delta` scenario that table doesn't exist (and the launcher
     # never seeds it), so leaving it in produces an extra dataflow spec
     # that fails at pipeline runtime with `TABLE_OR_VIEW_NOT_FOUND`.
-    # Strip it so STAGE 4's `from_uc.py` (which mirrors the real source
-    # schema) is the only thing populating onboarding.yml.
-    if scenario.name in _DELTA_SCENARIO_NAMES:
+    # Strip it so STAGE 4's recipe (from_uc.py for delta, from_topics.py
+    # for kafka/eventhub) is the only thing populating onboarding.yml.
+    if scenario.name in _DELTA_SCENARIO_NAMES or scenario.name in {"kafka", "eventhub"}:
         _strip_example_onboarding_entry(bundle_dir)
 
     print(f"\n[STAGE 1] Bundle scaffolded at {bundle_dir}")
@@ -1103,13 +1102,6 @@ def stage_recipe(scenario: Scenario, bundle_dir: Path, *, apply_recipe: bool,
 
 def stage_validate(bundle_dir: Path, profile: Optional[str]) -> None:
     _banner("STAGE 5", "bundle-validate  (sdp-meta sanity checks + databricks validate)")
-    errors = _sdp_meta_sanity_checks(bundle_dir)
-    if errors:
-        print("[STAGE 5] sdp-meta sanity checks reported issues:")
-        for e in errors:
-            print(f"  - {e}")
-    else:
-        print("[STAGE 5] sdp-meta sanity checks: clean")
     rc = bundle_validate(BundleValidateCommand(
         bundle_dir=str(bundle_dir),
         profile=profile,

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -213,11 +213,12 @@ python integration_tests/run_backward_compat_tests.py \
     --profile=<<DEFAULT>>
 
 # Custom branches with explicit profile pins (used when the branch
-# name doesn't match a registered prefix):
+# name doesn't match a registered prefix). Source ≠ target so the test
+# actually exercises the legacy → current shim path:
 python integration_tests/run_backward_compat_tests.py \
     --uc_catalog_name=<<uc catalog name>> \
-    --source_version=feature/legacy-bugfix --source_profile=legacy \
-    --target_version=feature/sdp-meta     --target_profile=current \
+    --source_version=v0.0.10            --source_profile=legacy \
+    --target_version=feature/sdp-meta   --target_profile=current \
     --profile=<<DEFAULT>>
 
 # Skip cleanup on success/failure so the run state is debuggable;

--- a/src/databricks/labs/sdp_meta/dataflow_pipeline.py
+++ b/src/databricks/labs/sdp_meta/dataflow_pipeline.py
@@ -565,13 +565,7 @@ class DataflowPipeline:
                     path=source_details.get("path"),
                     format="delta"
                 )
-        if select_exp:
-            bronze_df = bronze_df.selectExpr(*select_exp)
-        if where_clause:
-            where_clause_str = " ".join(where_clause)
-            if len(where_clause_str.strip()) > 0:
-                for where_clause in where_clause:
-                    bronze_df = bronze_df.where(where_clause)
+        bronze_df = self._apply_transformations(bronze_df, select_exp, where_clause)
         bronze_df = self.apply_custom_transform_fun(bronze_df)
         return bronze_df
 

--- a/src/databricks/labs/sdp_meta/templates/dab/template/{{.bundle_name}}/resources/variables.yml.tmpl
+++ b/src/databricks/labs/sdp_meta/templates/dab/template/{{.bundle_name}}/resources/variables.yml.tmpl
@@ -4,27 +4,22 @@
 variables:
   uc_catalog_name:
     description: Unity Catalog catalog where the sdp-meta schema and bronze/silver schemas live.
-    type: string
     default: {{.uc_catalog_name}}
 
   sdp_meta_schema:
     description: Schema that holds the bronze_dataflowspec / silver_dataflowspec tables.
-    type: string
     default: {{.sdp_meta_schema}}
 
   bronze_target_schema:
     description: Schema where the bronze LDP pipeline writes its tables.
-    type: string
     default: {{.bronze_target_schema}}
 
   silver_target_schema:
     description: Schema where the silver LDP pipeline writes its tables.
-    type: string
     default: {{.silver_target_schema}}
 
   layer:
     description: Layer to onboard. One of `bronze`, `silver`, `bronze_silver`.
-    type: string
     default: {{.layer}}
 
   pipeline_mode:
@@ -32,44 +27,36 @@ variables:
       Only consulted when layer=bronze_silver. `split` keeps two LDP pipelines
       (silver depends on bronze); `combined` collapses both layers into one
       LDP pipeline using sdp-meta's `bronze_silver` runtime mode.
-    type: string
     default: {{.pipeline_mode}}
 
   dataflow_group:
     description: |
       data_flow_group used by the seeded flow(s) and referenced from the LDP
       pipeline `configuration` as `bronze.group` / `silver.group`.
-    type: string
     default: {{.dataflow_group}}
 
   onboarding_file_name:
     description: Filename (inside conf/) of the onboarding file uploaded with this bundle.
-    type: string
     default: onboarding.{{if eq .onboarding_file_format "yaml"}}yml{{else}}json{{end}}
 
   bronze_dataflowspec_table:
     description: Bronze dataflowspec table name inside `sdp_meta_schema`.
-    type: string
     default: bronze_dataflowspec
 
   silver_dataflowspec_table:
     description: Silver dataflowspec table name inside `sdp_meta_schema`.
-    type: string
     default: silver_dataflowspec
 
   dataflowspec_version:
     description: Value written to the `version` column of dataflowspec rows.
-    type: string
     default: v1
 
   author:
     description: Value written to the `import_author` column of dataflowspec rows.
-    type: string
     default: {{.author}}
 
   overwrite_dataflowspecs:
     description: If "True", onboarding overwrites existing dataflowspec rows; if "False" it merges.
-    type: string
     default: "True"
 
   wheel_source:
@@ -77,7 +64,6 @@ variables:
       Documents (and lets `bundle-validate` enforce) which install style this
       bundle uses. `pypi` -> `sdp_meta_dependency` should be a coordinate.
       `volume_path` -> `sdp_meta_dependency` should start with `/Volumes/`.
-    type: string
     default: {{.wheel_source}}
 
   sdp_meta_dependency:
@@ -86,7 +72,6 @@ variables:
       `pip install` this verbatim and the onboarding job consumes it as an
       environments dependency. Must match `wheel_source`. The sentinel
       `__SET_ME__` will fail-fast at validate and at runtime.
-    type: string
     default: {{.sdp_meta_dependency}}
 
   serverless:


### PR DESCRIPTION
Cleanup: remove dead code, fix where-clause shadowing, harden bundle template

- dataflow_pipeline: extract bronze select/where into _apply_transformations;
  fixes 'for where_clause in where_clause' shadowing bug
- launch_dab_template_demo: drop unused _sdp_meta_sanity_checks import (still
  invoked inside bundle_validate); extend example-strip to kafka/eventhub
- SDP_META_INTERACTIVE_DEMO: remove unused 'import dlt' from snapshot runner
- variables.yml.tmpl: drop redundant 'type: string' (keep type: bool on
  serverless/photon_enabled/development_enabled to prevent SDK-boundary
  string→bool coercion regression)
- integration_tests/README: concrete v0.0.10 → feature/sdp-meta example